### PR TITLE
Update local theme to demonstrate header cell treatment

### DIFF
--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -201,10 +201,10 @@ const columns = [
     property: 'size',
     header: (
       <Box direction="row" gap="xsmall">
-        Size
-        <Text color="text" weight="normal">
-          (TiB)
+        <Text color="text-strong" weight="bold">
+          Size
         </Text>
+        (TiB)
       </Box>
     ),
     render: datum =>
@@ -216,10 +216,10 @@ const columns = [
     property: 'pinnable',
     header: (
       <Box direction="row" gap="xsmall">
-        Pinnable
-        <Text color="text" weight="normal">
-          (TiB)
+        <Text color="text-strong" weight="bold">
+          Pinnable
         </Text>
+        (TiB)
       </Box>
     ),
     render: datum =>
@@ -230,11 +230,11 @@ const columns = [
   {
     property: 'pinned',
     header: (
-      <Box direction="row" gap="xsmall">
-        Pinned
-        <Text color="text" weight="normal">
-          %
+      <Box direction="row" gap="xsmall" pad={{ horizontal: 'small' }}>
+        <Text color="text-strong" weight="bold">
+          Pinned
         </Text>
+        %
       </Box>
     ),
     render: datum => (
@@ -253,10 +253,10 @@ const columns = [
     property: 'savings',
     header: (
       <Box direction="row" gap="xsmall">
-        Savings
-        <Text color="text" weight="normal">
-          (xGHz)
+        <Text color="text-strong" weight="bold">
+          Savings
         </Text>
+        (xGHz)
       </Box>
     ),
     align: 'end',
@@ -302,10 +302,6 @@ export const TableExample = () => {
             },
             ...columns,
           ]}
-          background={{
-            pinned: 'background-front',
-            header: 'background-front',
-          }}
           fill
           onClickRow={({ datum }) => handleClickRow(datum)}
           pin

--- a/aries-site/src/examples/components/table/TableFixedHeaderExample.js
+++ b/aries-site/src/examples/components/table/TableFixedHeaderExample.js
@@ -202,10 +202,10 @@ const columns = [
     property: 'networkBand.value',
     header: (
       <Box direction="row" gap="xsmall">
-        Network Band
-        <Text color="text" weight="normal">
-          (GHz)
+        <Text color="text-strong" weight="bold">
+          Network Band
         </Text>
+        (GHz)
       </Box>
     ),
     render: datum => datum.networkBand.value,
@@ -215,10 +215,10 @@ const columns = [
     property: 'linkRate.value',
     header: (
       <Box direction="row" gap="xsmall">
-        Link Rate
-        <Text color="text" weight="normal">
-          (Mbps)
+        <Text color="text-strong" weight="bold">
+          Link Rate
         </Text>
+        (Mbps)
       </Box>
     ),
     render: datum => datum.linkRate.value,
@@ -240,15 +240,7 @@ export const TableFixedHeaderExample = () => {
         width={{ min: 'medium', max: 'large' }}
         overflow="auto"
       >
-        <DataTable
-          data={data}
-          columns={columns}
-          background={{
-            pinned: 'background-front',
-            header: 'background-front',
-          }}
-          pin
-        />
+        <DataTable data={data} columns={columns} pin />
       </Box>
     </>
   );

--- a/aries-site/src/examples/components/table/TableMultiSelectExample.js
+++ b/aries-site/src/examples/components/table/TableMultiSelectExample.js
@@ -259,13 +259,15 @@ export const TableMultiSelectExample = () => {
                 />
               ),
               header: (
-                <CheckBox
-                  checked={checked.length === data.length}
-                  indeterminate={
-                    checked.length > 0 && checked.length < data.length
-                  }
-                  onChange={onCheckAll}
-                />
+                <Box pad={{ left: 'small' }}>
+                  <CheckBox
+                    checked={checked.length === data.length}
+                    indeterminate={
+                      checked.length > 0 && checked.length < data.length
+                    }
+                    onChange={onCheckAll}
+                  />
+                </Box>
               ),
               sortable: false,
             },
@@ -277,10 +279,6 @@ export const TableMultiSelectExample = () => {
             },
             ...columns,
           ]}
-          background={{
-            pinned: 'background-front',
-            header: 'background-front',
-          }}
           pin={size === 'small'}
         />
       </Box>

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -224,10 +224,6 @@ export const TableSingleSelectExample = () => {
             { property: 'id', header: 'Id', pin: size === 'small' },
             ...columns,
           ]}
-          background={{
-            pinned: 'background-front',
-            header: 'background-front',
-          }}
           onClickRow={({ datum }) => onClickHandler(datum)}
           pin={size === 'small'}
         />

--- a/aries-site/src/examples/components/table/TableSortable.js
+++ b/aries-site/src/examples/components/table/TableSortable.js
@@ -161,10 +161,6 @@ export const TableSortable = () => {
             },
             ...columns,
           ]}
-          background={{
-            pinned: 'background-front',
-            header: 'background-front',
-          }}
           pin={size === 'small'}
           sort={{ property: 'numeric', direction: 'desc' }}
           sortable

--- a/aries-site/src/examples/components/table/TableSummaryExample.js
+++ b/aries-site/src/examples/components/table/TableSummaryExample.js
@@ -102,11 +102,11 @@ const columns = [
   {
     property: 'attachment',
     header: (
-      <Box direction="row" gap="small">
-        Attachment
-        <Text color="text" weight="normal">
-          %
+      <Box direction="row" gap="xsmall">
+        <Text color="text-strong" weight="bold">
+          Attachment
         </Text>
+        %
       </Box>
     ),
     render: datum => `${(datum.attachment * 100).toFixed([1])}`,
@@ -141,11 +141,6 @@ export const TableSummaryExample = () => {
             },
             ...columns,
           ]}
-          background={{
-            pinned: 'background-front',
-            header: 'background-front',
-            footer: 'background-front',
-          }}
           pin
         />
       </Box>

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -1,6 +1,5 @@
 import { hpe } from 'grommet-theme-hpe';
 import { deepMerge } from 'grommet/utils';
-import { CaretDown, CaretUp } from 'grommet-icons';
 
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
@@ -41,12 +40,40 @@ export const aries = deepMerge(hpe, {
     // groupEnd: {
     //   border: { side: 'bottom', size: 'xsmall' },
     // },
-    // header: {},
-    icons: {
-      ascending: CaretDown,
-      //   contract: FormUp,
-      descending: CaretUp,
-      //   expand: FormDown,
+    header: {
+      pad: { horizontal: 'small', vertical: 'xsmall' },
+      color: 'text-strong',
+      font: {
+        weight: 'bold',
+      },
+      hover: {
+        background: {
+          color: 'background-contrast',
+        },
+      },
+    },
+    pinned: {
+      header: {
+        background: {
+          color: 'background-front',
+          opacity: 'strong',
+        },
+        extend: 'backdrop-filter: blur(8px);',
+      },
+      body: {
+        background: {
+          color: 'background-front',
+          opacity: 'strong',
+        },
+        extend: 'backdrop-filter: blur(8px);',
+      },
+      footer: {
+        background: {
+          color: 'background-front',
+          opacity: 'strong',
+        },
+        extend: 'backdrop-filter: blur(8px);',
+      },
     },
     // primary: {
     //   // weight: 'bold',
@@ -61,29 +88,13 @@ export const aries = deepMerge(hpe, {
   table: {
     header: {
       // align: 'start',
-      // pad: { horizontal: 'small', vertical: 'xsmall' },
+      // space for focus indicator on sortable columns
+      pad: { left: 'none', vertical: 'none', right: 'xxsmall' },
       border: { side: 'bottom' },
       // verticalAlign: 'center',
       background: {
         color: 'background-front',
       },
-      extend: ({ theme }) => `
-        color: ${
-          theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
-        };
-        font-weight: bold;
-        :hover {
-          button {
-            background-color: ${
-              theme.global.colors['background-contrast'][
-                theme.dark ? 'dark' : 'light'
-              ]
-            };
-            height: 100%;
-            width: 100%;
-          }
-        }
-      `,
     },
     body: {
       // align: 'start',
@@ -91,12 +102,7 @@ export const aries = deepMerge(hpe, {
       // background: undefined,
       // border: undefined,
       extend: ({ theme }) => {
-        const { size, height } = theme.text.small;
         return `
-          span {
-            font-size: ${size};
-            line-height: ${height};
-          }
           :hover {
             button {
               background: ${
@@ -121,16 +127,11 @@ export const aries = deepMerge(hpe, {
       // border: 'top',
       // verticalAlign: undefined,
       background: 'background-front',
-      extend: ({ theme }) => {
-        const { size, height } = theme.text.small;
-        return `
+      extend: `
           span {
-            font-size: ${size};
-            line-height: ${height};
             font-weight: bold;
           }
-        `;
-      },
+        `,
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,9 +2413,9 @@
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
 "@types/babel__core@^7.1.7":
-  version "7.1.9"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
-  integrity sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==
+  version "7.1.10"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.10.tgz#ca58fc195dd9734e77e57c6f2df565623636ab40"
+  integrity sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -2431,9 +2431,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__template@*":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
-  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.3.tgz#b8aaeba0a45caca7b56a5de9459872dde3727214"
+  integrity sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -4834,12 +4834,12 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.14.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.4.tgz#66a18131439f9e16c3da7f352518dfa12f60b0e3"
-  integrity sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==
+  version "4.14.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.5.tgz#1c751461a102ddc60e40993639b709be7f2c4015"
+  integrity sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==
   dependencies:
     caniuse-lite "^1.0.30001135"
-    electron-to-chromium "^1.3.570"
+    electron-to-chromium "^1.3.571"
     escalade "^3.1.0"
     node-releases "^1.1.61"
 
@@ -5084,9 +5084,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001135:
-  version "1.0.30001135"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
-  integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
+  version "1.0.30001137"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz#6f0127b1d3788742561a25af3607a17fc778b803"
+  integrity sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -6472,7 +6472,7 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-domhandler@3.0.0, domhandler@^3.0.0:
+domhandler@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
   integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
@@ -6485,6 +6485,13 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+domhandler@^3.0.0, domhandler@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.2.0.tgz#41711ab2f48f42b692537bcf279bc7f1167c83cd"
+  integrity sha512-FnT5pxGpykNI10uuwyqae65Ysw7XBQJKDjDjlHgE/rsNtjr1FyGNVNQCVlM5hwcq9wkyWSqB+L5Z+Qa4khwLuA==
+  dependencies:
+    domelementtype "^2.0.1"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -6512,13 +6519,13 @@ domutils@^1.5.1, domutils@^1.7.0:
     domelementtype "1"
 
 domutils@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.3.0.tgz#6469c63a3da2de0c3016f3a59e6a969e10705bce"
-  integrity sha512-xWC75PM3QF6MjE5e58OzwTX0B/rPQnlqH0YyXB/c056RtVJA+eu60da2I/bdnEHzEYC00g8QaZUlAbqOZVbOsw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.0.tgz#60b85585a0e96113dff3d04d735196bb2bba49e2"
+  integrity sha512-rP+tl0A3YekdmSpYOEtm4C/aSzwtEOU5XrkdoGwb+Hn/941f5S5kZwHr37AEIcBbPug3uxD8z9PKQZd1R/R/tg==
   dependencies:
     dom-serializer "^1.0.1"
     domelementtype "^2.0.1"
-    domhandler "^3.0.0"
+    domhandler "^3.1.0"
 
 dot-case@^3.0.3:
   version "3.0.3"
@@ -6590,10 +6597,10 @@ ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.570:
-  version "1.3.571"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz#e57977f1569f8326ae2a7905e26f3943536ba28f"
-  integrity sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA==
+electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.571:
+  version "1.3.572"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.572.tgz#62d87dfe32ca1f6b9a0f76917d24f66e94e19c01"
+  integrity sha512-TKqdEukCCl7JC20SwEoWTbtnGt4YjfHWAv4tcNky0a9qGo0WdM+Lrd60tps+nkaJCmktKBJjr99fLtEBU1ipWQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -6875,9 +6882,9 @@ eslint-config-airbnb@^18.1.0:
     object.entries "^1.1.2"
 
 eslint-config-prettier@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
-  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz#9eb2bccff727db1c52104f0b49e87ea46605a0d2"
+  integrity sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -6946,9 +6953,9 @@ eslint-plugin-react-hooks@^4.0.0:
   integrity sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
 
 eslint-plugin-react@^7.19.0:
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.0.tgz#aa0699086f586d54a5005c99a703175bc5d21161"
-  integrity sha512-WaieZZ4cayAfPBmy5KkEqFfLQf/VkzoUsvM5DfD9G1lrz+3LtZ8X6nToEUQiFe1X5ApNIzkMd+7NUy+2OmSTQQ==
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz#3bd5d2c4c36d5a0428d0d6dda301ac9a84d681b2"
+  integrity sha512-j3XKvrK3rpBzveKFbgAeGsWb9uz6iUOrR0jixRfjwdFeGSRsXvVTFtHDQYCjsd1/6Z/xvb8Vy3LiI5Reo7fDrg==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flatmap "^1.2.3"
@@ -8061,9 +8068,9 @@ graphlib@^2.1.5:
     lodash "^4.17.15"
 
 grommet-icons@^4.2.0, "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
-  version "4.4.0"
-  uid "61edce8fd17d26c15db3c1826d011b4c62950dd4"
-  resolved "https://github.com/grommet/grommet-icons/tarball/stable#61edce8fd17d26c15db3c1826d011b4c62950dd4"
+  version "4.5.0"
+  uid f1641de85a77bee07e8db0556c9338c288cf42cb
+  resolved "https://github.com/grommet/grommet-icons/tarball/stable#f1641de85a77bee07e8db0556c9338c288cf42cb"
   dependencies:
     grommet-styles "^0.2.0"
 
@@ -8078,12 +8085,12 @@ grommet-styles@^0.2.0:
 
 "grommet-theme-hpe@https://github.com/grommet/grommet-theme-hpe/tarball/stable":
   version "0.0.0"
-  resolved "https://github.com/grommet/grommet-theme-hpe/tarball/stable#737f85f62ecf53948ed275302cbb115b7b1d34e8"
+  resolved "https://github.com/grommet/grommet-theme-hpe/tarball/stable#ec0120ddc49245339407340bfb9806b6c0ea10ee"
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.15.0"
-  uid "5ca71a1094fcd89c4c18591cf2c4ac4a4526a194"
-  resolved "https://github.com/grommet/grommet/tarball/stable#5ca71a1094fcd89c4c18591cf2c4ac4a4526a194"
+  uid "91431b98f26821dd922a38966e07cbc860f0b930"
+  resolved "https://github.com/grommet/grommet/tarball/stable#91431b98f26821dd922a38966e07cbc860f0b930"
   dependencies:
     grommet-icons "^4.2.0"
     hoist-non-react-statics "^3.2.0"
@@ -11711,9 +11718,9 @@ postcss-safe-parser@4.0.2:
     postcss "^7.0.26"
 
 postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.3.tgz#766d77728728817cc140fa1ac6da5e77f9fada98"
-  integrity sha512-0ClFaY4X1ra21LRqbW6y3rUbWcxnSVkDFG57R7Nxus9J9myPFlv+jYDMohzpkBx0RrjjiqjtycpchQ+PLGmZ9w==
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
+  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
   dependencies:
     cssesc "^3.0.0"
     indexes-of "^1.0.1"
@@ -14258,9 +14265,9 @@ tiny-emitter@^2.0.0:
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tinycolor2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
+  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 tmp-promise@^1.0.5:
   version "1.1.0"


### PR DESCRIPTION
[Preview](https://deploy-preview-1152--keen-mayer-a86c8b.netlify.app/components/table)

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Implements header cell styling with new grommet theme enhancements. Note: `backdrop-filter: blur(8px);` does not work on Firefox. I am still working separately on how to implement.

I have placed these changes on the local theme and will open a PR on grommet-theme-hpe once we confirm that all looks good. I have made appropriate adjustments to custom header renders in any table examples.

#### Where should the reviewer start?
aries-site/src/themes/aries.js

#### What testing has been done on this PR?
Local on tables page.

#### How should this be manually tested?
Look at table page.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1132

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Will cause visual updates, but moving us in the right direction to align with designs.