### PR TITLE
Adjust Github actions to accomodate forked repo

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -25,7 +25,14 @@ jobs:
         working-directory: aries-site
       # Tests are only run on headless Chrome
       - name: Build and run e2e tests on Chrome
+        if: ${{ github.repository == 'grommet/hpe-design-system' }}
         run: yarn test:ci
+        working-directory: aries-site
+      # Forked repo does not have access to APPLITOOLS_API_KEY
+      # Just run e2e tests but not snapshots
+      - name: Build and run e2e tests on Chrome, forked repo
+        if: ${{ github.repository != 'grommet/hpe-design-system' }}
+        run: yarn test:fork
         working-directory: aries-site
 
   batch-completion-notification:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -37,7 +37,7 @@ jobs:
 
   batch-completion-notification:
     needs: build-and-test
-    if: always()
+    if: ${{ github.repository == 'grommet/hpe-design-system' }}
     runs-on: ubuntu-latest
     steps:
       - name: Update Applitools batch status

--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -27,6 +27,7 @@
     "start-server": "yarn build && yarn next start -p 3030",
     "test": "yarn build && node src/scripts/start-tests.js",
     "test:local": "start-server-and-test start-server 3030 'testcafe all'",
+    "test:fork": "start-server-and-test start-server 3030 'testcafe chrome:headless'",
     "test:ci": "start-server-and-test start-server 3030 'testcafe chrome:headless src/tests/'",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

For public repositories, if a forked repo files a PR, the fork will not have access to any github secrets. In our checks, we rely on an API Key held in github secrets to run the snapshot tests. For security reasons, it's not recommended that these keys are passed to forked repos.

However, for teams that are aiming to file copy edits, we still would like the rest of the e2e tests to run. To do so, we create a separate script `test:fork` that will run the e2e tests (but not snapshot tests) on headless chrome. An update is made to the `testcafe.yml` file to check if a repo is forked or not.

#### Where should the reviewer start?
.github/workflows/testcafe.yml

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.