### PR TITLE
Update site header examples for consistent color usage

### DIFF
--- a/aries-site/src/components/content/AppIdentity.js
+++ b/aries-site/src/components/content/AppIdentity.js
@@ -1,0 +1,60 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import { Box, Button, Text } from 'grommet';
+import { Aruba, Hpe } from 'grommet-icons';
+
+const brands = {
+  hpe: {
+    name: 'HPE',
+    logo: <Hpe color="brand" />,
+  },
+  aruba: {
+    name: 'Aruba',
+    logo: <Aruba color="plain" />,
+  },
+};
+
+export const AppIdentity = forwardRef(
+  ({ brand, logoOnly, href, title, ...rest }, ref) => {
+    const textSize = 'medium';
+
+    return (
+      <Button href={href} ref={ref} {...rest}>
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
+          {brand && brands[brand].logo}
+          {!logoOnly && (
+            <Box direction="row" gap="xsmall">
+              <Text weight="bold" size={textSize} color="text">
+                {brands[brand].name}
+              </Text>
+              <Text size={textSize} color="text">
+                {title}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      </Button>
+    );
+  },
+);
+
+AppIdentity.propTypes = {
+  brand: PropTypes.string.isRequired,
+  logoOnly: PropTypes.bool,
+  href: PropTypes.string,
+  title: PropTypes.string,
+};
+
+AppIdentity.defaultProps = {
+  logoOnly: false,
+  href: '/',
+  title: undefined,
+};

--- a/aries-site/src/components/content/AppIdentity.js
+++ b/aries-site/src/components/content/AppIdentity.js
@@ -22,7 +22,7 @@ export const AppIdentity = forwardRef(
       <Button href={href} ref={ref} {...rest}>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -31,11 +31,11 @@ export const AppIdentity = forwardRef(
         >
           {brand && brands[brand].logo}
           {!logoOnly && (
-            <Box direction="row" gap="xsmall">
-              <Text weight="bold" size={textSize} color="text">
+            <Box direction="row" gap="xsmall" wrap>
+              <Text weight="bold" size={textSize} color="text-strong">
                 {brands[brand].name}
               </Text>
-              <Text size={textSize} color="text">
+              <Text size={textSize} color="text-strong">
                 {title}
               </Text>
             </Box>

--- a/aries-site/src/components/content/index.js
+++ b/aries-site/src/components/content/index.js
@@ -1,3 +1,4 @@
+export * from './AppIdentity';
 export * from './CollapsibleSection';
 export * from './ComingSoon';
 export * from './PageBackground';

--- a/aries-site/src/examples/cardPreviews/header.js
+++ b/aries-site/src/examples/cardPreviews/header.js
@@ -12,14 +12,15 @@ export const HeaderPreview = () => {
       <Box direction="row">
         <Button icon={<Hpe color="brand" />} tabIndex={-1} />
         <Box gap="xsmall" direction="row">
-          <Text weight="bold" alignSelf="center">
-            {' '}
-            HPE{' '}
+          <Text color="text-strong" weight="bold" alignSelf="center">
+            HPE
           </Text>
-          <Text alignSelf="center"> Text</Text>
+          <Text color="text-strong" alignSelf="center">
+            Text
+          </Text>
         </Box>
       </Box>
-      <Button icon={<Menu />} tabIndex={-1} />
+      <Button icon={<Menu color="text-strong" />} tabIndex={-1} />
     </Header>
   );
 };

--- a/aries-site/src/examples/cardPreviews/header.js
+++ b/aries-site/src/examples/cardPreviews/header.js
@@ -11,13 +11,11 @@ export const HeaderPreview = () => {
     >
       <Box direction="row">
         <Button icon={<Hpe color="brand" />} tabIndex={-1} />
-        <Box gap="xsmall" direction="row">
-          <Text color="text-strong" weight="bold" alignSelf="center">
+        <Box align="center" gap="xsmall" direction="row">
+          <Text color="text-strong" weight="bold">
             HPE
           </Text>
-          <Text color="text-strong" alignSelf="center">
-            Text
-          </Text>
+          <Text color="text-strong">Text</Text>
         </Box>
       </Box>
       <Button icon={<Menu />} tabIndex={-1} />

--- a/aries-site/src/examples/cardPreviews/header.js
+++ b/aries-site/src/examples/cardPreviews/header.js
@@ -20,7 +20,7 @@ export const HeaderPreview = () => {
           </Text>
         </Box>
       </Box>
-      <Button icon={<Menu color="text-strong" />} tabIndex={-1} />
+      <Button icon={<Menu />} tabIndex={-1} />
     </Header>
   );
 };

--- a/aries-site/src/examples/components/header/HeaderActionExample.js
+++ b/aries-site/src/examples/components/header/HeaderActionExample.js
@@ -6,11 +6,21 @@ export const HeaderActionExample = () => {
   return (
     <Header fill="horizontal">
       <Button plain>
-        <Box direction="row" align="center" gap="medium">
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
           <Hpe color="brand" />
           <Box direction="row" gap="xsmall">
-            <Text weight="bold">HPE</Text>
-            <Text>App Name</Text>
+            <Text color="text-strong" weight="bold">
+              HPE
+            </Text>
+            <Text color="text-strong">App Name</Text>
           </Box>
         </Box>
       </Button>

--- a/aries-site/src/examples/components/header/HeaderActionExample.js
+++ b/aries-site/src/examples/components/header/HeaderActionExample.js
@@ -8,7 +8,7 @@ export const HeaderActionExample = () => {
       <Button plain>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -16,7 +16,7 @@ export const HeaderActionExample = () => {
           responsive={false}
         >
           <Hpe color="brand" />
-          <Box direction="row" gap="xsmall">
+          <Box direction="row" gap="xsmall" wrap>
             <Text color="text-strong" weight="bold">
               HPE
             </Text>

--- a/aries-site/src/examples/components/header/HeaderAvatarExample.js
+++ b/aries-site/src/examples/components/header/HeaderAvatarExample.js
@@ -6,11 +6,21 @@ export const HeaderAvatarExample = () => {
   return (
     <Header fill="horizontal">
       <Button plain>
-        <Box direction="row" align="center" gap="medium">
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
           <Hpe color="brand" />
           <Box direction="row" gap="xsmall">
-            <Text weight="bold">HPE</Text>
-            <Text>App Name</Text>
+            <Text color="text-strong" weight="bold">
+              HPE
+            </Text>
+            <Text color="text-strong">App Name</Text>
           </Box>
         </Box>
       </Button>

--- a/aries-site/src/examples/components/header/HeaderAvatarExample.js
+++ b/aries-site/src/examples/components/header/HeaderAvatarExample.js
@@ -8,7 +8,7 @@ export const HeaderAvatarExample = () => {
       <Button plain>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -16,7 +16,7 @@ export const HeaderAvatarExample = () => {
           responsive={false}
         >
           <Hpe color="brand" />
-          <Box direction="row" gap="xsmall">
+          <Box direction="row" gap="xsmall" wrap>
             <Text color="text-strong" weight="bold">
               HPE
             </Text>

--- a/aries-site/src/examples/components/header/HeaderExample.js
+++ b/aries-site/src/examples/components/header/HeaderExample.js
@@ -53,7 +53,7 @@ export const HeaderExample = () => {
       <>
         {!focused && size === 'small' && (
           <Button
-            icon={<SearchIcon color="text-strong" />}
+            icon={<SearchIcon />}
             hoverIndicator
             onClick={() => setFocused(true)}
           />
@@ -63,9 +63,7 @@ export const HeaderExample = () => {
             <Keyboard onEsc={() => setFocused(false)}>
               <StyledTextInput
                 ref={inputRef}
-                icon={
-                  <SearchIcon color="text-strong" id="search-icon-example" />
-                }
+                icon={<SearchIcon id="search-icon-example" />}
                 dropHeight="small"
                 placeholder="Search HPE Design System"
                 onBlur={() => setFocused(false)}

--- a/aries-site/src/examples/components/header/HeaderExample.js
+++ b/aries-site/src/examples/components/header/HeaderExample.js
@@ -31,7 +31,7 @@ export const HeaderExample = () => {
       <Button plain>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -40,7 +40,7 @@ export const HeaderExample = () => {
         >
           <Hpe color="brand" />
           {(size !== 'small' || (size === 'small' && !focused)) && (
-            <Box direction="row" gap="xsmall">
+            <Box direction="row" gap="xsmall" wrap>
               <Text color="text-strong" weight="bold">
                 HPE
               </Text>

--- a/aries-site/src/examples/components/header/HeaderExample.js
+++ b/aries-site/src/examples/components/header/HeaderExample.js
@@ -17,6 +17,7 @@ const StyledTextInput = styled(TextInput).attrs(() => ({
 
 export const HeaderExample = () => {
   const size = useContext(ResponsiveContext);
+  console.log({ size });
   const [focused, setFocused] = useState(false);
   const inputRef = useRef();
 
@@ -29,12 +30,22 @@ export const HeaderExample = () => {
   return (
     <Header fill="horizontal" pad="none" background="background-front">
       <Button plain>
-        <Box direction="row" align="center" gap="medium">
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
           <Hpe color="brand" />
           {(size !== 'small' || (size === 'small' && !focused)) && (
             <Box direction="row" gap="xsmall">
-              <Text weight="bold">HPE</Text>
-              <Text>App Name</Text>
+              <Text color="text-strong" weight="bold">
+                HPE
+              </Text>
+              <Text color="text-strong">App Name</Text>
             </Box>
           )}
         </Box>
@@ -42,7 +53,7 @@ export const HeaderExample = () => {
       <>
         {!focused && size === 'small' && (
           <Button
-            icon={<SearchIcon />}
+            icon={<SearchIcon color="text-strong" />}
             hoverIndicator
             onClick={() => setFocused(true)}
           />
@@ -52,7 +63,9 @@ export const HeaderExample = () => {
             <Keyboard onEsc={() => setFocused(false)}>
               <StyledTextInput
                 ref={inputRef}
-                icon={<SearchIcon id="search-icon-example" />}
+                icon={
+                  <SearchIcon color="text-strong" id="search-icon-example" />
+                }
                 dropHeight="small"
                 placeholder="Search HPE Design System"
                 onBlur={() => setFocused(false)}

--- a/aries-site/src/examples/components/header/HeaderExample.js
+++ b/aries-site/src/examples/components/header/HeaderExample.js
@@ -17,7 +17,6 @@ const StyledTextInput = styled(TextInput).attrs(() => ({
 
 export const HeaderExample = () => {
   const size = useContext(ResponsiveContext);
-  console.log({ size });
   const [focused, setFocused] = useState(false);
   const inputRef = useRef();
 

--- a/aries-site/src/examples/components/header/HeaderNavigationExample.js
+++ b/aries-site/src/examples/components/header/HeaderNavigationExample.js
@@ -23,7 +23,7 @@ export const HeaderNavigationExample = () => {
       <Button plain>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -31,7 +31,7 @@ export const HeaderNavigationExample = () => {
           responsive={false}
         >
           <Hpe color="brand" />
-          <Box direction="row" gap="xsmall">
+          <Box direction="row" gap="xsmall" wrap>
             <Text color="text-strong" weight="bold">
               HPE
             </Text>

--- a/aries-site/src/examples/components/header/HeaderNavigationExample.js
+++ b/aries-site/src/examples/components/header/HeaderNavigationExample.js
@@ -21,11 +21,21 @@ export const HeaderNavigationExample = () => {
   return (
     <Header fill="horizontal">
       <Button plain>
-        <Box direction="row" align="center" gap="medium">
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
           <Hpe color="brand" />
           <Box direction="row" gap="xsmall">
-            <Text weight="bold">HPE</Text>
-            <Text>App Name</Text>
+            <Text color="text-strong" weight="bold">
+              HPE
+            </Text>
+            <Text color="text-strong">App Name</Text>
           </Box>
         </Box>
       </Button>

--- a/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
+++ b/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
@@ -61,7 +61,7 @@ export const HeaderSearchActionsExample = () => {
       <Button plain>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -69,7 +69,7 @@ export const HeaderSearchActionsExample = () => {
           responsive={false}
         >
           <Hpe color="brand" />
-          <Box direction="row" gap="xsmall">
+          <Box direction="row" gap="xsmall" wrap>
             <Text color="text-strong" weight="bold">
               HPE
             </Text>

--- a/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
+++ b/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
@@ -34,7 +34,7 @@ const Search = () => {
 
   return !focused && size === 'small' ? (
     <Button
-      icon={<SearchIcon color="text-strong" />}
+      icon={<SearchIcon />}
       hoverIndicator
       onClick={() => setFocused(true)}
     />
@@ -43,7 +43,7 @@ const Search = () => {
       <Keyboard onEsc={() => setFocused(false)}>
         <StyledTextInput
           ref={inputRef}
-          icon={<SearchIcon color="text-strong" id="search-complex-example" />}
+          icon={<SearchIcon id="search-complex-example" />}
           dropHeight="small"
           placeholder="Search App Name"
           onBlur={() => setFocused(false)}

--- a/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
+++ b/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
@@ -34,7 +34,7 @@ const Search = () => {
 
   return !focused && size === 'small' ? (
     <Button
-      icon={<SearchIcon />}
+      icon={<SearchIcon color="text-strong" />}
       hoverIndicator
       onClick={() => setFocused(true)}
     />
@@ -43,7 +43,7 @@ const Search = () => {
       <Keyboard onEsc={() => setFocused(false)}>
         <StyledTextInput
           ref={inputRef}
-          icon={<SearchIcon id="search-complex-example" />}
+          icon={<SearchIcon color="text-strong" id="search-complex-example" />}
           dropHeight="small"
           placeholder="Search App Name"
           onBlur={() => setFocused(false)}
@@ -59,11 +59,21 @@ export const HeaderSearchActionsExample = () => {
   return (
     <Header fill="horizontal">
       <Button plain>
-        <Box direction="row" align="center" gap="medium">
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
           <Hpe color="brand" />
           <Box direction="row" gap="xsmall">
-            <Text weight="bold">HPE</Text>
-            <Text>App Name</Text>
+            <Text color="text-strong" weight="bold">
+              HPE
+            </Text>
+            <Text color="text-strong">App Name</Text>
           </Box>
         </Box>
       </Button>

--- a/aries-site/src/examples/components/layer/LayerNotificationExample.js
+++ b/aries-site/src/examples/components/layer/LayerNotificationExample.js
@@ -35,11 +35,7 @@ export const LayerNotificationExample = () => {
                 This is a notifcation with position="top"
               </Text>
             </Box>
-            <Button
-              icon={<FormClose color="text-strong" />}
-              onClick={onClose}
-              plain
-            />
+            <Button icon={<FormClose />} onClick={onClose} plain />
           </Box>
         </Layer>
       )}

--- a/aries-site/src/examples/components/menu/MenuHeaderExample.js
+++ b/aries-site/src/examples/components/menu/MenuHeaderExample.js
@@ -16,7 +16,7 @@ export const MenuHeaderExample = () => {
       <Button>
         <Box
           direction="row"
-          align="center"
+          align="start"
           gap="medium"
           // pad maintains accessible hit target
           // non-responsive maintains same dimensions for mobile
@@ -25,7 +25,7 @@ export const MenuHeaderExample = () => {
         >
           <Hpe color="brand" />
           {size !== 'small' && (
-            <Box direction="row" gap="xsmall">
+            <Box direction="row" gap="xsmall" wrap>
               <Text color="text-strong" weight="bold">
                 HPE
               </Text>

--- a/aries-site/src/examples/components/menu/MenuHeaderExample.js
+++ b/aries-site/src/examples/components/menu/MenuHeaderExample.js
@@ -14,12 +14,22 @@ export const MenuHeaderExample = () => {
   return (
     <Header background="background-contrast" pad="small" fill="horizontal">
       <Button>
-        <Box direction="row" align="center" gap="medium">
+        <Box
+          direction="row"
+          align="center"
+          gap="medium"
+          // pad maintains accessible hit target
+          // non-responsive maintains same dimensions for mobile
+          pad={{ vertical: 'small' }}
+          responsive={false}
+        >
           <Hpe color="brand" />
           {size !== 'small' && (
             <Box direction="row" gap="xsmall">
-              <Text weight="bold">HPE</Text>
-              <Text>App Name</Text>
+              <Text color="text-strong" weight="bold">
+                HPE
+              </Text>
+              <Text color="text-strong">App Name</Text>
             </Box>
           )}
         </Box>

--- a/aries-site/src/examples/templates/dashboards/DashboardExample.js
+++ b/aries-site/src/examples/templates/dashboards/DashboardExample.js
@@ -254,7 +254,7 @@ const AppIdentity = ({ name }) => (
   <Button plain>
     <Box
       direction="row"
-      align="center"
+      align="start"
       gap="medium"
       // pad maintains accessible hit target
       // non-responsive maintains same dimensions for mobile
@@ -262,7 +262,7 @@ const AppIdentity = ({ name }) => (
       responsive={false}
     >
       <Hpe color="brand" />
-      <Box direction="row" gap="xsmall">
+      <Box direction="row" gap="xsmall" wrap>
         <Text color="text-strong" weight="bold">
           HPE
         </Text>

--- a/aries-site/src/examples/templates/dashboards/DashboardExample.js
+++ b/aries-site/src/examples/templates/dashboards/DashboardExample.js
@@ -252,13 +252,21 @@ const AppHeader = () => (
 
 const AppIdentity = ({ name }) => (
   <Button plain>
-    <Box direction="row" align="center" gap="small">
+    <Box
+      direction="row"
+      align="center"
+      gap="medium"
+      // pad maintains accessible hit target
+      // non-responsive maintains same dimensions for mobile
+      pad={{ vertical: 'small' }}
+      responsive={false}
+    >
       <Hpe color="brand" />
       <Box direction="row" gap="xsmall">
-        <Text color="text" weight="bold">
+        <Text color="text-strong" weight="bold">
           HPE
         </Text>
-        <Text color="text">{name}</Text>
+        <Text color="text-strong">{name}</Text>
       </Box>
     </Box>
   </Button>

--- a/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
+++ b/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
@@ -240,7 +240,7 @@ const AppIdentity = ({ name, ...rest }) => (
   <Button plain {...rest}>
     <Box
       direction="row"
-      align="center"
+      align="start"
       gap="medium"
       // pad maintains accessible hit target
       // non-responsive maintains same dimensions for mobile
@@ -248,7 +248,7 @@ const AppIdentity = ({ name, ...rest }) => (
       responsive={false}
     >
       <Hpe color="brand" />
-      <Box direction="row" gap="xsmall">
+      <Box direction="row" gap="xsmall" wrap>
         <Text color="text-strong" weight="bold">
           HPE
         </Text>

--- a/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
+++ b/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
@@ -238,13 +238,21 @@ AppHeader.propTypes = {
 
 const AppIdentity = ({ name, ...rest }) => (
   <Button plain {...rest}>
-    <Box direction="row" align="center" gap="small">
+    <Box
+      direction="row"
+      align="center"
+      gap="medium"
+      // pad maintains accessible hit target
+      // non-responsive maintains same dimensions for mobile
+      pad={{ vertical: 'small' }}
+      responsive={false}
+    >
       <Hpe color="brand" />
       <Box direction="row" gap="xsmall">
-        <Text color="text" weight="bold">
+        <Text color="text-strong" weight="bold">
           HPE
         </Text>
-        <Text color="text">{name}</Text>
+        <Text color="text-strong">{name}</Text>
       </Box>
     </Box>
   </Button>

--- a/aries-site/src/examples/templates/list-views/ListScreenExample.js
+++ b/aries-site/src/examples/templates/list-views/ListScreenExample.js
@@ -178,10 +178,10 @@ const AppHeaderExample = () => (
       >
         <Hpe color="plain" />
         <Box direction="row" gap="xsmall">
-          <Text weight="bold" size="medium" color="text">
+          <Text weight="bold" size="medium" color="text-strong">
             HPE
           </Text>
-          <Text size="medium" color="text">
+          <Text size="medium" color="text-strong">
             Server
           </Text>
         </Box>

--- a/aries-site/src/examples/templates/list-views/ListScreenExample.js
+++ b/aries-site/src/examples/templates/list-views/ListScreenExample.js
@@ -171,13 +171,13 @@ const AppHeaderExample = () => (
     <Button plain>
       <Box
         direction="row"
-        align="center"
+        align="start"
         gap="medium"
         pad={{ vertical: 'small' }}
         responsive={false}
       >
         <Hpe color="plain" />
-        <Box direction="row" gap="xsmall">
+        <Box direction="row" gap="xsmall" wrap>
           <Text weight="bold" size="medium" color="text-strong">
             HPE
           </Text>

--- a/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
@@ -154,7 +154,7 @@ const AppIdentity = ({ name }) => (
   <Button plain>
     <Box
       direction="row"
-      align="center"
+      align="start"
       gap="medium"
       // pad maintains accessible hit target
       // non-responsive maintains same dimensions for mobile
@@ -162,7 +162,7 @@ const AppIdentity = ({ name }) => (
       responsive={false}
     >
       <Hpe color="brand" />
-      <Box direction="row" gap="xsmall">
+      <Box direction="row" gap="xsmall" wrap>
         <Text color="text-strong" weight="bold">
           HPE
         </Text>

--- a/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
@@ -93,12 +93,12 @@ const MainNavigation = ({ activeItem, setActiveItem }) => {
   const size = React.useContext(ResponsiveContext);
 
   return size !== 'small' ? (
-    <Nav direction="row" gap="xsmall">
+    <Nav align="center" direction="row" gap="xsmall">
       <NavItems activeItem={activeItem} setActiveItem={setActiveItem} />
     </Nav>
   ) : (
     <Menu
-      icon={<MenuIcon />}
+      icon={<MenuIcon color="text-strong" />}
       dropAlign={{ top: 'bottom', right: 'right' }}
       hoverIndicator
       items={pages.map((item, index) => ({
@@ -123,7 +123,6 @@ const NavItems = ({ activeItem, setActiveItem }) => {
         label={item.name}
         active={index === activeItem}
         onClick={() => setActiveItem(index)}
-        round="xsmall"
       />
     ))
   );
@@ -153,13 +152,21 @@ PageContent.propTypes = {
 
 const AppIdentity = ({ name }) => (
   <Button plain>
-    <Box direction="row" align="center" gap="small">
+    <Box
+      direction="row"
+      align="center"
+      gap="medium"
+      // pad maintains accessible hit target
+      // non-responsive maintains same dimensions for mobile
+      pad={{ vertical: 'small' }}
+      responsive={false}
+    >
       <Hpe color="brand" />
       <Box direction="row" gap="xsmall">
-        <Text color="text" weight="bold">
+        <Text color="text-strong" weight="bold">
           HPE
         </Text>
-        <Text color="text">{name}</Text>
+        <Text color="text-strong">{name}</Text>
       </Box>
     </Box>
   </Button>

--- a/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
@@ -98,7 +98,7 @@ const MainNavigation = ({ activeItem, setActiveItem }) => {
     </Nav>
   ) : (
     <Menu
-      icon={<MenuIcon color="text-strong" />}
+      icon={<MenuIcon />}
       dropAlign={{ top: 'bottom', right: 'right' }}
       hoverIndicator
       items={pages.map((item, index) => ({

--- a/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
@@ -222,13 +222,21 @@ const SidebarHeader = () => <Avatar background="background-front">DS</Avatar>;
 
 const AppIdentity = ({ name }) => (
   <Button plain>
-    <Box direction="row" align="center" gap="small">
+    <Box
+      direction="row"
+      align="center"
+      gap="medium"
+      // pad maintains accessible hit target
+      // non-responsive maintains same dimensions for mobile
+      pad={{ vertical: 'small' }}
+      responsive={false}
+    >
       <Hpe color="brand" />
       <Box direction="row" gap="xsmall">
-        <Text color="text" weight="bold">
+        <Text color="text-strong" weight="bold">
           HPE
         </Text>
-        <Text color="text">{name}</Text>
+        <Text color="text-strong">{name}</Text>
       </Box>
     </Box>
   </Button>

--- a/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
@@ -145,7 +145,6 @@ const NavButton = ({ active, icon, name, ...rest }) => {
     <Box fill="horizontal">
       <Button
         ref={ref}
-        color="text-strong"
         icon={icon}
         onMouseOver={() => setHover(true)}
         onFocus={() => setHover(true)}

--- a/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
@@ -223,7 +223,7 @@ const AppIdentity = ({ name }) => (
   <Button plain>
     <Box
       direction="row"
-      align="center"
+      align="start"
       gap="medium"
       // pad maintains accessible hit target
       // non-responsive maintains same dimensions for mobile
@@ -231,7 +231,7 @@ const AppIdentity = ({ name }) => (
       responsive={false}
     >
       <Hpe color="brand" />
-      <Box direction="row" gap="xsmall">
+      <Box direction="row" gap="xsmall" wrap>
         <Text color="text-strong" weight="bold">
           HPE
         </Text>

--- a/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js
+++ b/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js
@@ -243,7 +243,7 @@ const WizardHeader = ({ active, setActive, setOpen, ...rest }) => {
         {active > 1 && (
           <Button
             label={size !== 'small' ? `Step ${active - 1}` : undefined}
-            icon={<FormPreviousLink color="text-strong" />}
+            icon={<FormPreviousLink />}
             onClick={() => setActive(active - 1)}
           />
         )}
@@ -256,7 +256,7 @@ const WizardHeader = ({ active, setActive, setOpen, ...rest }) => {
       <Box direction="row" flex justify="end">
         <Button
           label={size !== 'small' ? 'Cancel' : undefined}
-          icon={<FormClose color="text-strong" />}
+          icon={<FormClose />}
           reverse
           onClick={() => setOpen(true)}
         />

--- a/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -288,7 +288,7 @@ const WizardHeader = ({ active, setActive, setOpen }) => {
         {active > 1 && (
           <Button
             label={size !== 'small' ? `Step ${active - 1}` : undefined}
-            icon={<FormPreviousLink color="text-strong" />}
+            icon={<FormPreviousLink />}
             onClick={() => setActive(active - 1)}
           />
         )}
@@ -301,7 +301,7 @@ const WizardHeader = ({ active, setActive, setOpen }) => {
       <Box direction="row" flex justify="end">
         <Button
           label={size !== 'small' ? 'Cancel' : undefined}
-          icon={<FormClose color="text-strong" />}
+          icon={<FormClose />}
           reverse
           onClick={() => setOpen(true)}
         />

--- a/aries-site/src/examples/templates/wizard/WizardValidationExample.js
+++ b/aries-site/src/examples/templates/wizard/WizardValidationExample.js
@@ -299,7 +299,7 @@ const WizardHeader = ({ activeIndex, activeStep, setActiveIndex, setOpen }) => {
         {activeStep > 1 && (
           <Button
             label={size !== 'small' ? `Step ${activeStep - 1}` : undefined}
-            icon={<FormPreviousLink color="text-strong" />}
+            icon={<FormPreviousLink />}
             onClick={() => setActiveIndex(activeIndex - 1)}
           />
         )}
@@ -312,7 +312,7 @@ const WizardHeader = ({ activeIndex, activeStep, setActiveIndex, setOpen }) => {
       <Box direction="row" flex justify="end">
         <Button
           label={size !== 'small' ? 'Cancel' : undefined}
-          icon={<FormClose color="text-strong" />}
+          icon={<FormClose />}
           reverse
           onClick={() => setOpen(true)}
         />

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Keyboard, Layer, ResponsiveContext } from 'grommet';
 import { Contract } from 'grommet-icons';
@@ -39,6 +39,7 @@ export const Example = ({
 }) => {
   const [screen, setScreen] = React.useState(screens.laptop);
   const [showLayer, setShowLayer] = React.useState(false);
+  const size = useContext(ResponsiveContext);
 
   // If plain, we remove the Container that creates a padded
   // box with rounded corners around Example content
@@ -69,6 +70,11 @@ export const Example = ({
   else if (showResponsiveControls) ExampleWrapper = ResponsiveContainer;
   else ExampleWrapper = Box;
 
+  let viewPort;
+  if (screen === screens.mobile) viewPort = 'small';
+  else if (!screenContainer && !showResponsiveControls) viewPort = size;
+  else viewPort = undefined;
+
   // when Layer is open, we remove the inline Example to avoid
   // repeat id tags that may impede interactivity of inputs
   const content = !showLayer && (
@@ -82,9 +88,7 @@ export const Example = ({
         screen={screen}
         width={width}
       >
-        <ResponsiveContext.Provider
-          value={screen === screens.mobile && 'small'}
-        >
+        <ResponsiveContext.Provider value={viewPort}>
           {children}
         </ResponsiveContext.Provider>
       </ExampleWrapper>
@@ -202,16 +206,12 @@ export const Example = ({
                     id="layer-wrapper"
                     width={screen === screens.mobile ? 'medium' : '100%'}
                   >
-                    <ResponsiveContext.Provider
-                      value={screen === screens.mobile && 'small'}
-                    >
+                    <ResponsiveContext.Provider value={viewPort}>
                       {children}
                     </ResponsiveContext.Provider>
                   </Box>
                 ) : (
-                  <ResponsiveContext.Provider
-                    value={screen === screens.mobile && 'small'}
-                  >
+                  <ResponsiveContext.Provider value={viewPort}>
                     {children}
                   </ResponsiveContext.Provider>
                 )}

--- a/aries-site/src/layouts/main/Header.js
+++ b/aries-site/src/layouts/main/Header.js
@@ -1,8 +1,9 @@
 import React, { useContext, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Box, Button, Header, ResponsiveContext, Text } from 'grommet';
-import { Hpe, Search as SearchIcon } from 'grommet-icons';
+import { Box, Button, Header, ResponsiveContext } from 'grommet';
+import { Search as SearchIcon } from 'grommet-icons';
+import { AppIdentity } from '../../components';
 import { getPageDetails, nameToPath } from '../../utils';
 import { Search } from '../navigation';
 
@@ -22,27 +23,11 @@ const StyledHeader = ({ ...rest }) => {
       {...rest}
     >
       <Link href="/" passHref>
-        <Button plain>
-          <Box
-            direction="row"
-            align="center"
-            gap="medium"
-            // pad maintains accessible hit target
-            // non-responsive maintains same dimensions for mobile
-            pad={{ vertical: 'small' }}
-            responsive={false}
-          >
-            <Hpe color="brand" />
-            {(size !== 'small' || (size === 'small' && !searchFocused)) && (
-              <Box direction="row" gap="xsmall">
-                <Text color="text-strong" weight="bold">
-                  HPE
-                </Text>
-                <Text color="text-strong">App Name</Text>
-              </Box>
-            )}
-          </Box>
-        </Button>
+        <AppIdentity
+          brand="hpe"
+          logoOnly={size === 'small' && searchFocused}
+          title="Design System"
+        />
       </Link>
       {!searchFocused ? (
         <Box direction="row" align="center" gap="xsmall">

--- a/aries-site/src/layouts/main/Header.js
+++ b/aries-site/src/layouts/main/Header.js
@@ -1,9 +1,8 @@
 import React, { useContext, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { AppIdentity } from 'aries-core';
-import { Box, Button, Header, ResponsiveContext } from 'grommet';
-import { Search as SearchIcon } from 'grommet-icons';
+import { Box, Button, Header, ResponsiveContext, Text } from 'grommet';
+import { Hpe, Search as SearchIcon } from 'grommet-icons';
 import { getPageDetails, nameToPath } from '../../utils';
 import { Search } from '../navigation';
 
@@ -23,11 +22,27 @@ const StyledHeader = ({ ...rest }) => {
       {...rest}
     >
       <Link href="/" passHref>
-        <AppIdentity
-          brand="hpe"
-          logoOnly={size === 'small' && searchFocused}
-          title="Design System"
-        />
+        <Button plain>
+          <Box
+            direction="row"
+            align="center"
+            gap="medium"
+            // pad maintains accessible hit target
+            // non-responsive maintains same dimensions for mobile
+            pad={{ vertical: 'small' }}
+            responsive={false}
+          >
+            <Hpe color="brand" />
+            {(size !== 'small' || (size === 'small' && !searchFocused)) && (
+              <Box direction="row" gap="xsmall">
+                <Text color="text-strong" weight="bold">
+                  HPE
+                </Text>
+                <Text color="text-strong">App Name</Text>
+              </Box>
+            )}
+          </Box>
+        </Button>
       </Link>
       {!searchFocused ? (
         <Box direction="row" align="center" gap="xsmall">

--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -84,7 +84,7 @@ export const Search = ({ focused, setFocused }) => {
           <Keyboard onEsc={() => setFocused(false)} onEnter={onEnter}>
             <StyledTextInput
               ref={inputRef}
-              icon={<SearchIcon id="search-icon" />}
+              icon={<SearchIcon color="text-strong" id="search-icon" />}
               dropHeight="small"
               placeholder="Search HPE Design System"
               onChange={onChange}

--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -84,7 +84,7 @@ export const Search = ({ focused, setFocused }) => {
           <Keyboard onEsc={() => setFocused(false)} onEnter={onEnter}>
             <StyledTextInput
               ref={inputRef}
-              icon={<SearchIcon color="text-strong" id="search-icon" />}
+              icon={<SearchIcon id="search-icon" />}
               dropHeight="small"
               placeholder="Search HPE Design System"
               onChange={onChange}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,9 +5301,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001154:
-  version "1.0.30001154"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz#f3bbc245ce55e4c1cd20fa731b097880181a7f17"
-  integrity sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==
+  version "1.0.30001156"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz#75c20937b6012fe2b02ab58b30d475bf0718de97"
+  integrity sha512-z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7984,9 +7984,9 @@ fsevents@^1.2.7:
     nan "^2.12.1"
 
 fsevents@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.2.0.tgz#4150396a427ecb5baa747725b70270a72b17bc17"
-  integrity sha512-pKnaUh2TNvk+/egJdBw1h46LwyLx8BzEq+MGCf/RMCVfEHHsGOCWG00dqk91kUPPArIIwMBg9T/virxwzP03cA==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.2.1.tgz#1fb02ded2036a8ac288d507a65962bd87b97628d"
+  integrity sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==
 
 fsevents@~2.1.2:
   version "2.1.3"
@@ -8326,8 +8326,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.15.2"
-  uid "65178e4e2f87fc2bbf2dcaaca1dca5fa5bd33964"
-  resolved "https://github.com/grommet/grommet/tarball/stable#65178e4e2f87fc2bbf2dcaaca1dca5fa5bd33964"
+  uid "3ca84c25a68cb95ac3fe8419cde29b4e2b04cef9"
+  resolved "https://github.com/grommet/grommet/tarball/stable#3ca84c25a68cb95ac3fe8419cde29b4e2b04cef9"
   dependencies:
     grommet-icons "^4.2.0"
     hoist-non-react-statics "^3.2.0"
@@ -11070,9 +11070,9 @@ node-forge@^0.10.0:
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-html-parser@^1.2.19:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.4.6.tgz#1ab1ff2a787f95ef33cd8ff80222a9029d8112fb"
-  integrity sha512-VgX2Bk8dq59yFeNC46LdA6VzRXffOPVNOMoeZquACZVwbC1VYJ3ssd5/mncTBGBrd3M+t6cMD5KQWdK/l+qPFQ==
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.4.8.tgz#ca0d0ddb9b3609fdf52fd3a5cf771ee915a5b0af"
+  integrity sha512-goyDL2T1qnepirf64Qu1ttJ2UZmNGp1CPbG3pkh2VYc1yqzgPX0rjKN7vqThFcZmEIzC+ratLIod1O/MNXwgzg==
   dependencies:
     he "1.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5101,9 +5101,9 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.1.0, buffer@^5.2.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.0.tgz#88afbd29fc89fa7b58e82b39206f31f2cf34feed"
-  integrity sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
@@ -6817,9 +6817,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.585:
-  version "1.3.587"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.587.tgz#de570df7320eb259c0511f284c2d6008094edbf7"
-  integrity sha512-8XFNxzNj0R8HpTQslWAw6UWpGSuOKSP3srhyFHVbGUGb8vTHckZGCyWi+iQlaXJx5DNeTQTQLd6xN11WSckkmA==
+  version "1.3.588"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.588.tgz#c6515571737bfb42678115a5eaa818384593a9a5"
+  integrity sha512-0zr+ZfytnLeJZxGgmEpPTcItu5Mm4A5zHPZXLfHcGp0mdsk95rmD7ePNewYtK1yIdLbk8Z1U2oTRRfOtR4gbYg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -8326,8 +8326,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.15.2"
-  uid fc881ac2d5337eea63032f8d406856f81be00339
-  resolved "https://github.com/grommet/grommet/tarball/stable#fc881ac2d5337eea63032f8d406856f81be00339"
+  uid "65178e4e2f87fc2bbf2dcaaca1dca5fa5bd33964"
+  resolved "https://github.com/grommet/grommet/tarball/stable#65178e4e2f87fc2bbf2dcaaca1dca5fa5bd33964"
   dependencies:
     grommet-icons "^4.2.0"
     hoist-non-react-statics "^3.2.0"
@@ -9131,9 +9131,9 @@ is-ci@^2.0.0:
     ci-info "^2.0.0"
 
 is-core-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
-  integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
+  integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
   dependencies:
     has "^1.0.3"
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates Header examples throughout the site to have consistent styling. Color of `text-strong` should be used for text. Additionally, some adjustments were made to create consistency between the HPE element and text as well as hit target dimensions for mobile.

[Designs](https://www.figma.com/file/krgk9GTsccqOvcTm8OVzH2/HPE-Header-Component?node-id=0%3A1)

#### Where should the reviewer start?
Any file.

#### What testing has been done on this PR?
Tested locally.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #1223 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
