### PR TITLE
fix example to match figma

### DIFF
--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -52,7 +52,9 @@ export const LayerCenterExample = () => {
               background="background-contrast"
             >
               <Alert color="status-critical" />
-              <Text weight="bold">Footer if you need it</Text>
+              <Text color="text-strong" weight="bold">
+                Footer if you need it
+              </Text>
             </Box>
           </Box>
         </Layer>

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
-import { Button, Box, Heading, Layer, ResponsiveContext, Text } from 'grommet';
-import { Alert, MailOption } from 'grommet-icons';
+import { Button, Box, Layer, ResponsiveContext, Text } from 'grommet';
+import { Alert, MailOption, Close } from 'grommet-icons';
 
 export const LayerCenterExample = () => {
   const [open, setOpen] = useState(false);
@@ -18,27 +18,36 @@ export const LayerCenterExample = () => {
             fill="vertical"
             overflow="auto"
             width={size !== 'small' ? 'medium' : undefined}
+            pad="medium"
           >
-            <Box
-              flex="grow"
-              direction="row"
-              gap="medium"
-              pad="medium"
-              height="small"
-            >
-              <Box pad={{ top: 'xsmall' }}>
-                <MailOption />
-              </Box>
-              <Box gap="medium">
-                <Heading margin="none" size="small">
+            <Box justify="between" direction="row">
+              <Box flex={false} gap="small" direction="row">
+                <Box justify="center">
+                  <MailOption />
+                </Box>
+                <Text margin="none" size="xlarge">
                   Modal Dialog
-                </Heading>
-                <Text>
-                  For modal dialogs, the use case will determine the design and
-                  size of the box for your content
                 </Text>
               </Box>
+              <Box justify="center">
+                <Button
+                  icon={<Close size="small" align="center" />}
+                  onClick={onClose}
+                />
+              </Box>
             </Box>
+            <Box overflow="auto" pad={{ vertical: 'medium' }}>
+              <Text>
+                For modal dialogs, the use case will determine the design and
+                size of the box for your content
+              </Text>
+            </Box>
+          </Box>
+          <Box
+            fill="vertical"
+            overflow="auto"
+            width={size !== 'small' ? 'medium' : undefined}
+          >
             <Box
               direction="row"
               gap="small"

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { Button, Box, Layer, ResponsiveContext, Text } from 'grommet';
-import { Alert, MailOption, Close } from 'grommet-icons';
+import { Alert, MailOption, FormClose } from 'grommet-icons';
 
 export const LayerCenterExample = () => {
   const [open, setOpen] = useState(false);
@@ -30,10 +30,7 @@ export const LayerCenterExample = () => {
                 </Text>
               </Box>
               <Box justify="center">
-                <Button
-                  icon={<Close size="small" align="center" />}
-                  onClick={onClose}
-                />
+                <Button icon={<FormClose />} onClick={onClose} />
               </Box>
             </Box>
             <Box overflow="auto" pad={{ vertical: 'medium' }}>
@@ -51,7 +48,7 @@ export const LayerCenterExample = () => {
             <Box
               direction="row"
               gap="small"
-              pad="medium"
+              pad={{ vertical: 'small', horizontal: 'medium' }}
               background="background-contrast"
             >
               <Alert color="status-critical" />

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Button, Box, Layer, ResponsiveContext, Text } from 'grommet';
+import { Button, Box, Layer, Heading, ResponsiveContext, Text } from 'grommet';
 import { Alert, MailOption, FormClose } from 'grommet-icons';
 
 export const LayerCenterExample = () => {
@@ -25,9 +25,9 @@ export const LayerCenterExample = () => {
                 <Box justify="center">
                   <MailOption />
                 </Box>
-                <Text margin="none" size="xlarge">
+                <Heading margin="none" level={3} size="small">
                   Modal Dialog
-                </Text>
+                </Heading>
               </Box>
               <Box justify="center">
                 <Button icon={<FormClose />} onClick={onClose} />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR aligns the center layer example with the figma file
There were 3 key things missing. 
I will need to get the updated icon this is not yet in Grommet Icons

- [X] Add "x" close button in the upper right have corner
- [X] Left aligned text

#### Where should the reviewer start?
LayerCenterExample
#### What testing has been done on this PR?

#### How should this be manually tested?
https://www.figma.com/file/Ts53TAipMolmsv9DxWG3p0/HPE-Layer-Component?node-id=100%3A70
The example should match the figma fle
#### Any background context you want to provide?

#### What are the relevant issues?
Issue #1426
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
yes