### PR TITLE
Fix forward ref console warning

### DIFF
--- a/aries-core/package.json
+++ b/aries-core/package.json
@@ -12,7 +12,7 @@
   "peerDependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "styled-components": "5.2.1"
+    "styled-components": "^5.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",
@@ -33,7 +33,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "simple-git": "^1.126.0",
-    "styled-components": "5.2.1",
+    "styled-components": "^5.2.3",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.1.14"

--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -17,7 +17,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-ga": "^2.7.0",
-    "styled-components": "5.2.1"
+    "styled-components": "^5.2.3"
   },
   "scripts": {
     "build": "next build",

--- a/aries-site/src/components/cards/ContentPreviewCard.js
+++ b/aries-site/src/components/cards/ContentPreviewCard.js
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { StyledCard } from './ContentCard';
 
-export const ContentPreviewCard = ({ ...rest }) => {
+export const ContentPreviewCard = forwardRef(({ ...rest }, ref) => {
   const [isFocused, setIsFocused] = useState(false);
   return (
     <StyledCard
@@ -15,7 +15,8 @@ export const ContentPreviewCard = ({ ...rest }) => {
       onMouseOver={() => setIsFocused(true)}
       pad="large"
       round="small"
+      ref={ref}
       {...rest}
     />
   );
-};
+});

--- a/aries-site/src/components/home/Featured.js
+++ b/aries-site/src/components/home/Featured.js
@@ -30,6 +30,7 @@ const FeaturedLayout = ({ ...rest }) => {
               forwardedAs="a"
               style={{ textDecoration: 'none' }}
               pad="medium"
+              href={url || nameToPath(name)}
             >
               <Box width="100%" round="xsmall">
                 {icon}
@@ -52,8 +53,8 @@ const FeaturedLayout = ({ ...rest }) => {
 };
 
 export const Featured = ({ ...rest }) => (
-    <Stack guidingChild="last">
-      <Box background="background-front" margin={{ top: 'xlarge' }} fill />
-      <FeaturedLayout {...rest} />
-    </Stack>
-  );
+  <Stack guidingChild="last">
+    <Box background="background-front" margin={{ top: 'xlarge' }} fill />
+    <FeaturedLayout {...rest} />
+  </Stack>
+);

--- a/aries-site/src/components/home/Featured.js
+++ b/aries-site/src/components/home/Featured.js
@@ -30,7 +30,6 @@ const FeaturedLayout = ({ ...rest }) => {
               forwardedAs="a"
               style={{ textDecoration: 'none' }}
               pad="medium"
-              href={url || nameToPath(name)}
             >
               <Box width="100%" round="xsmall">
                 {icon}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3438,9 +3438,9 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.2.tgz#1396e27f208ed56dd5638ab5a251edeb1c91d402"
-  integrity sha512-V0HGxJd0PiDF0ecHYIesTOqfd1gJguwQUOYfMfAWnRsWQEXfc5ifbUFhD3Wjc+O+y7VAqL+g07prq9gHQ/JOZQ==
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.3.tgz#81f1b07003b329f000b7912e59a24f52392867b6"
+  integrity sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4212,7 +4212,7 @@ babel-plugin-react-docgen@^4.0.0:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.6:
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^1.10.6:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
   integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
@@ -5150,10 +5150,15 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6, classnames@^2.2.5:
+classnames@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+classnames@^2.2.5:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.0.tgz#19524334bad47ccd99793936b67f9be0860fe835"
+  integrity sha512-UUf/S3eeczXBjHPpSnrZ1ZyxH3KmLW8nVYFUWIZA/dixYMIQr7l94yYKxaAkmPk7HO9dlT6gFqAPZC02tTdfQw==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -11914,9 +11919,9 @@ promisify-event@^1.0.0:
     pinkie-promise "^2.0.0"
 
 prompts@^2.0.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
-  integrity sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
+  integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
@@ -13813,17 +13818,17 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.1.tgz#6ed7fad2dc233825f64c719ffbdedd84ad79101a"
-  integrity sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==
+styled-components@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.3.tgz#752669fd694aac10de814d96efc287dde0d11385"
+  integrity sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"
     "@emotion/is-prop-valid" "^0.8.8"
     "@emotion/stylis" "^0.8.4"
     "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1"
+    babel-plugin-styled-components ">= 1.12.0"
     css-to-react-native "^3.0.0"
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"
@@ -14124,9 +14129,9 @@ testcafe-hammerhead@19.5.0:
     webauth "^1.1.0"
 
 testcafe-hammerhead@>=19.4.0:
-  version "20.2.0"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-20.2.0.tgz#5d8a66faa42c91d7e72c7fa323add30ef6090a2f"
-  integrity sha512-GtjD3uhxD+d69+DtYOH9GuiKfYE9d7g8oZ1OMKNefY+SKOE6cDgoKEQxkBY9jnUeHPrRoNn//6WtDmGdhQxWUg==
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-21.0.0.tgz#0466d637ecd057e33e5d0ad7a83eebe93d0407c3"
+  integrity sha512-ctIM2nF93Xgm4jHGbwMtSD1aRJu5d62+jy6T0LrjZcT/312PPWU4a1X2leE4ID9fxDOK+KxAMRuptkZTcR7GUQ==
   dependencies:
     acorn-hammerhead "0.4.0"
     asar "^2.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes console warning resulting from Nextjs Links wrapping `<ContentPreviewCards />`

![Screen Shot 2021-04-01 at 9 26 18 AM](https://user-images.githubusercontent.com/1756948/113318140-637cb400-92cd-11eb-91b1-841e0b13ddc1.png)

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible
