### PR TITLE
Close Global Header menu layer onEsc

### DIFF
--- a/aries-site/src/examples/templates/global-header/components/MenuLayer.js
+++ b/aries-site/src/examples/templates/global-header/components/MenuLayer.js
@@ -29,6 +29,7 @@ export const MenuLayer = () => {
           full={size !== 'small' ? 'vertical' : true}
           modal={false}
           onClickOutside={() => setShowLayer(false)}
+          onEsc={() => setShowLayer(false)}
           position={size !== 'small' ? 'left' : undefined}
         >
           <Box

--- a/yarn.lock
+++ b/yarn.lock
@@ -7873,8 +7873,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.16.2"
-  uid "85f50afd13a2071208357db030dc06f2717a398e"
-  resolved "https://github.com/grommet/grommet/tarball/stable#85f50afd13a2071208357db030dc06f2717a398e"
+  uid ad1a6c810a3a73bbef436427ea2b238c6c173784
+  resolved "https://github.com/grommet/grommet/tarball/stable#ad1a6c810a3a73bbef436427ea2b238c6c173784"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds functionality that was added to grommet stable by [this PR](https://github.com/grommet/grommet/pull/4864) where onEsc with close the sidebar menu of global header.


Note: e2e tests are failing due to an unrelated issue with text input suggestions. I've filed an issue here https://github.com/grommet/grommet/issues/4875, but don't think it should block this PR.

#### Where should the reviewer start?
aries-site/src/examples/templates/global-header/components/MenuLayer.js

#### What testing has been done on this PR?
Tested locally in site.

#### How should this be manually tested?
With Global Header example. Open the layer, then have keyboard focus somewhere on page, then use `Esc` to close the layer.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.