### PR TITLE
Update how wizard width is determined

### DIFF
--- a/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -64,7 +64,6 @@ const StepOne = () => {
       direction={size !== 'small' ? 'row' : 'column-reverse'}
       margin={{ bottom: 'medium' }}
       gap={size === 'small' ? 'small' : undefined}
-      width={{ max: 'large' }}
       justify="between"
       wrap
     >
@@ -74,8 +73,8 @@ const StepOne = () => {
         gap="medium"
         flex={false}
       >
-        <>
-          <Box>
+        <Box gap="medium">
+          <>
             <FormField
               label="Email"
               htmlFor="twocolumn-textinput"
@@ -103,13 +102,13 @@ const StepOne = () => {
                 options={['Radio button 1', 'Radio button 2']}
               />
             </FormField>
-          </Box>
+          </>
           {!error.isValid && (
             <Error>There is an error with one or more inputs.</Error>
           )}
-        </>
+        </Box>
       </Box>
-      <Box flex width={{ max: 'xsmall' }} />
+      <Box flex width={{ max: 'xxsmall' }} />
       <Guidance />
     </Box>
   );
@@ -241,8 +240,8 @@ export const TwoColumnWizardExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
-  const countColumns = 2;
-  const width = getWidth(countColumns, theme, size);
+  const numberColumns = 2;
+  const width = getWidth(numberColumns, theme, size);
   return (
     <WizardContext.Provider
       value={{
@@ -285,7 +284,7 @@ const Guidance = () => {
       pad="medium"
       round="small"
       flex
-      width={size !== 'small' ? { max: 'medium' } : '100%'}
+      width={size !== 'small' ? { min: 'small', max: 'medium' } : '100%'}
     >
       <Text color="text-strong" size="large">
         When guidance is required for the form or content of the wizard, you

--- a/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -240,8 +240,7 @@ export const TwoColumnWizardExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
-  const numberColumns = 2;
-  const width = getWidth(numberColumns, theme, size);
+  const width = getWidth(numberColumns = 2, theme, size);
   return (
     <WizardContext.Provider
       value={{

--- a/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -240,7 +240,8 @@ export const TwoColumnWizardExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
-  const width = getWidth(numberColumns = 2, theme, size);
+  const numberColumns = 2;
+  const width = getWidth(numberColumns, theme, size);
   return (
     <WizardContext.Provider
       value={{

--- a/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
+import { ThemeContext } from 'styled-components';
 import {
   Box,
   CheckBoxGroup,
@@ -20,6 +21,7 @@ import {
   StepContent,
   StepFooter,
 } from './components';
+import { getWidth } from './utils';
 
 const defaultFormValues = {
   'twocolumn-textinput': '',
@@ -162,22 +164,22 @@ const data = [
 ];
 
 const StepThree = () => (
-    <Box gap="small">
-      <List data={data} pad={{ horizontal: 'none', vertical: 'small' }}>
-        {(datum, index) => (
-          <Box key={index} direction="row" gap="small" align="center">
-            <Checkmark color="text-strong" size="small" />
-            <Text color="text-strong" weight={500}>
-              {datum}
-            </Text>
-          </Box>
-        )}
-      </List>
-      <Text color="text-strong">
-        Include guidance to what will occur when “Finish Wizard" is clicked.
-      </Text>
-    </Box>
-  );
+  <Box gap="small">
+    <List data={data} pad={{ horizontal: 'none', vertical: 'small' }}>
+      {(datum, index) => (
+        <Box key={index} direction="row" gap="small" align="center">
+          <Checkmark color="text-strong" size="small" />
+          <Text color="text-strong" weight={500}>
+            {datum}
+          </Text>
+        </Box>
+      )}
+    </List>
+    <Text color="text-strong">
+      Include guidance to what will occur when “Finish Wizard" is clicked.
+    </Text>
+  </Box>
+);
 
 const steps = [
   {
@@ -198,6 +200,8 @@ const steps = [
 ];
 
 export const TwoColumnWizardExample = () => {
+  const size = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
   const [activeIndex, setActiveIndex] = useState(0);
   // for readability, this is used to display numeric value of step on screen,
   // such as step 1 of 3. it will always be one more than the active array index
@@ -237,6 +241,8 @@ export const TwoColumnWizardExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
+  const countColumns = 2;
+  const width = getWidth(countColumns, theme, size);
   return (
     <WizardContext.Provider
       value={{
@@ -256,6 +262,7 @@ export const TwoColumnWizardExample = () => {
         steps,
         validation,
         wizardTitle: 'Wizard Title',
+        width,
       }}
     >
       <Box fill>
@@ -278,7 +285,7 @@ const Guidance = () => {
       pad="medium"
       round="small"
       flex
-      width={size !== 'small' ? { min: 'small' } : '100%'}
+      width={size !== 'small' ? { max: 'medium' } : '100%'}
     >
       <Text color="text-strong" size="large">
         When guidance is required for the form or content of the wizard, you

--- a/aries-site/src/examples/templates/wizard/WizardValidationExample.js
+++ b/aries-site/src/examples/templates/wizard/WizardValidationExample.js
@@ -268,7 +268,8 @@ export const WizardValidationExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
-  const width = getWidth(numberColumns = 2, theme, size);
+  const numberColumns = 2;
+  const width = getWidth(numberColumns, theme, size);
   return (
     <WizardContext.Provider
       value={{

--- a/aries-site/src/examples/templates/wizard/WizardValidationExample.js
+++ b/aries-site/src/examples/templates/wizard/WizardValidationExample.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
+import { ThemeContext } from 'styled-components';
 import {
   Box,
   CheckBoxGroup,
@@ -21,6 +22,7 @@ import {
   WizardContext,
   WizardHeader,
 } from './components';
+import { getWidth } from './utils';
 
 export const defaultFormValues = {
   'text-input-validation': '',
@@ -57,7 +59,7 @@ const validation = [
 
 const stepOneInputs = [
   (attemptedAdvance, error, formValues, setError) => (
-    <Box>
+    <Box width={{ max: 'medium' }}>
       <FormField
         label="First Name"
         htmlFor="firstname-validation"
@@ -107,7 +109,7 @@ const stepOneInputs = [
     </Box>
   ),
   (attemptedAdvance, error) => (
-    <>
+    <Box width={{ max: 'medium' }}>
       <FormField
         htmlFor="radio-button-group-validation"
         label="RadioButtonGroup"
@@ -122,7 +124,7 @@ const stepOneInputs = [
       {!error.isValid && (
         <Error>There is an error with one or more inputs.</Error>
       )}
-    </>
+    </Box>
   ),
 ];
 
@@ -131,12 +133,12 @@ const StepOne = () => {
     WizardContext,
   );
   const size = useContext(ResponsiveContext);
-  console.log(error.isValid);
+
   return (
     <>
       <Box margin={{ bottom: 'medium' }}>
         <Grid
-          columns={size !== 'small' ? { count: 2, size: 'auto' } : '100%'}
+          columns={size !== 'small' ? { count: 'fit', size: 'medium' } : '100%'}
           rows={[['auto', 'full']]}
           gap={size !== 'small' ? 'large' : undefined}
           fill
@@ -191,22 +193,22 @@ const data = [
 ];
 
 const StepThree = () => (
-    <Box gap="small">
-      <List data={data} pad={{ horizontal: 'none', vertical: 'small' }}>
-        {(datum, index) => (
-          <Box key={index} direction="row" gap="small" align="center">
-            <Checkmark color="text-strong" size="small" />
-            <Text color="text-strong" weight={500}>
-              {datum}
-            </Text>
-          </Box>
-        )}
-      </List>
-      <Text color="text-strong">
-        Include guidance to what will occur when “Finish Wizard" is clicked.
-      </Text>
-    </Box>
-  );
+  <Box gap="small">
+    <List data={data} pad={{ horizontal: 'none', vertical: 'small' }}>
+      {(datum, index) => (
+        <Box key={index} direction="row" gap="small" align="center">
+          <Checkmark color="text-strong" size="small" />
+          <Text color="text-strong" weight={500}>
+            {datum}
+          </Text>
+        </Box>
+      )}
+    </List>
+    <Text color="text-strong">
+      Include guidance to what will occur when “Finish Wizard" is clicked.
+    </Text>
+  </Box>
+);
 
 export const steps = [
   {
@@ -229,6 +231,8 @@ export const steps = [
 ];
 
 export const WizardValidationExample = () => {
+  const size = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
   const [activeIndex, setActiveIndex] = useState(0);
   // for readability, this is used to display numeric value of step on screen,
   // such as step 1 of 3. it will always be one more than the active array index
@@ -267,6 +271,8 @@ export const WizardValidationExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
+  const countColumns = 2;
+  const width = getWidth(countColumns, theme, size);
   return (
     <WizardContext.Provider
       value={{
@@ -286,6 +292,7 @@ export const WizardValidationExample = () => {
         setFormValues,
         validation,
         wizardTitle: 'Wizard Title',
+        width,
       }}
     >
       <Box fill>

--- a/aries-site/src/examples/templates/wizard/WizardValidationExample.js
+++ b/aries-site/src/examples/templates/wizard/WizardValidationExample.js
@@ -59,7 +59,7 @@ const validation = [
 
 const stepOneInputs = [
   (attemptedAdvance, error, formValues, setError) => (
-    <Box width={{ max: 'medium' }}>
+    <>
       <FormField
         label="First Name"
         htmlFor="firstname-validation"
@@ -106,25 +106,20 @@ const stepOneInputs = [
           type="email"
         />
       </FormField>
-    </Box>
+    </>
   ),
-  (attemptedAdvance, error) => (
-    <Box width={{ max: 'medium' }}>
-      <FormField
-        htmlFor="radio-button-group-validation"
-        label="RadioButtonGroup"
+  () => (
+    <FormField
+      htmlFor="radio-button-group-validation"
+      label="RadioButtonGroup"
+      name="radio-button-group-validation"
+    >
+      <RadioButtonGroup
+        id="radio-button-group-validation"
         name="radio-button-group-validation"
-      >
-        <RadioButtonGroup
-          id="radio-button-group-validation"
-          name="radio-button-group-validation"
-          options={['Radio button 1', 'Radio button 2']}
-        />
-      </FormField>
-      {!error.isValid && (
-        <Error>There is an error with one or more inputs.</Error>
-      )}
-    </Box>
+        options={['Radio button 1', 'Radio button 2']}
+      />
+    </FormField>
   ),
 ];
 
@@ -136,18 +131,20 @@ const StepOne = () => {
 
   return (
     <>
-      <Box margin={{ bottom: 'medium' }}>
-        <Grid
-          columns={size !== 'small' ? { count: 'fit', size: 'medium' } : '100%'}
-          rows={[['auto', 'full']]}
-          gap={size !== 'small' ? 'large' : undefined}
-          fill
-        >
-          {stepOneInputs.map(input =>
-            input(attemptedAdvance, error, formValues, setError),
-          )}
-        </Grid>
-      </Box>
+      <Grid
+        columns={size !== 'small' ? { count: 'fit', size: 'medium' } : '100%'}
+        gap={size !== 'small' ? 'large' : undefined}
+        margin={{ bottom: 'medium' }}
+      >
+        {stepOneInputs.map((input, index) => (
+          <Box width={{ max: 'medium' }} key={index}>
+            {input(attemptedAdvance, error, formValues, setError)}
+          </Box>
+        ))}
+      </Grid>
+      {!error.isValid && (
+        <Error>There is an error with one or more inputs.</Error>
+      )}
     </>
   );
 };
@@ -271,8 +268,8 @@ export const WizardValidationExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
-  const countColumns = 2;
-  const width = getWidth(countColumns, theme, size);
+  const numberColumns = 2;
+  const width = getWidth(numberColumns, theme, size);
   return (
     <WizardContext.Provider
       value={{

--- a/aries-site/src/examples/templates/wizard/WizardValidationExample.js
+++ b/aries-site/src/examples/templates/wizard/WizardValidationExample.js
@@ -268,8 +268,7 @@ export const WizardValidationExample = () => {
     container.scrollTop = -header.getBoundingClientRect().bottom;
   }, [activeIndex, open]);
 
-  const numberColumns = 2;
-  const width = getWidth(numberColumns, theme, size);
+  const width = getWidth(numberColumns = 2, theme, size);
   return (
     <WizardContext.Provider
       value={{

--- a/aries-site/src/examples/templates/wizard/components/Error.js
+++ b/aries-site/src/examples/templates/wizard/components/Error.js
@@ -4,21 +4,22 @@ import { Box, Text } from 'grommet';
 import { CircleAlert } from 'grommet-icons';
 
 export const Error = ({ children, ...rest }) => (
-    <Box
-      animation="fadeIn"
-      background="validation-critical"
-      margin={{ top: 'small' }}
-      pad="small"
-      round="4px"
-    >
-      <Box direction="row" gap="xsmall" {...rest}>
-        <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
-          <CircleAlert size="small" />
-        </Box>
-        <Text size="xsmall">{children}</Text>
+  <Box
+    animation="fadeIn"
+    background="validation-critical"
+    margin={{ bottom: 'medium' }}
+    pad="small"
+    round="4px"
+    width="medium"
+  >
+    <Box direction="row" gap="xsmall" {...rest}>
+      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
+        <CircleAlert size="small" />
       </Box>
+      <Text size="xsmall">{children}</Text>
     </Box>
-  );
+  </Box>
+);
 
 Error.propTypes = {
   children: PropTypes.string,

--- a/aries-site/src/examples/templates/wizard/components/StepContent.js
+++ b/aries-site/src/examples/templates/wizard/components/StepContent.js
@@ -26,7 +26,7 @@ export const StepContent = () => {
       <Box
         width={width}
         gap="medium"
-        pad={size === 'small' ? { horizontal: 'small' } : 'xxsmall'}
+        pad={size === 'small' ? { horizontal: 'medium' } : 'xxsmall'}
       >
         <StepHeader />
         <Box margin={{ top: 'small' }}>

--- a/aries-site/src/examples/templates/wizard/components/StepContent.js
+++ b/aries-site/src/examples/templates/wizard/components/StepContent.js
@@ -21,7 +21,7 @@ export const StepContent = () => {
       overflow="auto"
       ref={ref}
       flex={size === 'small' ? true : undefined}
-      margin={{ horizontal: 'medium' }}
+      margin={size !== 'small' ? { horizontal: 'medium' } : undefined}
     >
       <Box
         width={width}

--- a/aries-site/src/examples/templates/wizard/components/StepContent.js
+++ b/aries-site/src/examples/templates/wizard/components/StepContent.js
@@ -4,9 +4,16 @@ import { StepHeader, WizardContext } from '.';
 
 export const StepContent = () => {
   const size = useContext(ResponsiveContext);
-  const { activeIndex, formValues, id, ref, setFormValues, steps } = useContext(
-    WizardContext,
-  );
+  const {
+    activeIndex,
+    formValues,
+    id,
+    ref,
+    setFormValues,
+    steps,
+    width,
+  } = useContext(WizardContext);
+
   return (
     <Box
       align="center"
@@ -14,9 +21,10 @@ export const StepContent = () => {
       overflow="auto"
       ref={ref}
       flex={size === 'small' ? true : undefined}
+      margin={{ horizontal: 'medium' }}
     >
       <Box
-        width="large"
+        width={width}
         gap="medium"
         pad={size === 'small' ? { horizontal: 'small' } : 'xxsmall'}
       >

--- a/aries-site/src/examples/templates/wizard/components/StepFooter.js
+++ b/aries-site/src/examples/templates/wizard/components/StepFooter.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Button, Footer, ResponsiveContext } from 'grommet';
+import { Box, Button, Footer, ResponsiveContext } from 'grommet';
 import { FormNextLink } from 'grommet-icons';
 import { WizardContext } from '.';
 
@@ -14,6 +14,7 @@ export const StepFooter = () => {
     setError,
     steps,
     validation,
+    width,
   } = useContext(WizardContext);
 
   const buttonProps = {
@@ -24,56 +25,55 @@ export const StepFooter = () => {
   };
 
   return (
-    <Footer
-      border={{ side: 'top', color: 'border' }}
-      justify="end"
-      pad={
-        size !== 'small'
-          ? { vertical: 'medium' }
-          : { vertical: 'small', horizontal: 'medium' }
-      }
-      width="large"
-      alignSelf="center"
-    >
-      {activeIndex < steps.length - 1 && (
-        <Button
-          {...buttonProps}
-          label="Next"
-          onClick={() => {
-            // mark that the user is trying to advance, so that onChange
-            // validation will run on any errors in the future
-            setAttemptedAdvance(true);
+    <Box margin={{ horizontal: 'medium' }} flex={false}>
+      <Footer
+        border={{ side: 'top', color: 'border' }}
+        justify="end"
+        pad={size !== 'small' ? { vertical: 'medium' } : { vertical: 'small' }}
+        alignSelf="center"
+        width={width}
+      >
+        {activeIndex < steps.length - 1 && (
+          <Button
+            {...buttonProps}
+            label="Next"
+            onClick={() => {
+              // mark that the user is trying to advance, so that onChange
+              // validation will run on any errors in the future
+              setAttemptedAdvance(true);
 
-            let nextIndex = activeIndex + 1;
-            nextIndex = nextIndex <= steps.length - 1 ? nextIndex : activeIndex;
+              let nextIndex = activeIndex + 1;
+              nextIndex =
+                nextIndex <= steps.length - 1 ? nextIndex : activeIndex;
 
-            if (validation && validation[activeIndex]) {
-              // check for errors
-              const validationRes =
-                validation[activeIndex].validator &&
-                validation[activeIndex].validator(formValues);
-              // advance to next step if successful
-              if (validationRes && validationRes.isValid)
+              if (validation && validation[activeIndex]) {
+                // check for errors
+                const validationRes =
+                  validation[activeIndex].validator &&
+                  validation[activeIndex].validator(formValues);
+                // advance to next step if successful
+                if (validationRes && validationRes.isValid)
+                  setActiveIndex(nextIndex);
+                // otherwise, display error and wizard will not advance to
+                // next step
+                else {
+                  setError(validationRes);
+                }
+              } else {
                 setActiveIndex(nextIndex);
-              // otherwise, display error and wizard will not advance to
-              // next step
-              else {
-                setError(validationRes);
               }
-            } else {
-              setActiveIndex(nextIndex);
-            }
-          }}
-        />
-      )}
-      {activeIndex === steps.length - 1 && (
-        <Button
-          {...buttonProps}
-          label="Finish Wizard"
-          form={`${id}-form`}
-          type="submit"
-        />
-      )}
-    </Footer>
+            }}
+          />
+        )}
+        {activeIndex === steps.length - 1 && (
+          <Button
+            {...buttonProps}
+            label="Finish Wizard"
+            form={`${id}-form`}
+            type="submit"
+          />
+        )}
+      </Footer>
+    </Box>
   );
 };

--- a/aries-site/src/examples/templates/wizard/components/StepFooter.js
+++ b/aries-site/src/examples/templates/wizard/components/StepFooter.js
@@ -35,7 +35,7 @@ export const StepFooter = () => {
         pad={
           size !== 'small'
             ? { vertical: 'medium' }
-            : { vertical: 'small', horizontal: 'small' }
+            : { vertical: 'small', horizontal: 'medium' }
         }
         alignSelf="center"
         width={width}

--- a/aries-site/src/examples/templates/wizard/components/StepFooter.js
+++ b/aries-site/src/examples/templates/wizard/components/StepFooter.js
@@ -25,11 +25,18 @@ export const StepFooter = () => {
   };
 
   return (
-    <Box margin={{ horizontal: 'medium' }} flex={false}>
+    <Box
+      margin={size !== 'small' ? { horizontal: 'medium' } : undefined}
+      flex={false}
+    >
       <Footer
         border={{ side: 'top', color: 'border' }}
         justify="end"
-        pad={size !== 'small' ? { vertical: 'medium' } : { vertical: 'small' }}
+        pad={
+          size !== 'small'
+            ? { vertical: 'medium' }
+            : { vertical: 'small', horizontal: 'small' }
+        }
         alignSelf="center"
         width={width}
       >

--- a/aries-site/src/examples/templates/wizard/utils.js
+++ b/aries-site/src/examples/templates/wizard/utils.js
@@ -2,12 +2,13 @@
 // on the max number of columns it will contain * the width
 // of those columns (medium) + gap between columns + small amount
 // of pad to ensure focus is visible.
-export const getWidth = (countColumns, theme, size) => {
+export const getWidth = (numberColumns, theme, size) => {
   const inputWidth =
-    parseInt(theme.global.size.medium.replace('px', ''), 10) * countColumns;
+    parseInt(theme.global.size.medium.replace('px', ''), 10) * numberColumns;
   const gapWidth =
     size !== 'small'
-      ? parseInt(theme.global.edgeSize.large.replace('px', ''), 10)
+      ? parseInt(theme.global.edgeSize.large.replace('px', ''), 10) *
+        (numberColumns - 1)
       : 0;
   const focusPad =
     2 *

--- a/aries-site/src/examples/templates/wizard/utils.js
+++ b/aries-site/src/examples/templates/wizard/utils.js
@@ -1,0 +1,18 @@
+// Wizard width is not a t-shirt size but instead dependent
+// on the max number of columns it will contain * the width
+// of those columns (medium) + gap between columns + small amount
+// of pad to ensure focus is visible.
+export const getWidth = (countColumns, theme, size) => {
+  const inputWidth =
+    parseInt(theme.global.size.medium.replace('px', ''), 10) * countColumns;
+  const gapWidth =
+    size !== 'small'
+      ? parseInt(theme.global.edgeSize.large.replace('px', ''), 10)
+      : 0;
+  const focusPad =
+    2 *
+    (size === 'small'
+      ? parseInt(theme.global.edgeSize.small.replace('px', ''), 10)
+      : parseInt(theme.global.edgeSize.xxsmall.replace('px', ''), 10));
+  return `${inputWidth + gapWidth + focusPad}px`;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3438,9 +3438,9 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.3.tgz#81f1b07003b329f000b7912e59a24f52392867b6"
-  integrity sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.5.tgz#f07d6fdeffcdbb80485570ce3f1bc845fcc812b9"
+  integrity sha512-RkiLa/AeJx7+9OvniQ/qeWu0w74A8DiPPBclQ6ji3ZQkv5KamO+QGpqmi7O4JIw3rHGUXZ6CoP9tsAkn3gyazg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -3900,9 +3900,9 @@ axe-core@^3.4.2:
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
 axe-core@^4.0.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
-  integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
+  integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
 
 axe-testcafe@^3.0.0:
   version "3.0.0"
@@ -4946,9 +4946,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001181:
-  version "1.0.30001205"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz#d79bf6a6fb13196b4bb46e5143a22ca0242e0ef8"
-  integrity sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==
+  version "1.0.30001207"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz#364d47d35a3007e528f69adb6fecb07c2bb2cc50"
+  integrity sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5156,9 +5156,9 @@ classnames@2.2.6:
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 classnames@^2.2.5:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.0.tgz#19524334bad47ccd99793936b67f9be0860fe835"
-  integrity sha512-UUf/S3eeczXBjHPpSnrZ1ZyxH3KmLW8nVYFUWIZA/dixYMIQr7l94yYKxaAkmPk7HO9dlT6gFqAPZC02tTdfQw==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -6310,10 +6310,10 @@ domelementtype@1, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@^2.0.1, domelementtype@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
-  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -6343,12 +6343,12 @@ domhandler@^3.0.0:
   dependencies:
     domelementtype "^2.0.1"
 
-domhandler@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.0.0.tgz#01ea7821de996d85f69029e81fa873c21833098e"
-  integrity sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==
+domhandler@^4.0.0, domhandler@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.1.0.tgz#c1d8d494d5ec6db22de99e46a149c2a4d23ddd43"
+  integrity sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==
   dependencies:
-    domelementtype "^2.1.0"
+    domelementtype "^2.2.0"
 
 domutils@2.1.0:
   version "2.1.0"
@@ -6368,13 +6368,13 @@ domutils@^1.5.1, domutils@^1.7.0:
     domelementtype "1"
 
 domutils@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.5.0.tgz#42f49cffdabb92ad243278b331fd761c1c2d3039"
-  integrity sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.5.1.tgz#9b8e84b5d9f788499ae77506ea832e9b4f9aa1c0"
+  integrity sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==
   dependencies:
     dom-serializer "^1.0.1"
-    domelementtype "^2.0.1"
-    domhandler "^4.0.0"
+    domelementtype "^2.2.0"
+    domhandler "^4.1.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6447,9 +6447,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.649:
-  version "1.3.704"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz#894205a237cbe0097d63da8f6d19e605dd13ab51"
-  integrity sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA==
+  version "1.3.707"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz#71386d0ceca6727835c33ba31f507f6824d18c35"
+  integrity sha512-BqddgxNPrcWnbDdJw7SzXVzPmp+oiyjVrc7tkQVaznPGSS9SKZatw6qxoP857M+HbOyyqJQwYQtsuFIMSTNSZA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7955,8 +7955,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.1"
-  uid "0ff1f9506ae6a202836ce47486b600e02dfe82ed"
-  resolved "https://github.com/grommet/grommet/tarball/stable#0ff1f9506ae6a202836ce47486b600e02dfe82ed"
+  uid "7b075c7212b227f4663764381b2f77a7ea909f9b"
+  resolved "https://github.com/grommet/grommet/tarball/stable#7b075c7212b227f4663764381b2f77a7ea909f9b"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"
@@ -8842,9 +8842,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
-  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.0.tgz#b037c8815281edaad6c2562648a5f5f18839d5f7"
+  integrity sha512-K4GwB4i/HzhAzwP/XSlspzRdFTI9N8OxJOyOU7Y5Rz+p+WBokXWVWblaJeBkggthmoSV0OoGTH5thJNvplpkvQ==
 
 is-dom@^1.0.9:
   version "1.1.0"
@@ -10351,10 +10351,10 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-db@1.46.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.41.0, mime-db@^1.43.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
-  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
+mime-db@1.47.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.41.0, mime-db@^1.43.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
 mime-types@2.1.27:
   version "2.1.27"
@@ -10364,11 +10364,11 @@ mime-types@2.1.27:
     mime-db "1.44.0"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.29"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
-  integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   dependencies:
-    mime-db "1.46.0"
+    mime-db "1.47.0"
 
 mime@1.6.0, mime@^1.3.4:
   version "1.6.0"
@@ -13508,9 +13508,9 @@ stack-trace@0.0.10:
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.4.tgz#4b600971dcfc6aed0cbdf2a8268177cc916c87c8"
-  integrity sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
+  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
   dependencies:
     escape-string-regexp "^2.0.0"
 
@@ -14549,9 +14549,9 @@ tslib@^1.9.0, tslib@^1.9.3:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.1, tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -14779,9 +14779,9 @@ unist-util-remove-position@^2.0.0:
     unist-util-visit "^2.0.0"
 
 unist-util-remove@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-2.0.1.tgz#fa13c424ff8e964f3aa20d1098b9a690c6bfaa39"
-  integrity sha512-YtuetK6o16CMfG+0u4nndsWpujgsHDHHLyE0yGpJLLn5xSjKeyGyzEBOI2XbmoUHCYabmNgX52uxlWoQhcvR7Q==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-2.1.0.tgz#b0b4738aa7ee445c402fda9328d604a02d010588"
+  integrity sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q==
   dependencies:
     unist-util-is "^4.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4364,9 +4364,9 @@ bail@^1.0.0:
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.3.1:
   version "1.5.1"
@@ -6447,9 +6447,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.649:
-  version "1.3.707"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz#71386d0ceca6727835c33ba31f507f6824d18c35"
-  integrity sha512-BqddgxNPrcWnbDdJw7SzXVzPmp+oiyjVrc7tkQVaznPGSS9SKZatw6qxoP857M+HbOyyqJQwYQtsuFIMSTNSZA==
+  version "1.3.708"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.708.tgz#127970d2fc665ab356be59e668f2914856419176"
+  integrity sha512-+A8ggYZ5riOLMcVAuzHx6bforaPzaiLnW1QOMD2SlMYQVi7QQTyQ/WrlZoebIH9ikmgr+tLJGpNITFFCUiQcPw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7955,8 +7955,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.1"
-  uid "7b075c7212b227f4663764381b2f77a7ea909f9b"
-  resolved "https://github.com/grommet/grommet/tarball/stable#7b075c7212b227f4663764381b2f77a7ea909f9b"
+  uid e40ee6316c4fd34669c0d20fa94c71e46213ef3d
+  resolved "https://github.com/grommet/grommet/tarball/stable#e40ee6316c4fd34669c0d20fa94c71e46213ef3d"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Wizard content/footer width should be determined by the total width of the inputs, gap between columns, and a small amount of pad to accommodate focus outline on inputs.

In a wizard, the width should remain constant across steps, matching the width needed for the step with the max number of columns. The inputs themselves should be `width="medium"` and so in the case of a two-column wizard the width of the content and footer should be:
```
medium * numberColumns + gap * (numberColumns - 1) + tiny amount of pad for focus ring
```

This PR adjusts how this styling occurs, makes sure the inputs wrap appropriately and maintain their designated widths, and ensures there's always some small margin between step content/footer content and the edges of the screen (which previously was not applying properly).

#### Where should the reviewer start?
aries-site/src/examples/templates/wizard/WizardValidationExample.js

#### What testing has been done on this PR?
Check wizard deploy page.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?
Discussions with CCS determined that the inputs should remain a width of `medium` and wrap when there's not enough space.

#### What are the relevant issues?
Closes #1399 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
Yes. Updated Wizard layout so that inputs always remain width="medium" and wrap when there is not sufficient horizontal space.

#### Is this change backwards compatible or is it a breaking change?
New behavior to align with a conclusion between Design System and CCS.