### PR TITLE
Update Background Colors Guidance

### DIFF
--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -32,7 +32,7 @@
     "lint-fix": "eslint src --fix"
   },
   "devDependencies": {
-    "@applitools/eyes-testcafe": "1.12.1",
+    "@applitools/eyes-testcafe": "^1.12.3",
     "axe-core": "^3.4.2",
     "axe-testcafe": "^3.0.0",
     "babel-plugin-prismjs": "^2.0.1",

--- a/aries-site/src/examples/foundation/background-colors/BasicLayoutCardsExample.js
+++ b/aries-site/src/examples/foundation/background-colors/BasicLayoutCardsExample.js
@@ -1,0 +1,111 @@
+import React, { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+import {
+  Button,
+  Card,
+  Header,
+  Box,
+  Grid,
+  Heading,
+  Main,
+  Paragraph,
+  ResponsiveContext,
+  Sidebar,
+  Text,
+} from 'grommet';
+import { AppIdentity } from '../../../components/content/AppIdentity';
+
+const data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+export const BasicLayoutCardsExample = () => {
+  const size = useContext(ResponsiveContext);
+  return (
+    <AppContainer>
+      <AppSidebar />
+      <Box flex overflow="auto">
+        <Header
+          border={{ color: 'border-weak', side: 'bottom' }}
+          background="background"
+          fill="horizontal"
+          pad={{ horizontal: 'medium', vertical: 'small' }}
+        >
+          <AppIdentity title="App Name" brand="hpe" />
+        </Header>
+        <Main background="background" pad="medium" fill={undefined}>
+          <Box align="start" gap="medium">
+            <Heading margin="none" color="text-strong">
+              Page title
+            </Heading>
+            <Paragraph margin="none">
+              This is the main page content. It may include buttons, tables,
+              forms, or any other kind of component.
+            </Paragraph>
+            <Button
+              label="Learn about page layouts"
+              href="/templates/page-layouts"
+              primary
+            />
+            <Grid
+              columns="small"
+              gap={size !== 'small' ? 'medium' : 'small'}
+              fill
+            >
+              {data.map((datum, index) => (
+                <Card
+                  align="center"
+                  justify="center"
+                  background="background"
+                  elevation="medium"
+                  key={index}
+                  onClick={() => {
+                    // eslint-disable-next-line no-alert
+                    alert(`
+            Typically a click would route to a view with 
+            greater detail behind this summary information.
+            `);
+                  }}
+                  height="small"
+                >
+                  <Text weight="bold">Card {datum + 1}</Text>
+                </Card>
+              ))}
+            </Grid>
+          </Box>
+        </Main>
+      </Box>
+    </AppContainer>
+  );
+};
+
+const AppSidebar = () => {
+  const size = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
+  return (
+    <Sidebar
+      /* Sidebar should switch from column to row orientation
+       * when on smaller screens */
+      direction={size !== 'small' ? 'column' : 'row'}
+      flex={false}
+      /* Min height is not needed in mobile contexts */
+      height={size !== 'small' ? { min: '100%' } : undefined}
+      pad="small"
+      background={!theme.dark ? { color: 'background', dark: true } : 'blue'}
+    >
+      <Text weight="bold" color="text-strong">
+        Sidebar
+      </Text>
+    </Sidebar>
+  );
+};
+
+const AppContainer = ({ ...rest }) => {
+  const size = React.useContext(ResponsiveContext);
+  return (
+    <Box
+      direction={size === 'small' ? 'column-reverse' : 'row'}
+      fill
+      margin="auto"
+      width={{ max: 'xxlarge' }}
+      {...rest}
+    />
+  );
+};

--- a/aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js
+++ b/aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js
@@ -15,7 +15,8 @@ import { ThemeContext } from 'styled-components';
 import { AppIdentity } from '../../../components/content/AppIdentity';
 
 const data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-export const LayeredLayoutExample = () => {
+
+export const LayeredLayoutFixedExample = () => {
   const size = useContext(ResponsiveContext);
   return (
     <AppContainer>
@@ -24,13 +25,13 @@ export const LayeredLayoutExample = () => {
         <Box height={{ min: '100%' }}>
           <Header
             border={{ color: 'border-weak', side: 'bottom' }}
-            background="background-back"
+            background="background-front"
             fill="horizontal"
             pad={{ horizontal: 'medium', vertical: 'small' }}
           >
             <AppIdentity title="App Name" brand="hpe" />
           </Header>
-          <Main background="background-back" pad="medium" fill={undefined}>
+          <Main background="background-back" flex pad="medium">
             <Heading color="text-strong" margin="none">
               Page title
             </Heading>

--- a/aries-site/src/examples/foundation/background-colors/index.js
+++ b/aries-site/src/examples/foundation/background-colors/index.js
@@ -1,3 +1,4 @@
 export * from './BasicLayoutExample';
+export * from './BasicLayoutCardsExample';
 export * from './LayeredLayoutExample';
 export * from './LayeredLayoutFixedExample';

--- a/aries-site/src/examples/foundation/background-colors/index.js
+++ b/aries-site/src/examples/foundation/background-colors/index.js
@@ -1,2 +1,3 @@
 export * from './BasicLayoutExample';
 export * from './LayeredLayoutExample';
+export * from './LayeredLayoutFixedExample';

--- a/aries-site/src/examples/templates/dashboards/components/DashboardCard.js
+++ b/aries-site/src/examples/templates/dashboards/components/DashboardCard.js
@@ -5,7 +5,12 @@ import { Button, Card, CardBody, Text } from 'grommet';
 export const DashboardCard = ({ card, ...rest }) => {
   const { background, cta, description, descriptionColor, icon, title } = card;
   return (
-    <Card background={background || 'background-front'} fill {...rest}>
+    <Card
+      background={background || 'background'}
+      elevation="medium"
+      fill
+      {...rest}
+    >
       <CardBody gap="small" align="start" flex="grow">
         {icon}
         <Text size="large" weight="bold" color="text-strong">

--- a/aries-site/src/examples/templates/dashboards/components/DashboardFooter.js
+++ b/aries-site/src/examples/templates/dashboards/components/DashboardFooter.js
@@ -22,6 +22,7 @@ export const DashboardFooter = () => {
 
   return (
     <Footer
+      background="background"
       direction="row-responsive"
       pad={{ horizontal: 'medium', vertical: 'small' }}
       wrap

--- a/aries-site/src/pages/foundation/background-colors-guidance.mdx
+++ b/aries-site/src/pages/foundation/background-colors-guidance.mdx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { BasicLayoutExample, LayeredLayoutExample, LayeredLayoutFixedExample } from '../../examples';
+import { BasicLayoutExample, BasicLayoutCardsExample, DashboardExample, LayeredLayoutExample, LayeredLayoutFixedExample } from '../../examples';
 import { Example } from '../../layouts';
 import { ThemeContext } from 'styled-components';
 import { Box } from 'grommet';
@@ -13,7 +13,18 @@ The application of background colors creates a visual hierarchy supporting the i
 hierarchy for the page. When applying background colors to content or layout, it is helpful
 to think about the content's role and relation to the page's information hierarchy.
 
-There are two approaches to how background colors should be used: [Basic](#basic) or [Layered](#layered). Explore guidance for applying each approach below.
+## Basic or Layered approach?
+
+There are two approaches to how background colors should be used: [Basic](#basic) or [Layered](#layered). For consistency across an application, a single approach should be used app-wide. 
+
+The decision to use the Basic or Layered approach comes down to how much visual differentiation is desired between background and foreground elements.
+
+- If a more subtle distinction is desired, use the [Basic](#basic) layout.
+- If a more defined contrast is desired, such as what is used for this Design System website, use the [Layered](#layered) layout.
+
+A single approach should be used app-wide. You should not use the layered approach on some pages of an application and the basic approach on others. 
+
+Explore detailed guidance for applying each approach below.
 
 ## Basic
 
@@ -34,7 +45,24 @@ achieving visual separation of the sidebar from the primary content.
 Refer to the [background palette](/foundation/color#background-palette) for definition
 of each background color namespace and value.
 
-### Example of basic layout
+### Basic layout with Cards
+
+`background` <ColorSwatch background="background" /> should be used for the application background as well as foreground elements, like Cards.
+
+The header, main content, and cards all use `background` <ColorSwatch background="background" /> for the background color. The sidebar uses a different color <ColorSwatch background={{color: "background", dark: true, sidebar: true}} /> to differentiate it from the rest of the content.
+
+<Example
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/background-colors/BasicLayoutCardsExample.js"
+  width="100%"
+  showResponsiveControls={['laptop', 'mobile']}
+  screenContainer
+>
+  <BasicLayoutCardsExample />
+</Example>
+
+### Basic layout with supporting content
+
+In this example, the header and main content use `background` <ColorSwatch background="background" /> and the help text uses `background-contrast` <ColorSwatch background="background-contrast" />. Usage of `background-contrast` and supplemental regions like this should be kept to a minimum.
 
 <Example
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/background-colors/BasicLayoutExample.js"

--- a/aries-site/src/pages/foundation/background-colors-guidance.mdx
+++ b/aries-site/src/pages/foundation/background-colors-guidance.mdx
@@ -103,7 +103,7 @@ For a multi-column page layout, `background-front` could be used to distinguish 
 
 ### With fixed header
 
-When the header is fixed, use `background-front` for the header since it is layered in front of the main content.
+When the header is fixed, use `background-front` <ColorSwatch background="background-front" /> for the header since it is layered in front of the main content.
 
 <Example
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js"

--- a/aries-site/src/pages/foundation/background-colors-guidance.mdx
+++ b/aries-site/src/pages/foundation/background-colors-guidance.mdx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { BasicLayoutExample, LayeredLayoutExample } from '../../examples';
+import { BasicLayoutExample, LayeredLayoutExample, LayeredLayoutFixedExample } from '../../examples';
 import { Example } from '../../layouts';
 import { ThemeContext } from 'styled-components';
 import { Box } from 'grommet';
@@ -65,13 +65,30 @@ above a main content section that uses `background-back`.
 Refer to the [background palette](/foundation/color#background-palette) for definition
 of each background color namespace and value.
 
-### Example of layered layout
+## Examples of Layered Layout
 
 For example, a page with a [header](/components/header), summary content, and a grid of
 [cards](/components/card) would use `background-front` for each card and
 `background-back` for everything else.
 
 For a multi-column page layout, `background-front` could be used to distinguish the column which should be the primary focus.
+
+### With fixed header
+
+When the header is fixed, use `background-front` for the header since it is layered in front of the main content.
+
+<Example
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js"
+  width="100%"
+  showResponsiveControls={['laptop', 'mobile']}
+  screenContainer
+>
+  <LayeredLayoutFixedExample />
+</Example>
+
+### Header scrolls with content
+
+When the header scrolls with the main content, use `background-back` for the header since it is flush with the main content. An example of this design would be the Design System website.
 
 <Example
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/background-colors/LayeredLayoutExample.js"

--- a/aries-site/src/pages/foundation/background-colors-guidance.mdx
+++ b/aries-site/src/pages/foundation/background-colors-guidance.mdx
@@ -116,7 +116,7 @@ When the header is fixed, use `background-front` <ColorSwatch background="backgr
 
 ### Header scrolls with content
 
-When the header scrolls with the main content, use `background-back` for the header since it is flush with the main content. An example of this design would be the Design System website.
+When the header scrolls with the main content, use `background-back` <ColorSwatch background="background-back" /> for the header since it is flush with the main content. An example of this design would be the Design System website.
 
 <Example
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/background-colors/LayeredLayoutExample.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2866,9 +2866,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@^7.0.5":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
-  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -2876,9 +2876,9 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/lodash@^4.14.72":
-  version "4.14.167"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
-  integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/mdast@^3.0.0":
   version "3.0.3"
@@ -2893,9 +2893,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.14.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
-  integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
+  version "14.14.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
+  integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
 
 "@types/node@^10.12.19":
   version "10.17.51"
@@ -3617,7 +3617,7 @@ array.prototype.flatmap@^1.2.1, array.prototype.flatmap@^1.2.3:
     es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
 
-array.prototype.map@^1.0.1:
+array.prototype.map@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.3.tgz#1609623618d3d84134a37d4a220030c2bd18420b"
   integrity sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==
@@ -4525,7 +4525,7 @@ browserslist@4.7.0:
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
 
-browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.0:
+browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.1:
   version "4.16.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
   integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
@@ -4726,7 +4726,7 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-call-bind@^1.0.0:
+call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -4821,9 +4821,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001173:
-  version "1.0.30001177"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz#2c3b384933aafda03e29ccca7bb3d8c3389e1ece"
-  integrity sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==
+  version "1.0.30001178"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz#3ad813b2b2c7d585b0be0a2440e1e233c6eabdbc"
+  integrity sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4953,9 +4953,9 @@ chokidar@2.1.8, chokidar@^2.0.4, chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.4.0, chokidar@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
-  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -5394,17 +5394,17 @@ copy-to-clipboard@^3.0.8:
     toggle-selection "^1.0.6"
 
 core-js-compat@^3.6.2, core-js-compat@^3.8.0:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.2.tgz#3717f51f6c3d2ebba8cbf27619b57160029d1d4c"
-  integrity sha512-LO8uL9lOIyRRrQmZxHZFl1RV+ZbcsAkFWTktn5SmH40WgLtSNYN4m4W2v9ONT147PxBY/XrRhrWq8TlvObyUjQ==
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.3.tgz#9123fb6b9cad30f0651332dc77deba48ef9b0b3f"
+  integrity sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==
   dependencies:
-    browserslist "^4.16.0"
+    browserslist "^4.16.1"
     semver "7.0.0"
 
 core-js-pure@^3.0.0, core-js-pure@^3.0.1:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.2.tgz#286f885c0dac1cdcd6d78397392abc25ddeca225"
-  integrity sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.3.tgz#10e9e3b2592ecaede4283e8f3ad7020811587c02"
+  integrity sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -5412,9 +5412,9 @@ core-js@^1.0.0:
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^3.0.1, core-js@^3.0.4, core-js@^3.2.1:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.2.tgz#0a1fd6709246da9ca8eff5bb0cbd15fba9ac7044"
-  integrity sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"
+  integrity sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -6362,9 +6362,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.634:
-  version "1.3.639"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz#0a27e3018ae3acf438a14a1dd4e41db4b8ab764e"
-  integrity sha512-bwl6/U6xb3d3CNufQU9QeO1L32ueouFwW4bWANSwdXR7LVqyLzWjNbynoKNfuC38QFB5Qn7O0l2KLqBkcXnC3Q==
+  version "1.3.642"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.642.tgz#8b884f50296c2ae2a9997f024d0e3e57facc2b94"
+  integrity sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -6507,23 +6507,25 @@ es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
-es-abstract@^1.18.0-next.1:
-  version "1.18.0-next.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
-  integrity sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
+  version "1.18.0-next.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.2.tgz#088101a55f0541f595e7e057199e27ddc8f3a5c2"
+  integrity sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
   dependencies:
+    call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
     has "^1.0.3"
     has-symbols "^1.0.1"
     is-callable "^1.2.2"
-    is-negative-zero "^2.0.0"
+    is-negative-zero "^2.0.1"
     is-regex "^1.1.1"
-    object-inspect "^1.8.0"
+    object-inspect "^1.9.0"
     object-keys "^1.1.1"
-    object.assign "^4.1.1"
-    string.prototype.trimend "^1.0.1"
-    string.prototype.trimstart "^1.0.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.3"
+    string.prototype.trimstart "^1.0.3"
 
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
@@ -7128,9 +7130,9 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     micromatch "^3.1.10"
 
 fast-glob@^3.0.3:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
-  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -7874,8 +7876,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.16.2"
-  uid d3dd01804e45dc3690a02d61be8bc2c871707353
-  resolved "https://github.com/grommet/grommet/tarball/stable#d3dd01804e45dc3690a02d61be8bc2c871707353"
+  uid "770d5f50ef314631ba4b75eea0f24f0579ee32df"
+  resolved "https://github.com/grommet/grommet/tarball/stable#770d5f50ef314631ba4b75eea0f24f0579ee32df"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"
@@ -8321,9 +8323,9 @@ humanize-ms@^1.2.1:
     ms "^2.0.0"
 
 husky@^4.2.3:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.7.tgz#ca47bbe6213c1aa8b16bbd504530d9600de91e88"
-  integrity sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
+  integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
   dependencies:
     chalk "^4.0.0"
     ci-info "^2.0.0"
@@ -8846,7 +8848,7 @@ is-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
-is-negative-zero@^2.0.0:
+is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
@@ -9102,7 +9104,7 @@ iterate-iterator@^1.0.1:
   resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
   integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
 
-iterate-value@^1.0.0:
+iterate-value@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
   integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
@@ -10244,9 +10246,9 @@ mime@1.6.0, mime@^1.3.4:
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.4.4:
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.7.tgz#962aed9be0ed19c91fd7dc2ece5d7f4e89a90d74"
-  integrity sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.0.tgz#2b4af934401779806ee98026bb42e8c1ae1876b1"
+  integrity sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==
 
 mime@~1.4.1:
   version "1.4.1"
@@ -10742,9 +10744,9 @@ node-notifier@^6.0.0:
     which "^1.3.1"
 
 node-releases@^1.1.29, node-releases@^1.1.58, node-releases@^1.1.69:
-  version "1.1.69"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.69.tgz#3149dbde53b781610cd8b486d62d86e26c3725f6"
-  integrity sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
+  version "1.1.70"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
+  integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
 
 node-version@^1.0.0:
   version "1.2.0"
@@ -11261,9 +11263,9 @@ parse-json@^4.0.0:
     json-parse-better-errors "^1.0.1"
 
 parse-json@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"
-  integrity sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     error-ex "^1.3.1"
@@ -11800,15 +11802,15 @@ promise-inflight@^1.0.1:
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
 promise.allsettled@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.2.tgz#d66f78fbb600e83e863d893e98b3d4376a9c47c9"
-  integrity sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.3.tgz#f127931bf0acfe644419586b1af557fe733e32a0"
+  integrity sha512-ptvtUnD20Ipx4+qskEo89Qt64AVhnvotQuHQoCuszXaleNPnkFjmJYWQbrutEiZVIX80Ix8JcrVloq7POgx65g==
   dependencies:
-    array.prototype.map "^1.0.1"
+    array.prototype.map "^1.0.3"
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    iterate-value "^1.0.0"
+    es-abstract "^1.18.0-next.2"
+    iterate-value "^1.0.2"
 
 promise.prototype.finally@^3.1.0:
   version "3.1.2"
@@ -12378,12 +12380,12 @@ regex-parser@2.2.10:
   integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
 
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
-  integrity sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -13642,7 +13644,7 @@ string.prototype.padstart@^3.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
 
-string.prototype.trimend@^1.0.1:
+string.prototype.trimend@^1.0.1, string.prototype.trimend@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
   integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
@@ -13650,7 +13652,7 @@ string.prototype.trimend@^1.0.1:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
 
-string.prototype.trimstart@^1.0.1:
+string.prototype.trimstart@^1.0.1, string.prototype.trimstart@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
   integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
@@ -14782,14 +14784,14 @@ url@^0.11.0:
     querystring "0.2.0"
 
 use-callback-ref@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
-  integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
+  integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
 use-sidecar@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.3.tgz#17a4e567d4830c0c0ee100040e85a7fe68611e0f"
-  integrity sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.4.tgz#38398c3723727f9f924bed2343dfa3db6aaaee46"
+  integrity sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==
   dependencies:
     detect-node-es "^1.0.0"
     tslib "^1.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,10 +66,10 @@
   resolved "https://registry.yarnpkg.com/@applitools/dom-shared/-/dom-shared-1.0.5.tgz#d67d9bd8c2c612da6dd9dcdea2b08f9630b22a3a"
   integrity sha512-O2zgnnqVi3/Atq7EQjURLa73XNaDFJCj8wHht6WQtxIv1EWYnPutNTmnJSKwK7FnbJAg65OVjZylcz4EezyYZA==
 
-"@applitools/dom-snapshot@4.4.4":
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.4.4.tgz#4c070e6950a4ac90d86a25018d404c424b947ff1"
-  integrity sha512-+jVafDV+z/bkjJbLxFbqOisdJXufPY5PWr/9k//0Q6aPSwCoGM8tEex2SmxFj92eQG32le0o2ck4Wj0yLvgV/w==
+"@applitools/dom-snapshot@4.4.7":
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.4.7.tgz#fc297b8554465773200e46f3dd65492071f534d4"
+  integrity sha512-HM1xB4ZLi0mBg4WFrOiXLzXYrXar3NasZ3nkhMXT5G6N3eVL6zSIBgv4e7jlNBj8TRIzfE6PsH2E/W78kA2wLg==
   dependencies:
     "@applitools/dom-shared" "1.0.5"
     "@applitools/functional-commons" "1.6.0"
@@ -84,13 +84,13 @@
     "@applitools/snippets" "2.1.0"
     "@applitools/utils" "1.0.0"
 
-"@applitools/eyes-sdk-core@12.12.1":
-  version "12.12.1"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes-sdk-core/-/eyes-sdk-core-12.12.1.tgz#89509022245f02cd18e905469ad90adc0b7611de"
-  integrity sha512-NxDaPQo4MZ1TwhQ3vwMOvGZkV12QRMByHeaP6ZwF2JdkWSVLr1rkJhzkZRyQ6geLlD/kWccB8Ubed+UvXNU3vA==
+"@applitools/eyes-sdk-core@12.13.0":
+  version "12.13.0"
+  resolved "https://registry.yarnpkg.com/@applitools/eyes-sdk-core/-/eyes-sdk-core-12.13.0.tgz#d785d6e3e891e0f54dfcf963328a50163f8074e3"
+  integrity sha512-p/BstvD9iPCLbP7B51SlJL1quafWUakvS3FLye2h4hpIQOHbrJuiFe/ZtSmNwKP9pyYPJgW3Qa3om6+5MrkHtQ==
   dependencies:
     "@applitools/dom-capture" "11.0.0"
-    "@applitools/dom-snapshot" "4.4.4"
+    "@applitools/dom-snapshot" "4.4.7"
     "@applitools/driver" "1.0.2"
     "@applitools/isomorphic-fetch" "3.0.0"
     "@applitools/screenshoter" "2.0.0"
@@ -105,13 +105,13 @@
     stack-trace "0.0.10"
     tunnel "0.0.6"
 
-"@applitools/eyes-testcafe@1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes-testcafe/-/eyes-testcafe-1.12.1.tgz#d0fc0cd67797c801e47c99fe5004809bbc2e7b1d"
-  integrity sha512-VdXFOMDeapCHwB1v0oLi3QAEdsdnAcIT7LaJ3H87MLOv39LloKRvyy+n4vXjbte6jCYyjoDadxrLJFcI9TLECQ==
+"@applitools/eyes-testcafe@^1.12.3":
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/@applitools/eyes-testcafe/-/eyes-testcafe-1.12.3.tgz#a6dd51ef1e3642803dc47a1305db52a544a9fb57"
+  integrity sha512-5En99mzq5cLeNbG8UrSKpZ5WXHVxkM0iuzOnDGXYc3P+0vWcG/bxfECEidelWnob/W/unGxX0GPs7pLqhhS8KQ==
   dependencies:
-    "@applitools/eyes-sdk-core" "12.12.1"
-    "@applitools/visual-grid-client" "15.5.4"
+    "@applitools/eyes-sdk-core" "12.13.0"
+    "@applitools/visual-grid-client" "15.5.6"
     rimraf "3.0.2"
 
 "@applitools/functional-commons@1.6.0", "@applitools/functional-commons@^1.5.5":
@@ -196,12 +196,12 @@
   resolved "https://registry.yarnpkg.com/@applitools/utils/-/utils-1.0.0.tgz#ecf845148f6e2c952b97462f11b0d702cce6cb40"
   integrity sha512-jf3DDLSRLYsTYK6/PiriVC5mejemVzHFFSFGTirKRnUg2121xyhpA/SQcx0UUoDLLEYZGNlfqiTpBSE9Gr/UMQ==
 
-"@applitools/visual-grid-client@15.5.4":
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/@applitools/visual-grid-client/-/visual-grid-client-15.5.4.tgz#2f373312a4c360ce0ddef1f5adff237dd6995e7c"
-  integrity sha512-vUBBRR+WPLHca/JzqRzEybl67KJMzX2F1Se5fqfccWOEFGaIP7d3bprO1YuefEqoYE0mWs834theXVl/mutOVA==
+"@applitools/visual-grid-client@15.5.6":
+  version "15.5.6"
+  resolved "https://registry.yarnpkg.com/@applitools/visual-grid-client/-/visual-grid-client-15.5.6.tgz#72bf55516ba1d8f3f5335c387f93250ba70598eb"
+  integrity sha512-D/LNHvdwZv0VJ8UFpMggOCdJCL83LPM451RtI/lSOLSwqOMN76yCrorVwvMJDzl6mLglaE8GFjGrs9HjOD0bNQ==
   dependencies:
-    "@applitools/eyes-sdk-core" "12.12.1"
+    "@applitools/eyes-sdk-core" "12.13.0"
     "@applitools/functional-commons" "1.6.0"
     "@applitools/http-commons" "2.4.3"
     "@applitools/isomorphic-fetch" "3.0.0"
@@ -2893,14 +2893,14 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.14.20"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
-  integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
+  version "14.14.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
+  integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
 
 "@types/node@^10.12.19":
-  version "10.17.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.50.tgz#7a20902af591282aa9176baefc37d4372131c32d"
-  integrity sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==
+  version "10.17.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.51.tgz#639538575befbcf3d3861f95c41de8e47124d674"
+  integrity sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -7858,6 +7858,7 @@ graphlib@^2.1.5:
 
 grommet-icons@^4.5.0, "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
   version "4.5.0"
+  uid "960fdf0ab63e335403ec9b6f214da5864f48b592"
   resolved "https://github.com/grommet/grommet-icons/tarball/stable#960fdf0ab63e335403ec9b6f214da5864f48b592"
   dependencies:
     grommet-styles "^0.2.0"
@@ -7873,7 +7874,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.16.2"
-  resolved "https://github.com/grommet/grommet/tarball/stable#9a30ecd09f4c606d5b4137478cef03ec8ff55c92"
+  uid d3dd01804e45dc3690a02d61be8bc2c871707353
+  resolved "https://github.com/grommet/grommet/tarball/stable#d3dd01804e45dc3690a02d61be8bc2c871707353"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,11 +2830,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/history@*":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -2938,11 +2933,10 @@
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
 "@types/reach__router@^1.2.3":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.6.tgz#413417ce74caab331c70ce6a03a4c825188e4709"
-  integrity sha512-RHYataCUPQnt+GHoASyRLq6wmZ0n8jWlBW8Lxcwd30NN6vQfbmTeoSDfkgxO0S1lEzArp8OFDsq5KIs7FygjtA==
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.7.tgz#de8ab374259ae7f7499fc1373b9697a5f3cd6428"
+  integrity sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==
   dependencies:
-    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.4":
@@ -4821,9 +4815,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001173:
-  version "1.0.30001178"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz#3ad813b2b2c7d585b0be0a2440e1e233c6eabdbc"
-  integrity sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==
+  version "1.0.30001179"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
+  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7876,8 +7870,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.16.2"
-  uid "770d5f50ef314631ba4b75eea0f24f0579ee32df"
-  resolved "https://github.com/grommet/grommet/tarball/stable#770d5f50ef314631ba4b75eea0f24f0579ee32df"
+  uid "0ea8bca6050046749a68800e9790563bd3fee6de"
+  resolved "https://github.com/grommet/grommet/tarball/stable#0ea8bca6050046749a68800e9790563bd3fee6de"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"
@@ -11802,14 +11796,15 @@ promise-inflight@^1.0.1:
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
 promise.allsettled@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.3.tgz#f127931bf0acfe644419586b1af557fe733e32a0"
-  integrity sha512-ptvtUnD20Ipx4+qskEo89Qt64AVhnvotQuHQoCuszXaleNPnkFjmJYWQbrutEiZVIX80Ix8JcrVloq7POgx65g==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.4.tgz#65e71f2a604082ed69c548b68603294090ee6803"
+  integrity sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==
   dependencies:
     array.prototype.map "^1.0.3"
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
+    get-intrinsic "^1.0.2"
     iterate-value "^1.0.2"
 
 promise.prototype.finally@^3.1.0:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

[Preview](https://deploy-preview-1360--keen-mayer-a86c8b.netlify.app/foundation/background-colors-guidance)

#### What does this PR do?
Adds in new exampe of Cards in Basic layout where `background` is used as the background color. Elevation provides a way to differentiate Card boundary.

Adds in new guidance around header background color in Layered Layouts. The guidance is that if a header is fixed, the header should use `background-front` since it is layered in front of the content. If the header scrolls with the page content (like the design system site), it should use `background-back` like the rest of the content.

#### Where should the reviewer start?
aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js

#### What testing has been done on this PR?
Tested locally.

#### How should this be manually tested?
Check deploy.

#### Any background context you want to provide?
Related to this thread: https://grommet.slack.com/archives/C04LMJWQT/p1610636492000700?thread_ts=1610579439.277200&cid=C04LMJWQT

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
Yes. Respond in thread linked above.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.