### PR TITLE
Filtering - Fix usage of result vs results

### DIFF
--- a/aries-site/src/examples/templates/filtering/FilteringCards.js
+++ b/aries-site/src/examples/templates/filtering/FilteringCards.js
@@ -588,13 +588,15 @@ const RecordSummary = ({ data, filtering }) => (
     <Text size="small" weight="bold">
       {data.length}
     </Text>
-    <Text size="small">{filtering ? 'results of ' : 'items'}</Text>
+    <Text size="small">
+      {filtering ? `result${data.length > 1 ? 's' : ''} of ` : 'items'}
+    </Text>
     {filtering && (
       <Box direction="row" gap="xxsmall">
         <Text size="small" weight="bold">
           {allData.length}
         </Text>
-        <Text size="small">items</Text>
+        <Text size="small">{`item${allData.length > 1 ? 's' : ''}`}</Text>
       </Box>
     )}
   </Box>

--- a/aries-site/src/examples/templates/filtering/FilteringLists.js
+++ b/aries-site/src/examples/templates/filtering/FilteringLists.js
@@ -461,13 +461,15 @@ const RecordSummary = ({ data, filtering }) => (
     <Text size="small" weight="bold">
       {data.length}
     </Text>
-    <Text size="small">{filtering ? 'results of ' : 'items'}</Text>
+    <Text size="small">
+      {filtering ? `result${data.length > 1 ? 's' : ''} of ` : 'items'}
+    </Text>
     {filtering && (
       <Box direction="row" gap="xxsmall">
         <Text size="small" weight="bold">
           {allData.length}
         </Text>
-        <Text size="small">items</Text>
+        <Text size="small">{`item${allData.length > 1 ? 's' : ''}`}</Text>
       </Box>
     )}
   </Box>

--- a/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
@@ -347,13 +347,15 @@ const RecordSummary = ({ data, filtering }) => (
     <Text size="small" weight="bold">
       {data.length}
     </Text>
-    <Text size="small">{filtering ? 'results of ' : 'items'}</Text>
+    <Text size="small">
+      {filtering ? `result${data.length > 1 ? 's' : ''} of ` : 'items'}
+    </Text>
     {filtering && (
       <Box direction="row" gap="xxsmall">
         <Text size="small" weight="bold">
           {allData.length}
         </Text>
-        <Text size="small">items</Text>
+        <Text size="small">{`item${allData.length > 1 ? 's' : ''}`}</Text>
       </Box>
     )}
   </Box>

--- a/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
@@ -519,13 +519,15 @@ const RecordSummary = ({ data, filtering }) => (
     <Text size="small" weight="bold">
       {data.length}
     </Text>
-    <Text size="small">{filtering ? 'results of ' : 'items'}</Text>
+    <Text size="small">
+      {filtering ? `result${data.length > 1 ? 's' : ''} of ` : 'items'}
+    </Text>
     {filtering && (
       <Box direction="row" gap="xxsmall">
         <Text size="small" weight="bold">
           {allData.length}
         </Text>
-        <Text size="small">items</Text>
+        <Text size="small">{`item${allData.length > 1 ? 's' : ''}`}</Text>
       </Box>
     )}
   </Box>

--- a/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
@@ -300,13 +300,15 @@ const RecordSummary = ({ data, filtering }) => (
     <Text size="small" weight="bold">
       {data.length}
     </Text>
-    <Text size="small">{filtering ? 'results of ' : 'items'}</Text>
+    <Text size="small">
+      {filtering ? `result${data.length > 1 ? 's' : ''} of ` : 'items'}
+    </Text>
     {filtering && (
       <Box direction="row" gap="xxsmall">
         <Text size="small" weight="bold">
           {allData.length}
         </Text>
-        <Text size="small">items</Text>
+        <Text size="small">{`item${allData.length > 1 ? 's' : ''}`}</Text>
       </Box>
     )}
   </Box>

--- a/aries-site/src/examples/templates/filtering/PersistentFiltering.js
+++ b/aries-site/src/examples/templates/filtering/PersistentFiltering.js
@@ -788,13 +788,15 @@ const RecordSummary = ({ data, filtering }) => (
     <Text size="small" weight="bold">
       {data.length}
     </Text>
-    <Text size="small">{filtering ? 'results of ' : 'items'}</Text>
+    <Text size="small">
+      {filtering ? `result${data.length > 1 ? 's' : ''} of ` : 'items'}
+    </Text>
     {filtering && (
       <Box direction="row" gap="xxsmall">
         <Text size="small" weight="bold">
           {allData.length}
         </Text>
-        <Text size="small">items</Text>
+        <Text size="small">{`item${allData.length > 1 ? 's' : ''}`}</Text>
       </Box>
     )}
   </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
When filter has a single result, use "result' instead of "results". For example: `1 result of 6 items`.

#### Where should the reviewer start?
Any file.

#### What testing has been done on this PR?
Any file.

#### How should this be manually tested?
Engage with filtering example until there is only one result.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #1234 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.