### PR TITLE
Remove usage of plain

### DIFF
--- a/aries-site/src/examples/components/header/HeaderActionExample.js
+++ b/aries-site/src/examples/components/header/HeaderActionExample.js
@@ -5,7 +5,7 @@ import { Add, Hpe } from 'grommet-icons';
 export const HeaderActionExample = () => {
   return (
     <Header fill="horizontal">
-      <Button plain>
+      <Button>
         <Box
           direction="row"
           align="start"

--- a/aries-site/src/examples/components/header/HeaderAvatarExample.js
+++ b/aries-site/src/examples/components/header/HeaderAvatarExample.js
@@ -5,7 +5,7 @@ import { Hpe } from 'grommet-icons';
 export const HeaderAvatarExample = () => {
   return (
     <Header fill="horizontal">
-      <Button plain>
+      <Button>
         <Box
           direction="row"
           align="start"

--- a/aries-site/src/examples/components/header/HeaderExample.js
+++ b/aries-site/src/examples/components/header/HeaderExample.js
@@ -28,7 +28,7 @@ export const HeaderExample = () => {
 
   return (
     <Header fill="horizontal" pad="none" background="background-front">
-      <Button plain>
+      <Button>
         <Box
           direction="row"
           align="start"

--- a/aries-site/src/examples/components/header/HeaderNavigationExample.js
+++ b/aries-site/src/examples/components/header/HeaderNavigationExample.js
@@ -20,7 +20,7 @@ export const HeaderNavigationExample = () => {
   const size = useContext(ResponsiveContext);
   return (
     <Header fill="horizontal">
-      <Button plain>
+      <Button>
         <Box
           direction="row"
           align="start"

--- a/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
+++ b/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
@@ -58,7 +58,7 @@ const Search = () => {
 export const HeaderSearchActionsExample = () => {
   return (
     <Header fill="horizontal">
-      <Button plain>
+      <Button>
         <Box
           direction="row"
           align="start"

--- a/aries-site/src/examples/components/table/TableMultiSelectExample.js
+++ b/aries-site/src/examples/components/table/TableMultiSelectExample.js
@@ -180,7 +180,7 @@ const columns = [
     property: 'orderName',
     header: 'Order Name',
     render: datum => (
-      <Button onClick={() => onClickHandler(datum)} plain>
+      <Button onClick={() => onClickHandler(datum)}>
         <Text truncate weight="bold">
           {datum.orderName}
         </Text>

--- a/aries-site/src/examples/foundation/icons/IconTextExample.js
+++ b/aries-site/src/examples/foundation/icons/IconTextExample.js
@@ -5,13 +5,7 @@ import { Chat } from 'grommet-icons';
 export const IconTextExample = () => {
   return (
     <Box pad="xsmall">
-      <Button
-        gap="small"
-        alignSelf="start"
-        plain
-        icon={<Chat />}
-        label="Chat"
-      />
+      <Button gap="small" alignSelf="start" icon={<Chat />} label="Chat" />
     </Box>
   );
 };

--- a/aries-site/src/examples/templates/dashboards/DashboardExample.js
+++ b/aries-site/src/examples/templates/dashboards/DashboardExample.js
@@ -251,7 +251,7 @@ const AppHeader = () => (
 );
 
 const AppIdentity = ({ name }) => (
-  <Button plain>
+  <Button>
     <Box
       direction="row"
       align="start"

--- a/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
+++ b/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
@@ -237,7 +237,7 @@ AppHeader.propTypes = {
 };
 
 const AppIdentity = ({ name, ...rest }) => (
-  <Button plain {...rest}>
+  <Button {...rest}>
     <Box
       direction="row"
       align="start"

--- a/aries-site/src/examples/templates/list-views/ListScreenExample.js
+++ b/aries-site/src/examples/templates/list-views/ListScreenExample.js
@@ -168,7 +168,7 @@ const PageHeaderExample = ({ title }) => (
 
 const AppHeaderExample = () => (
   <Header pad={{ vertical: 'small' }}>
-    <Button plain>
+    <Button>
       <Box
         direction="row"
         align="start"

--- a/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/HeaderNavExample.js
@@ -151,7 +151,7 @@ PageContent.propTypes = {
 };
 
 const AppIdentity = ({ name }) => (
-  <Button plain>
+  <Button>
     <Box
       direction="row"
       align="start"

--- a/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
+++ b/aries-site/src/examples/templates/persistent-navigation/MinimalSidebarExample.js
@@ -220,7 +220,7 @@ PageContent.propTypes = {
 const SidebarHeader = () => <Avatar background="background-front">DS</Avatar>;
 
 const AppIdentity = ({ name }) => (
-  <Button plain>
+  <Button>
     <Box
       direction="row"
       align="start"

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -83,12 +83,12 @@ export const Subsection = ({
               <Box align="start" gap="small">
                 {level === 1 && topic && (
                   <Link href={`/${topic.toLowerCase()}`} passHref>
-                    <Button
-                      label={<Text color="text">{parent.name}</Text>}
-                      icon={parent.icon('small', parent.color)}
-                      plain
-                      {...rest}
-                    />
+                    <Button {...rest}>
+                      <Box align="center" direction="row" gap="small">
+                        {parent.icon('small', parent.color)}
+                        <Text color="text">{parent.name}</Text>
+                      </Box>
+                    </Button>
                   </Link>
                 )}
                 <Subheading


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Since `plain` is automatically applied when a button has children, this removes redundant usages of plain.

#### Where should the reviewer start?
Any file.

#### What testing has been done on this PR?
Looked at deploy to ensure no visual changes.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.