### PR TITLE
Simplify form implementation or error messages

### DIFF
--- a/aries-site/src/examples/templates/forms/PayExample.js
+++ b/aries-site/src/examples/templates/forms/PayExample.js
@@ -10,7 +10,7 @@ import {
   Text,
   TextInput,
 } from 'grommet';
-import { Apple, CreditCard, CircleAlert } from 'grommet-icons';
+import { Apple, CreditCard } from 'grommet-icons';
 
 const currentDate = new Date();
 const dateValidation = [
@@ -105,19 +105,6 @@ const FormContainer = ({ ...rest }) => {
   );
 };
 
-const Error = ({ textError, ...rest }) => {
-  return (
-    <Box align="center" gap="xsmall" direction="row" {...rest} >
-      <CircleAlert size="small" />
-      <Text size="xsmall">{textError}</Text>
-    </Box>
-  );
-};
-
-Error.propTypes = {
-  textError: PropTypes.string,
-};
-
 export const PayExample = () => {
   const [formValues, setFormValues] = React.useState({});
   // eslint-disable-next-line no-unused-vars
@@ -144,9 +131,7 @@ export const PayExample = () => {
         >
           <Form
             messages={{
-              required: (
-                <Error>This is a required field.</Error>
-              ),
+              required: 'This is a required field.',
             }}
             value={formValues}
             onChange={setFormValues}

--- a/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
+++ b/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
@@ -95,13 +95,12 @@ export const RequiredFieldsExample = () => {
         >
           <Form
             messages={{
-              required: (
+              required:
                 // need to define background otherwise
                 // inherits validation-critical background
-                <Error background="background-front">
-                  This is a required field.
-                </Error>
-              ),
+                // <Error background="background-front">
+                'This is a required field.',
+              // </Error>
             }}
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
             value={formValues}
@@ -109,11 +108,7 @@ export const RequiredFieldsExample = () => {
           >
             <RequiredFormField
               required
-              error={
-                <Error background="background-front">
-                  Provide a unique name.
-                </Error>
-              }
+              error="Provide a unique name."
               htmlFor="name__input"
               name="name"
               label="Name"
@@ -163,11 +158,20 @@ export const RequiredFieldsExample = () => {
                 round="4px"
                 pad="small"
                 background="validation-critical"
+                direction="row"
+                gap="xsmall"
               >
-                <Error>
+                <Box
+                  flex={false}
+                  margin={{ top: 'hair' }}
+                  pad={{ top: 'xxsmall' }}
+                >
+                  <CircleAlert size="small" />
+                </Box>
+                <Text size="xsmall">
                   The name of the superhero is already being used. Provide a
                   unique name.
-                </Error>
+                </Text>
               </Box>
             )}
             <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>

--- a/aries-site/src/examples/templates/forms/ShippingExample.js
+++ b/aries-site/src/examples/templates/forms/ShippingExample.js
@@ -12,22 +12,6 @@ import {
   Text,
   TextInput,
 } from 'grommet';
-import { CircleAlert } from 'grommet-icons';
-
-const Error = ({ children, ...rest }) => {
-  return (
-    <Box direction="row" gap="xsmall" {...rest}>
-      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
-        <CircleAlert size="small" />
-      </Box>
-      <Text size="xsmall">{children}</Text>
-    </Box>
-  );
-};
-
-Error.propTypes = {
-  children: PropTypes.object,
-};
 
 const emailMask = [
   {
@@ -124,23 +108,17 @@ const phoneMask = [
 const emailValidation = [
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@'),
-    message: (
-      <Error background="background-front">Enter a valid email address.</Error>
-    ),
+    message: 'Enter a valid email address.',
     status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: (
-      <Error background="background-front">Enter a valid email address.</Error>
-    ),
+    message: 'Enter a valid email address.',
     status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: (
-      <Error background="background-front">Enter a valid email address.</Error>
-    ),
+    message: 'Enter a valid email address.',
     status: 'error',
   },
 ];
@@ -229,11 +207,7 @@ export const ShippingExample = () => {
             value={formValues}
             onChange={setFormValues}
             messages={{
-              required: (
-                <Error background="background-front">
-                  This is a required field.
-                </Error>
-              ),
+              required: 'This is a required field.',
             }}
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
             onValidate={onValidate}

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   Anchor,
   Box,
@@ -13,31 +12,12 @@ import {
   Text,
   TextInput,
 } from 'grommet';
-import { FormCheckmark, CircleAlert } from 'grommet-icons';
-
-const Error = ({ children, ...rest }) => {
-  return (
-    <Box direction="row" gap="xsmall" {...rest}>
-      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
-        <CircleAlert size="small" />
-      </Box>
-      <Text size="xsmall">{children}</Text>
-    </Box>
-  );
-};
-
-Error.propTypes = {
-  children: PropTypes.object,
-};
+import { FormCheckmark } from 'grommet-icons';
 
 const passwordRequirements = [
   {
     regexp: new RegExp('(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[#?!@$ %^&*-]).{8,}'),
-    message: (
-      <Error background="background-front">
-        Password requirements not met.
-      </Error>
-    ),
+    message: 'Password requirements not met.',
     status: 'error',
   },
 ];
@@ -45,23 +25,17 @@ const passwordRequirements = [
 const emailValidation = [
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@'),
-    message: (
-      <Error background="background-front">Enter a valid email address.</Error>
-    ),
+    message: 'Enter a valid email address.',
     status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: (
-      <Error background="background-front">Enter a valid email address.</Error>
-    ),
+    message: 'Enter a valid email address.',
     status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: (
-      <Error background="background-front">Enter a valid email address.</Error>
-    ),
+    message: 'Enter a valid email address.',
     status: 'error',
   },
 ];

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -1,6 +1,6 @@
 import { hpe } from 'grommet-theme-hpe';
 import { deepMerge } from 'grommet/utils';
-import { Unsorted } from 'grommet-icons';
+import { CircleAlert, Unsorted } from 'grommet-icons';
 
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
@@ -9,6 +9,15 @@ export const aries = deepMerge(hpe, {
   // keeping file for use as playground for future theme adjusments that need
   // to be quickly tested
 
+  // to be removed once merged into grommet-theme-hpe
+  formField: {
+    error: {
+      icon: <CircleAlert size="small" style={{ marginTop: '4px' }} />,
+      container: {
+        gap: 'xsmall',
+      },
+    },
+  },
   dataTable: {
     body: {
       extend: ({ theme }) => `


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes custom component of "Error" message in form implementation and instead relies on theme to supply error icon and styling. Currently theme changes are being implemented locally since grommet-theme-hpe cannot currently support format of `icon: <CustomIcon myProps />`. However, I will be working on updating the theme to properly support this.

#### Where should the reviewer start?
Any file.

#### What testing has been done on this PR?
Tested on all local form examples.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/grommet-theme-hpe/issues/126

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.