### PR TITLE
Add X-Frame-Options and CSP rule

### DIFF
--- a/aries-site/next.config.js
+++ b/aries-site/next.config.js
@@ -4,17 +4,36 @@ const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
 });
 
-module.exports = withPlugins([
+const config = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)?',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = withPlugins(
   [
-    withTM,
-    {
-      transpileModules: ['aries-core'],
-    },
+    [
+      withTM,
+      {
+        transpileModules: ['aries-core'],
+      },
+    ],
+    [
+      withMDX,
+      {
+        pageExtensions: ['js', 'jsx', 'md', 'mdx'],
+      },
+    ],
   ],
-  [
-    withMDX,
-    {
-      pageExtensions: ['js', 'jsx', 'md', 'mdx'],
-    },
-  ],
-]);
+  config,
+);

--- a/aries-site/src/components/seo/Meta.js
+++ b/aries-site/src/components/seo/Meta.js
@@ -89,6 +89,17 @@ export const Meta = ({ title, description, canonicalUrl, socialImageUrl }) => {
       <meta key="segment" name="segment" content={segment} />
       <meta key="lifecycle" name="lifecycle" content={lifecycle} />
       <meta key="page_content" name="page_content" content={pageContent} />
+      <meta
+        httpEquiv="Content-Security-Policy"
+        content="default-src 'self' 'unsafe-eval'; 
+        style-src 'self' *.hpe.com/hfws-static/slim/css/ 'unsafe-inline';
+        connect-src 'self' *.githubusercontent.com/grommet/hpe-design-system/ https://www.google-analytics.com https://www.github.com https://eyes.applitools.com;
+        media-src 'self' https://d3hq6blov2iije.cloudfront.net/media/HPE+Design+System-v3.mp4;
+        img-src 'self' https://www.google-analytics.com;
+        script-src-elem 'self' *.hpe.com https://www.google-analytics.com/analytics.js;
+        font-src *.hpe.com hpefonts.s3.amazonaws.com *.cloudfront.net/fonts/;
+        object-src 'none';"
+      />
     </Head>
   );
 };


### PR DESCRIPTION
#### What does this PR do?
Mirroring what was done in https://github.com/grommet/hpe-design-system/pull/1482
From issue #1466:
> Results from OWASP ZAP scan identified potential for "Clickjacking" because of lack of X-Frame-Options header in the HTTP response.

I added the following rule to the next.config.js file:
```javascript
source: '/(.*)?',
        headers: [
          {
            key: 'X-Frame-Options',
            value: 'SAMEORIGIN',
          }
        ]
```
This allows the page to only be displayed in a frame on the same origin as the page itself to prevent clickjacking attacks.

I also added the following CSP rule which tells the browser what domains are allowed:
```javascript
<meta httpEquiv="Content-Security-Policy" content="default-src 'self' 'unsafe-eval'; 
        style-src 'self' *.hpe.com/hfws-static/slim/css/ 'unsafe-inline';
        connect-src 'self' *.githubusercontent.com/grommet/hpe-design-system/ https://www.google-analytics.com;
        media-src 'self' https://d3hq6blov2iije.cloudfront.net/media/HPE+Design+System-v3.mp4;
        img-src 'self' https://www.google-analytics.com;
        script-src-elem 'self' *.hpe.com https://www.google-analytics.com/analytics.js;
        font-src *.hpe.com hpefonts.s3.amazonaws.com *.cloudfront.net/fonts/;
        object-src 'none';"></meta>
```
Notes:
**‘unsafe-eval’**
That is used in the `<meta>` above, allows the use of eval() and similar methods for creating code from strings. It needed to be added in default-src because webpack uses eval().
eval() can potentially be unsafe because it executes the code it is passed with the privileges of the caller. ‘unsafe-eval’ is only allowed on 'self' (only same origin, no external sources).
Without ‘unsafe-eval’ the following errors occur:
![image](https://user-images.githubusercontent.com/54560994/110704803-b671b880-81b2-11eb-99c5-74a3e5aa8db4.png)

**‘unsafe-inline’**
allows the use of inline resources, such as inline <script> elements, javascript: URLs, inline event handlers, and inline <style> elements.
This can be unsafe because it creates the potential for code to be injected into inline tags. ‘unsafe-inline’ is only allowed on the following: 'self' and *.hpe.com/hfws-static/slim/css/
Example error when ‘unsafe-inline’ is not included:
![image](https://user-images.githubusercontent.com/54560994/110704878-d0ab9680-81b2-11eb-9ca9-cd49797ce04e.png)

More info about clickjacking, CSP, and X-Frame-Options: https://owasp.org/www-community/attacks/Clickjacking

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested CSP with https://csp-evaluator.withgoogle.com/
Tested in browser and tested with testcafe

#### How should this be manually tested?
Using any of the methods above, and checking that no additional resources are required that aren't included in the CSP rule

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #1466

#### Screenshots (if appropriate)
<img width="398" alt="Screen Shot 2021-03-12 at 12 21 08 PM" src="https://user-images.githubusercontent.com/54560994/111193034-5ba7da80-857f-11eb-8bf2-22a984410f66.png">

#### Should this PR be mentioned in Design System updates?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
