### PR TITLE
Riffing on status badge

### DIFF
--- a/aries-site/src/components/content/Status.js
+++ b/aries-site/src/components/content/Status.js
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Text } from 'grommet';
+import { Box, Text, Grid, ResponsiveContext } from 'grommet';
 import { Figma, Grommet } from 'grommet-icons';
 import { IconCircle, IconTriangle } from '../icons';
 
 const types = {
   figma: {
     name: 'Figma',
-    icon: <Figma color="plain" />,
+    icon: <Figma color="plain" size="small" />,
   },
   grommet: {
     name: 'Grommet',
-    icon: <Grommet color="plain" />,
+    icon: <Grommet color="plain" size="small" />,
   },
 };
 
@@ -24,31 +24,54 @@ const statuses = {
   },
 };
 
+const Badge = ({ label, icon, side, ...rest }) => {
+  const size = useContext(ResponsiveContext);
+
+  return (
+    <Box
+      direction="row"
+      align="center"
+      gap="xsmall"
+      pad={{
+        vertical: size !== 'small' ? 'xxsmall' : 'small',
+        horizontal: size !== 'small' ? 'small' : 'medium',
+      }}
+      round={{ corner: side, size: 'xsmall' }}
+      {...rest}
+    >
+      {icon}
+      {size !== 'small' && (
+        <Text size="small" weight={600}>
+          {label}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+Badge.propTypes = {
+  label: PropTypes.string,
+  icon: PropTypes.element,
+  side: PropTypes.string,
+};
+
 const StatusBadge = ({ status, type }) => {
   return (
-    <Box direction="row">
-      <Box
+    <Box direction="row" round="xsmall">
+      <Badge
         background="background-front"
-        pad={{ vertical: 'xsmall', horizontal: 'small' }}
-        round={{ corner: 'left', size: 'xsmall' }}
-        direction="row"
-      >
-        <Box direction="row" gap="xsmall" align="center">
-          {types[type].icon}
-          <Text weight="bold">{type && types[type].name}</Text>
-        </Box>
-      </Box>
-      <Box
+        icon={types[type].icon}
+        justify="end"
+        label={type && types[type].name}
+        side="left"
+      />
+      <Badge
         background="background-contrast"
-        pad={{ vertical: 'xsmall', horizontal: 'small' }}
-        round={{ corner: 'right', size: 'xsmall' }}
-        direction="row"
-        align="center"
-        gap="small"
-      >
-        {statuses[status[type]].icon}
-        <Text weight="bold">{status[type]}</Text>
-      </Box>
+        flex
+        icon={statuses[status[type]].icon}
+        label={status[type]}
+        side="right"
+      />
     </Box>
   );
 };
@@ -62,11 +85,17 @@ StatusBadge.propTypes = {
 };
 
 export const Status = ({ status }) => {
+  const size = useContext(ResponsiveContext);
+
   return (
-    <Box direction="row-responsive" gap="medium">
+    <Grid
+      columns={{ count: size !== 'small' ? 2 : 1, size: 'auto' }}
+      gap={size !== 'small' ? 'small' : 'xsmall'}
+      justify="end"
+    >
       {status.figma && <StatusBadge type="figma" status={status} />}
       {status.grommet && <StatusBadge type="grommet" status={status} />}
-    </Box>
+    </Grid>
   );
 };
 

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
-import { Anchor, Box, Button, Header } from 'grommet';
+import { Anchor, Box, Button, Header, Stack } from 'grommet';
 import { Link as LinkIcon } from 'grommet-icons';
-import { Subheading } from '../../components';
+import { Status, Subheading } from '../../components';
 import { getPageDetails } from '../../utils';
 
 // Text size should be based on if its parent heading is an
@@ -27,6 +27,7 @@ export const Subsection = ({
   level,
   name,
   topic,
+  componentStatus,
   ...rest
 }) => {
   const [over, setOver] = useState(false);
@@ -82,33 +83,38 @@ export const Subsection = ({
        */}
       <Box gap={level !== 3 ? 'small' : undefined}>
         {showHeading && (
-          <Header>
-            <Box align="start" gap="small">
-              {level === 1 && topic && (
-                <Link href={`/${topic.toLowerCase()}`} passHref>
-                  <Button
-                    label={parent.name}
-                    icon={parent.icon('small', parent.color)}
-                    {...rest}
-                    plain
-                  />
-                </Link>
+          <Stack anchor="right">
+            <Header>
+              <Box align="start" gap="small">
+                {level === 1 && topic && (
+                  <Link href={`/${topic.toLowerCase()}`} passHref>
+                    <Button
+                      label={parent.name}
+                      icon={parent.icon('small', parent.color)}
+                      {...rest}
+                      plain
+                    />
+                  </Link>
+                )}
+                <Subheading
+                  level={level}
+                  headingSize={headingSize || HEADING_SIZE[level]}
+                >
+                  {name}
+                </Subheading>
+              </Box>
+              {level > 1 && (
+                <Anchor
+                  a11yTitle={`Jump to section titled ${name}`}
+                  href={`#${id}`}
+                  icon={
+                    <LinkIcon color={over ? 'text-xweak' : 'transparent'} />
+                  }
+                />
               )}
-              <Subheading
-                level={level}
-                headingSize={headingSize || HEADING_SIZE[level]}
-              >
-                {name}
-              </Subheading>
-            </Box>
-            {level > 1 && (
-              <Anchor
-                a11yTitle={`Jump to section titled ${name}`}
-                href={`#${id}`}
-                icon={<LinkIcon color={over ? 'text-xweak' : 'transparent'} />}
-              />
-            )}
-          </Header>
+            </Header>
+            {componentStatus && <Status status={componentStatus} />}
+          </Stack>
         )
         /* Isolates the first child to ensure the gap between heading and
          * first child is correct size. See comment on line 33 for reasoning.
@@ -129,6 +135,10 @@ Subsection.propTypes = {
   name: PropTypes.string.isRequired,
   showHeading: PropTypes.bool,
   topic: PropTypes.string,
+  componentStatus: PropTypes.shape({
+    figma: PropTypes.string,
+    grommet: PropTypes.string,
+  }),
 };
 
 Subsection.defaultProps = {

--- a/aries-site/src/pages/components/button.js
+++ b/aries-site/src/pages/components/button.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import { Anchor } from 'grommet';
 
-import {
-  BulletedList,
-  CardGrid,
-  Meta,
-  Status,
-  SubsectionText,
-} from '../../components';
+import { BulletedList, CardGrid, Meta, SubsectionText } from '../../components';
 import {
   ButtonExample,
   ButtonIconExample,
@@ -33,9 +27,13 @@ const Button = () => (
       canonicalUrl="https://design-system.hpe.design/components/button"
     />
     <ContentSection>
-      <Subsection name={title} level={1} topic={topic}>
+      <Subsection
+        name={title}
+        level={1}
+        topic={topic}
+        componentStatus={page.status}
+      >
         <SubsectionText>{page.description}</SubsectionText>
-        {page.status && <Status status={page.status} />}
         <Example
           docs="https://v2.grommet.io/button?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/button/ButtonExample.js"


### PR DESCRIPTION
Playing with alternate approach to displaying status badges...  If adopted, this PR would additional work to migrate existing badge implementation.

Work included:
- Moved badges to be part of Subsection
- Place badges in Stack in relation to Subsection Header

[Preview](https://deploy-preview-759--keen-mayer-a86c8b.netlify.app/components/button)

Screenshots:

![Screen Shot 2020-05-08 at 9 35 17 AM](https://user-images.githubusercontent.com/1756948/81422124-c8f11080-910f-11ea-896b-a9aabd4fab6b.png)
![Screen Shot 2020-05-08 at 9 35 32 AM](https://user-images.githubusercontent.com/1756948/81422133-cb536a80-910f-11ea-8f19-5039f8fb81b3.png)

