### PR TITLE
add search to also be cleared

### DIFF
--- a/aries-site/src/examples/templates/filtering/FilteringCards.js
+++ b/aries-site/src/examples/templates/filtering/FilteringCards.js
@@ -136,9 +136,9 @@ export const FilteringCards = ({ containerRef }) => {
 
     let filterResults;
     const filterKeys = Object.keys(criteria);
-    filterResults = array.filter(item => 
+    filterResults = array.filter(item =>
       // validates all filter criteria
-       filterKeys.every(key => {
+      filterKeys.every(key => {
         // ignores non-function predicates
         if (typeof criteria[key] !== 'function') return true;
         return criteria[key](item[key]);
@@ -208,6 +208,7 @@ export const FilteringCards = ({ containerRef }) => {
                 filters={filters}
                 setFilters={setFilters}
                 filterData={filterData}
+                setSearch={setSearch}
                 // target is for demo purposes only, remove in production
                 target={containerRef && containerRef.current}
               />
@@ -232,6 +233,7 @@ const Filters = ({
   filterData,
   setData,
   setFiltering,
+  setSearch,
   target, // target is for demo purposes only, remove in production
 }) => {
   const [hoursAvailable, setHoursAvailable] = useState(defaultHoursAvailable);
@@ -254,6 +256,7 @@ const Filters = ({
     setName([]);
     setFilters(defaultFilters);
     setFiltering(false);
+    setSearch();
   };
 
   // everytime the Filters layer opens, save a temp
@@ -401,6 +404,7 @@ Filters.propTypes = {
   filterData: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
   setFiltering: PropTypes.func.isRequired,
+  setSearch: PropTypes.func.isRequired,
   target: PropTypes.object,
 };
 
@@ -554,34 +558,34 @@ const HoursAvailableFilter = ({
   filters,
   setFilters,
 }) => (
-    <Box flex={false}>
-      <FormField label="Remaining Available Work Hours">
-        <Stack>
-          <Box background="border" height="3px" direction="row" />
-          <RangeSelector
-            name="range-selector-employee-count"
-            id="range-selector-employee-count"
-            min={defaultHoursAvailable[0]}
-            max={defaultHoursAvailable[1]}
-            values={hoursAvailable}
-            onChange={nextRange => {
-              setHoursAvailable(nextRange);
-              const nextFilters = {
-                ...filters,
-                hoursAvailable: nexthoursAvailable =>
-                  nexthoursAvailable >= hoursAvailable[0] &&
-                  nexthoursAvailable <= hoursAvailable[1],
-              };
-              setFilters(nextFilters);
-            }}
-          />
-        </Stack>
-      </FormField>
-      <Text size="small">
-        {`${hoursAvailable[0]} - ${hoursAvailable[1]} hours`}
-      </Text>
-    </Box>
-  );
+  <Box flex={false}>
+    <FormField label="Remaining Available Work Hours">
+      <Stack>
+        <Box background="border" height="3px" direction="row" />
+        <RangeSelector
+          name="range-selector-employee-count"
+          id="range-selector-employee-count"
+          min={defaultHoursAvailable[0]}
+          max={defaultHoursAvailable[1]}
+          values={hoursAvailable}
+          onChange={nextRange => {
+            setHoursAvailable(nextRange);
+            const nextFilters = {
+              ...filters,
+              hoursAvailable: nexthoursAvailable =>
+                nexthoursAvailable >= hoursAvailable[0] &&
+                nexthoursAvailable <= hoursAvailable[1],
+            };
+            setFilters(nextFilters);
+          }}
+        />
+      </Stack>
+    </FormField>
+    <Text size="small">
+      {`${hoursAvailable[0]} - ${hoursAvailable[1]} hours`}
+    </Text>
+  </Box>
+);
 
 HoursAvailableFilter.propTypes = {
   filters: PropTypes.shape({

--- a/aries-site/src/examples/templates/filtering/FilteringCards.js
+++ b/aries-site/src/examples/templates/filtering/FilteringCards.js
@@ -119,7 +119,7 @@ export const FilteringCards = ({ containerRef }) => {
   const [filtering, setFiltering] = useState(false);
   const [filters, setFilters] = useState(defaultFilters);
   const [searchFocused, setSearchFocused] = useState(false);
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
   const inputRef = useRef();
   const size = useContext(ResponsiveContext);
 

--- a/aries-site/src/examples/templates/filtering/FilteringCards.js
+++ b/aries-site/src/examples/templates/filtering/FilteringCards.js
@@ -256,7 +256,7 @@ const Filters = ({
     setName([]);
     setFilters(defaultFilters);
     setFiltering(false);
-    setSearch();
+    setSearch('');
   };
 
   // everytime the Filters layer opens, save a temp

--- a/aries-site/src/examples/templates/filtering/FilteringLists.js
+++ b/aries-site/src/examples/templates/filtering/FilteringLists.js
@@ -245,7 +245,7 @@ const Filters = ({
     setTenant([]);
     setFilters(defaultFilters);
     setFiltering(false);
-    setSearch();
+    setSearch('');
   };
 
   // everytime the Filters layer opens, save a temp

--- a/aries-site/src/examples/templates/filtering/FilteringLists.js
+++ b/aries-site/src/examples/templates/filtering/FilteringLists.js
@@ -103,7 +103,7 @@ export const FilteringLists = ({ containerRef }) => {
   const [filtering, setFiltering] = useState(false);
   const [filters, setFilters] = useState(defaultFilters);
   const [searchFocused, setSearchFocused] = useState(false);
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
   const inputRef = useRef();
   const size = useContext(ResponsiveContext);
 
@@ -120,9 +120,9 @@ export const FilteringLists = ({ containerRef }) => {
 
     let filterResults;
     const filterKeys = Object.keys(criteria);
-    filterResults = array.filter(item => 
+    filterResults = array.filter(item =>
       // validates all filter criteria
-       filterKeys.every(key => {
+      filterKeys.every(key => {
         // ignores non-function predicates
         if (typeof criteria[key] !== 'function') return true;
         return criteria[key](item[key]);
@@ -192,6 +192,7 @@ export const FilteringLists = ({ containerRef }) => {
                 filters={filters}
                 setFilters={setFilters}
                 filterData={filterData}
+                setSearch={setSearch}
                 // target is for demo purposes only, remove in production
                 target={containerRef && containerRef.current}
               />
@@ -224,6 +225,7 @@ const Filters = ({
   filtering,
   setData,
   setFiltering,
+  setSearch,
   // target is for demo purposes only, remove in production
   target,
 }) => {
@@ -243,6 +245,7 @@ const Filters = ({
     setTenant([]);
     setFilters(defaultFilters);
     setFiltering(false);
+    setSearch();
   };
 
   // everytime the Filters layer opens, save a temp
@@ -374,6 +377,7 @@ Filters.propTypes = {
   filterData: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
   setFiltering: PropTypes.func.isRequired,
+  setSearch: PropTypes.func.isRequired,
   target: PropTypes.object,
 };
 

--- a/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
@@ -205,7 +205,7 @@ const Filters = ({
     setRam([]);
     setFilters(defaultFilters);
     setFiltering(false);
-    setSearch();
+    setSearch('');
   };
 
   // everytime the Filters layer opens, save a temp

--- a/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
@@ -164,6 +164,7 @@ export const FilteringWithDropButton = () => {
                 filters={filters}
                 setFilters={setFilters}
                 filterData={filterData}
+                setSearch={setSearch}
               />
             )}
           </Box>
@@ -190,6 +191,7 @@ const Filters = ({
   filtering,
   setData,
   setFiltering,
+  setSearch,
 }) => {
   const [ram, setRam] = useState([]);
   const [previousValues, setPreviousValues] = useState({});
@@ -203,6 +205,7 @@ const Filters = ({
     setRam([]);
     setFilters(defaultFilters);
     setFiltering(false);
+    setSearch();
   };
 
   // everytime the Filters layer opens, save a temp
@@ -289,6 +292,7 @@ Filters.propTypes = {
   filterData: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
   setFiltering: PropTypes.func.isRequired,
+  setSearch: PropTypes.func.isRequired,
 };
 
 const RamFilter = ({ filters, setFilters, ram, setRam }) => (

--- a/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
@@ -81,7 +81,7 @@ export const FilteringWithDropButton = () => {
   const [filtering, setFiltering] = useState(false);
   const [searchFocused, setSearchFocused] = useState(false);
   const [filters, setFilters] = useState(defaultFilters);
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
   const size = useContext(ResponsiveContext);
   const inputRef = useRef();
 

--- a/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
@@ -88,9 +88,9 @@ export const FilteringWithRangeSelector = ({ containerRef }) => {
 
     let filterResults;
     const filterKeys = Object.keys(criteria);
-    filterResults = array.filter(item => 
+    filterResults = array.filter(item =>
       // validates all filter criteria
-       filterKeys.every(key => {
+      filterKeys.every(key => {
         // ignores non-function predicates
         if (typeof criteria[key] !== 'function') return true;
         return criteria[key](item[key]);
@@ -160,6 +160,7 @@ export const FilteringWithRangeSelector = ({ containerRef }) => {
                 filters={filters}
                 setFilters={setFilters}
                 filterData={filterData}
+                setSearch={setSearch}
                 // target is for demo purposes only, remove in production
                 target={containerRef && containerRef.current}
               />
@@ -190,6 +191,7 @@ const Filters = ({
   filtering,
   setData,
   setFiltering,
+  setSearch,
   target, // target is for demo purposes only, remove in production
 }) => {
   const [availability, setAvailability] = useState(defaultAvailability);
@@ -213,14 +215,15 @@ const Filters = ({
     setData(allData);
     setFilters(defaultFilters);
     setLocation(defaultLocation);
+    setSearch();
   };
 
   const filterData = (array, criteria) => {
     setFilters(criteria);
     const filterKeys = Object.keys(criteria);
-    return array.filter(item => 
+    return array.filter(item =>
       // validates all filter criteria
-       filterKeys.every(key => {
+      filterKeys.every(key => {
         // ignores non-function predicates
         if (typeof criteria[key] !== 'function') return true;
         return criteria[key](item[key]);
@@ -411,6 +414,7 @@ Filters.propTypes = {
   filtering: PropTypes.bool.isRequired,
   setData: PropTypes.func.isRequired,
   setFiltering: PropTypes.func.isRequired,
+  setSearch: PropTypes.func.isRequired,
   // target is for demo purposes only, remove in production
   target: PropTypes.object,
 };
@@ -424,34 +428,34 @@ const LocationFilter = ({
   previousValues,
   setPreviousValues,
 }) => (
-    <Select
-      options={[
-        'All Locations',
-        'Fort Collins, CO',
-        'Houston, TX',
-        'New York, NY',
-        'San Jose, CA',
-      ]}
-      value={location}
-      onChange={({ option }) => {
-        const nextFilters = {
-          ...filters,
-          location:
-            option !== defaultLocation &&
-            (nextLocation => nextLocation === option),
-        };
-        const nextData = filterData(allData, nextFilters);
-        // save previous value in case user
-        // clicks 'x'
-        setPreviousValues({
-          ...previousValues,
-          location,
-        });
-        setLocation(option);
-        setData(nextData);
-      }}
-    />
-  );
+  <Select
+    options={[
+      'All Locations',
+      'Fort Collins, CO',
+      'Houston, TX',
+      'New York, NY',
+      'San Jose, CA',
+    ]}
+    value={location}
+    onChange={({ option }) => {
+      const nextFilters = {
+        ...filters,
+        location:
+          option !== defaultLocation &&
+          (nextLocation => nextLocation === option),
+      };
+      const nextData = filterData(allData, nextFilters);
+      // save previous value in case user
+      // clicks 'x'
+      setPreviousValues({
+        ...previousValues,
+        location,
+      });
+      setLocation(option);
+      setData(nextData);
+    }}
+  />
+);
 
 LocationFilter.propTypes = {
   filters: PropTypes.shape({

--- a/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
@@ -77,7 +77,7 @@ export const FilteringWithRangeSelector = ({ containerRef }) => {
   const [filtering, setFiltering] = useState(false);
   const [searchFocused, setSearchFocused] = useState(false);
   const [filters, setFilters] = useState(defaultFilters);
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
   const size = useContext(ResponsiveContext);
   const inputRef = useRef();
 

--- a/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
@@ -215,7 +215,7 @@ const Filters = ({
     setData(allData);
     setFilters(defaultFilters);
     setLocation(defaultLocation);
-    setSearch();
+    setSearch('');
   };
 
   const filterData = (array, criteria) => {

--- a/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
@@ -48,7 +48,7 @@ export const FilteringWithSelect = ({ containerRef }) => {
   const [filtering, setFiltering] = useState(false);
   const [filters, setFilters] = useState(defaultFilters);
   const [searchFocused, setSearchFocused] = useState(false);
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
   const inputRef = useRef();
   const size = useContext(ResponsiveContext);
 

--- a/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
@@ -65,9 +65,9 @@ export const FilteringWithSelect = ({ containerRef }) => {
 
     let filterResults;
     const filterKeys = Object.keys(criteria);
-    filterResults = array.filter(item => 
+    filterResults = array.filter(item =>
       // validates all filter criteria
-       filterKeys.every(key => {
+      filterKeys.every(key => {
         // ignores non-function predicates
         if (typeof criteria[key] !== 'function') return true;
         return criteria[key](item[key]);
@@ -145,6 +145,7 @@ export const FilteringWithSelect = ({ containerRef }) => {
                 filters={filters}
                 setFilters={setFilters}
                 filterData={filterData}
+                setSearch={setSearch}
                 // target is for demo purposes only, remove in production
                 target={containerRef && containerRef.current}
               />
@@ -170,6 +171,7 @@ const Filters = ({
   filterData,
   setFilters,
   setFiltering,
+  setSearch,
   target, // target is for demo purposes only, remove in production
 }) => {
   const [selectValue, setSelectValue] = useState(defaultSelectValue);
@@ -183,6 +185,7 @@ const Filters = ({
     setSelectValue(defaultSelectValue);
     setFilters(defaultFilters);
     setFiltering(false);
+    setSearch();
   };
 
   // everytime the Filters layer opens, save a temp
@@ -304,6 +307,7 @@ Filters.propTypes = {
   filterData: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
   setFiltering: PropTypes.func.isRequired,
+  setSearch: PropTypes.func.isRequired,
   // target is for demo purposes only, remove in production
   target: PropTypes.object,
 };

--- a/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
@@ -185,7 +185,7 @@ const Filters = ({
     setSelectValue(defaultSelectValue);
     setFilters(defaultFilters);
     setFiltering(false);
-    setSearch();
+    setSearch('');
   };
 
   // everytime the Filters layer opens, save a temp

--- a/aries-site/src/examples/templates/filtering/PersistentFiltering.js
+++ b/aries-site/src/examples/templates/filtering/PersistentFiltering.js
@@ -151,7 +151,7 @@ export const PersistentFiltering = ({ containerRef }) => {
     status: allFilters.status.defaultValue,
   });
   const [searchFocused, setSearchFocused] = useState(false);
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
   const size = useContext(ResponsiveContext);
   const inputRef = useRef();
 
@@ -169,9 +169,9 @@ export const PersistentFiltering = ({ containerRef }) => {
 
       let filterResults;
       const filterKeys = Object.keys(criteria);
-      filterResults = array.filter(item => 
+      filterResults = array.filter(item =>
         // validates all filter criteria
-         filterKeys.every(key => {
+        filterKeys.every(key => {
           // ignores non-function predicates
           if (typeof criteria[key] !== 'function') return true;
           return criteria[key](item[key]);
@@ -207,6 +207,7 @@ export const PersistentFiltering = ({ containerRef }) => {
     setFiltering,
     filterValues,
     setFilterValues,
+    setSearch,
     // target is for demo purposes only, remove in production
     target: containerRef && containerRef.current,
   };
@@ -414,6 +415,7 @@ const Filters = ({
   setFiltering,
   filterValues,
   setFilterValues,
+  setSearch,
   target, // target is for demo purposes only, remove in production
 }) => {
   const { country, employeeCount, locationType, status } = filterValues;
@@ -433,6 +435,7 @@ const Filters = ({
     });
     setFilters(defaultFilters);
     setFiltering(false);
+    setSearch();
   };
 
   // everytime the Filters layer opens, save a temp
@@ -599,6 +602,7 @@ Filters.propTypes = {
   filtering: PropTypes.bool.isRequired,
   setData: PropTypes.func.isRequired,
   setFiltering: PropTypes.func.isRequired,
+  setSearch: PropTypes.func.isRequired,
   target: PropTypes.object,
 };
 
@@ -608,30 +612,30 @@ const LocationTypeFilter = ({
   filterValues,
   setFilterValues,
 }) => (
-    <FormField
-      label="Location Type"
-      htmlFor="location-type-b"
+  <FormField
+    label="Location Type"
+    htmlFor="location-type-b"
+    name="location-type-b"
+  >
+    <CheckBoxGroup
+      id="location-type-b"
       name="location-type-b"
-    >
-      <CheckBoxGroup
-        id="location-type-b"
-        name="location-type-b"
-        options={allFilters.locationType.options}
-        value={filters.locationType ? filterValues.locationType : []}
-        onChange={({ value }) => {
-          setFilterValues({ ...filterValues, locationType: value });
-          const nextFilters = {
-            ...filters,
-            locationType:
-              value.length &&
-              (nextLocationType => value.includes(nextLocationType)),
-          };
-          if (!value.length) delete nextFilters.locationType;
-          setFilters(nextFilters);
-        }}
-      />
-    </FormField>
-  );
+      options={allFilters.locationType.options}
+      value={filters.locationType ? filterValues.locationType : []}
+      onChange={({ value }) => {
+        setFilterValues({ ...filterValues, locationType: value });
+        const nextFilters = {
+          ...filters,
+          locationType:
+            value.length &&
+            (nextLocationType => value.includes(nextLocationType)),
+        };
+        if (!value.length) delete nextFilters.locationType;
+        setFilters(nextFilters);
+      }}
+    />
+  </FormField>
+);
 
 LocationTypeFilter.propTypes = {
   filters: PropTypes.shape({
@@ -653,24 +657,24 @@ const StatusFilter = ({
   filterValues,
   setFilterValues,
 }) => (
-    <FormField label="Status" htmlFor="status-b" name="status-b">
-      <CheckBoxGroup
-        id="status-b"
-        name="status-b"
-        options={allFilters.status.options}
-        value={filters.status ? filterValues.status : []}
-        onChange={({ value }) => {
-          setFilterValues({ ...filterValues, status: value });
-          const nextFilters = {
-            ...filters,
-            status: value.length && (nextStatus => value.includes(nextStatus)),
-          };
-          if (!value.length) delete nextFilters.status;
-          setFilters(nextFilters);
-        }}
-      />
-    </FormField>
-  );
+  <FormField label="Status" htmlFor="status-b" name="status-b">
+    <CheckBoxGroup
+      id="status-b"
+      name="status-b"
+      options={allFilters.status.options}
+      value={filters.status ? filterValues.status : []}
+      onChange={({ value }) => {
+        setFilterValues({ ...filterValues, status: value });
+        const nextFilters = {
+          ...filters,
+          status: value.length && (nextStatus => value.includes(nextStatus)),
+        };
+        if (!value.length) delete nextFilters.status;
+        setFilters(nextFilters);
+      }}
+    />
+  </FormField>
+);
 
 StatusFilter.propTypes = {
   filters: PropTypes.shape({
@@ -692,25 +696,24 @@ const CountryFilter = ({
   filterValues,
   setFilterValues,
 }) => (
-    <FormField label="Country" htmlFor="country-b" name="country-b">
-      <CheckBoxGroup
-        id="country-b"
-        name="country-b"
-        options={allFilters.country.options}
-        value={filters.country ? filterValues.country : []}
-        onChange={({ value }) => {
-          setFilterValues({ ...filterValues, country: value });
-          const nextFilters = {
-            ...filters,
-            country:
-              value.length && (nextCountry => value.includes(nextCountry)),
-          };
-          if (!value.length) delete nextFilters.country;
-          setFilters(nextFilters);
-        }}
-      />
-    </FormField>
-  );
+  <FormField label="Country" htmlFor="country-b" name="country-b">
+    <CheckBoxGroup
+      id="country-b"
+      name="country-b"
+      options={allFilters.country.options}
+      value={filters.country ? filterValues.country : []}
+      onChange={({ value }) => {
+        setFilterValues({ ...filterValues, country: value });
+        const nextFilters = {
+          ...filters,
+          country: value.length && (nextCountry => value.includes(nextCountry)),
+        };
+        if (!value.length) delete nextFilters.country;
+        setFilters(nextFilters);
+      }}
+    />
+  </FormField>
+);
 
 CountryFilter.propTypes = {
   filters: PropTypes.shape({
@@ -732,49 +735,49 @@ const EmployeeCountFilter = ({
   filterValues,
   setFilterValues,
 }) => (
-    <Box flex={false}>
-      <FormField
-        label="Employee Count"
-        htmlFor="employee-count-b"
-        name="employee-count-b"
-      >
-        <Stack>
-          <Box background="border" height="3px" direction="row" />
-          <RangeSelector
-            id="employee-count-b"
-            name="employee-count-b"
-            min={0}
-            max={2000}
-            values={
-              filters.employeeCount
-                ? filterValues.employeeCount
-                : allFilters.employeeCount.defaultValue
+  <Box flex={false}>
+    <FormField
+      label="Employee Count"
+      htmlFor="employee-count-b"
+      name="employee-count-b"
+    >
+      <Stack>
+        <Box background="border" height="3px" direction="row" />
+        <RangeSelector
+          id="employee-count-b"
+          name="employee-count-b"
+          min={0}
+          max={2000}
+          values={
+            filters.employeeCount
+              ? filterValues.employeeCount
+              : allFilters.employeeCount.defaultValue
+          }
+          onChange={nextRange => {
+            setFilterValues({ ...filterValues, employeeCount: nextRange });
+            const nextFilters = {
+              ...filters,
+              employeeCount: nextEmployeeCount =>
+                nextEmployeeCount >= filterValues.employeeCount[0] &&
+                nextEmployeeCount <= filterValues.employeeCount[1],
+            };
+            if (
+              nextRange[0] === allFilters.employeeCount.defaultValue[0] &&
+              nextRange[1] === allFilters.employeeCount.defaultValue[1]
+            ) {
+              delete nextFilters.employeeCount;
             }
-            onChange={nextRange => {
-              setFilterValues({ ...filterValues, employeeCount: nextRange });
-              const nextFilters = {
-                ...filters,
-                employeeCount: nextEmployeeCount =>
-                  nextEmployeeCount >= filterValues.employeeCount[0] &&
-                  nextEmployeeCount <= filterValues.employeeCount[1],
-              };
-              if (
-                nextRange[0] === allFilters.employeeCount.defaultValue[0] &&
-                nextRange[1] === allFilters.employeeCount.defaultValue[1]
-              ) {
-                delete nextFilters.employeeCount;
-              }
-              setFilters(nextFilters);
-            }}
-          />
-        </Stack>
-      </FormField>
-      <Text size="small">
-        {`${filterValues.employeeCount[0]} - 
+            setFilters(nextFilters);
+          }}
+        />
+      </Stack>
+    </FormField>
+    <Text size="small">
+      {`${filterValues.employeeCount[0]} - 
         ${filterValues.employeeCount[1]} people`}
-      </Text>
-    </Box>
-  );
+    </Text>
+  </Box>
+);
 
 EmployeeCountFilter.propTypes = {
   filters: PropTypes.shape({

--- a/aries-site/src/examples/templates/filtering/PersistentFiltering.js
+++ b/aries-site/src/examples/templates/filtering/PersistentFiltering.js
@@ -435,7 +435,7 @@ const Filters = ({
     });
     setFilters(defaultFilters);
     setFiltering(false);
-    setSearch();
+    setSearch('');
   };
 
   // everytime the Filters layer opens, save a temp

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,22 +5508,22 @@ copy-to-clipboard@^3.0.8:
     toggle-selection "^1.0.6"
 
 core-js-compat@^3.6.2, core-js-compat@^3.8.1, core-js-compat@^3.9.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.10.0.tgz#3600dc72869673c110215ee7a005a8609dea0fe1"
-  integrity sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.10.1.tgz#62183a3a77ceeffcc420d907a3e6fc67d9b27f1c"
+  integrity sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==
   dependencies:
     browserslist "^4.16.3"
     semver "7.0.0"
 
 core-js-pure@^3.0.0, core-js-pure@^3.0.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.10.0.tgz#dab9d6b141779b622b40567e7a536d2276646c15"
-  integrity sha512-CC582enhrFZStO4F8lGI7QL3SYx7/AIRc+IdSi3btrQGrVsTawo5K/crmKbRrQ+MOMhNX4v+PATn0k2NN6wI7A==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.10.1.tgz#28642697dfcf02e0fd9f4d9891bd03a22df28ecf"
+  integrity sha512-PeyJH2SE0KuxY5eCGNWA+W+CeDpB6M1PN3S7Am7jSv/Ttuxz2SnWbIiVQOn/TDaGaGtxo8CRWHkXwJscbUHtVw==
 
 core-js@^3.0.1, core-js@^3.0.4, core-js@^3.2.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
-  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.1.tgz#e683963978b6806dcc6c0a4a8bd4ab0bdaf3f21a"
+  integrity sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -7955,8 +7955,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.1"
-  uid e40ee6316c4fd34669c0d20fa94c71e46213ef3d
-  resolved "https://github.com/grommet/grommet/tarball/stable#e40ee6316c4fd34669c0d20fa94c71e46213ef3d"
+  uid "9510334625f3ffb1a5bb5dcf25909f680111f8ba"
+  resolved "https://github.com/grommet/grommet/tarball/stable#9510334625f3ffb1a5bb5dcf25909f680111f8ba"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"
@@ -15478,9 +15478,9 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.2.tgz#c504495ba9b59230dd60226d1dd89c3c0a1b745e"
-  integrity sha512-DnBDwcL54b5xWMM/7RfFg4xs5amYxq2ot49aUfLjQSAracXkGvlZq0txzqr3Pa6Q0ayuCxBcwTzrPUScKY0O8w==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 yallist@^3.0.2:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3438,9 +3438,9 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.3.tgz#81f1b07003b329f000b7912e59a24f52392867b6"
-  integrity sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.5.tgz#f07d6fdeffcdbb80485570ce3f1bc845fcc812b9"
+  integrity sha512-RkiLa/AeJx7+9OvniQ/qeWu0w74A8DiPPBclQ6ji3ZQkv5KamO+QGpqmi7O4JIw3rHGUXZ6CoP9tsAkn3gyazg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -3564,9 +3564,9 @@ anymatch@^2.0.0:
     normalize-path "^2.1.1"
 
 anymatch@^3.0.3, anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -3900,9 +3900,9 @@ axe-core@^3.4.2:
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
 axe-core@^4.0.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
-  integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
+  integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
 
 axe-testcafe@^3.0.0:
   version "3.0.0"
@@ -4364,9 +4364,9 @@ bail@^1.0.0:
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.3.1:
   version "1.5.1"
@@ -4946,9 +4946,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001181:
-  version "1.0.30001205"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz#d79bf6a6fb13196b4bb46e5143a22ca0242e0ef8"
-  integrity sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==
+  version "1.0.30001207"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz#364d47d35a3007e528f69adb6fecb07c2bb2cc50"
+  integrity sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5156,9 +5156,9 @@ classnames@2.2.6:
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 classnames@^2.2.5:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.0.tgz#19524334bad47ccd99793936b67f9be0860fe835"
-  integrity sha512-UUf/S3eeczXBjHPpSnrZ1ZyxH3KmLW8nVYFUWIZA/dixYMIQr7l94yYKxaAkmPk7HO9dlT6gFqAPZC02tTdfQw==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -6310,10 +6310,10 @@ domelementtype@1, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@^2.0.1, domelementtype@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
-  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -6343,12 +6343,12 @@ domhandler@^3.0.0:
   dependencies:
     domelementtype "^2.0.1"
 
-domhandler@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.0.0.tgz#01ea7821de996d85f69029e81fa873c21833098e"
-  integrity sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==
+domhandler@^4.0.0, domhandler@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.1.0.tgz#c1d8d494d5ec6db22de99e46a149c2a4d23ddd43"
+  integrity sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==
   dependencies:
-    domelementtype "^2.1.0"
+    domelementtype "^2.2.0"
 
 domutils@2.1.0:
   version "2.1.0"
@@ -6368,13 +6368,13 @@ domutils@^1.5.1, domutils@^1.7.0:
     domelementtype "1"
 
 domutils@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.5.0.tgz#42f49cffdabb92ad243278b331fd761c1c2d3039"
-  integrity sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.5.1.tgz#9b8e84b5d9f788499ae77506ea832e9b4f9aa1c0"
+  integrity sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==
   dependencies:
     dom-serializer "^1.0.1"
-    domelementtype "^2.0.1"
-    domhandler "^4.0.0"
+    domelementtype "^2.2.0"
+    domhandler "^4.1.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6447,9 +6447,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.649:
-  version "1.3.704"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz#894205a237cbe0097d63da8f6d19e605dd13ab51"
-  integrity sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA==
+  version "1.3.709"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz#d7be0b5686a2fdfe8bad898faa3a428d04d8f656"
+  integrity sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7955,8 +7955,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.1"
-  uid "0ff1f9506ae6a202836ce47486b600e02dfe82ed"
-  resolved "https://github.com/grommet/grommet/tarball/stable#0ff1f9506ae6a202836ce47486b600e02dfe82ed"
+  uid e40ee6316c4fd34669c0d20fa94c71e46213ef3d
+  resolved "https://github.com/grommet/grommet/tarball/stable#e40ee6316c4fd34669c0d20fa94c71e46213ef3d"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"
@@ -8842,9 +8842,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
-  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.0.tgz#b037c8815281edaad6c2562648a5f5f18839d5f7"
+  integrity sha512-K4GwB4i/HzhAzwP/XSlspzRdFTI9N8OxJOyOU7Y5Rz+p+WBokXWVWblaJeBkggthmoSV0OoGTH5thJNvplpkvQ==
 
 is-dom@^1.0.9:
   version "1.1.0"
@@ -10351,10 +10351,10 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-db@1.46.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.41.0, mime-db@^1.43.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
-  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
+mime-db@1.47.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.41.0, mime-db@^1.43.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
 mime-types@2.1.27:
   version "2.1.27"
@@ -10364,11 +10364,11 @@ mime-types@2.1.27:
     mime-db "1.44.0"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.29"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
-  integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   dependencies:
-    mime-db "1.46.0"
+    mime-db "1.47.0"
 
 mime@1.6.0, mime@^1.3.4:
   version "1.6.0"
@@ -13508,9 +13508,9 @@ stack-trace@0.0.10:
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.4.tgz#4b600971dcfc6aed0cbdf2a8268177cc916c87c8"
-  integrity sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
+  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
   dependencies:
     escape-string-regexp "^2.0.0"
 
@@ -13885,9 +13885,9 @@ supports-color@^7.0.0, supports-color@^7.1.0:
     has-flag "^4.0.0"
 
 supports-hyperlinks@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
-  integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
+  integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
@@ -14097,38 +14097,7 @@ testcafe-browser-tools@2.0.15:
     read-file-relative "^1.2.0"
     which-promise "^1.0.0"
 
-testcafe-hammerhead@19.5.0:
-  version "19.5.0"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-19.5.0.tgz#ef98290c224d408e57ad4fb389c70c8b8c587ec5"
-  integrity sha512-KtSPudvokOrLdsYH1kp8wFqG/JY7zg72/soam2ubrgxv13wcNB1szp1YN4rJnJdZgdGvSfeO1hsrPKhi4Ax+Qw==
-  dependencies:
-    acorn-hammerhead "0.4.0"
-    asar "^2.0.1"
-    bowser "1.6.0"
-    brotli "^1.3.1"
-    crypto-md5 "^1.0.0"
-    css "2.2.3"
-    debug "4.3.1"
-    esotope-hammerhead "0.6.1"
-    http-cache-semantics "^4.1.0"
-    iconv-lite "0.5.1"
-    lodash "^4.17.20"
-    lru-cache "2.6.3"
-    match-url-wildcard "0.0.4"
-    merge-stream "^1.0.1"
-    mime "~1.4.1"
-    mustache "^2.1.1"
-    nanoid "^3.1.12"
-    os-family "^1.0.0"
-    parse5 "2.2.3"
-    pinkie "2.0.4"
-    read-file-relative "^1.2.0"
-    semver "5.5.0"
-    tough-cookie "2.3.3"
-    tunnel-agent "0.6.0"
-    webauth "^1.1.0"
-
-testcafe-hammerhead@>=19.4.0:
+testcafe-hammerhead@21.0.0, testcafe-hammerhead@>=19.4.0:
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-21.0.0.tgz#0466d637ecd057e33e5d0ad7a83eebe93d0407c3"
   integrity sha512-ctIM2nF93Xgm4jHGbwMtSD1aRJu5d62+jy6T0LrjZcT/312PPWU4a1X2leE4ID9fxDOK+KxAMRuptkZTcR7GUQ==
@@ -14159,10 +14128,10 @@ testcafe-hammerhead@>=19.4.0:
     tunnel-agent "0.6.0"
     webauth "^1.1.0"
 
-testcafe-legacy-api@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-4.2.5.tgz#3f78c0aeb9bab0db495cbe4983347c76b107c641"
-  integrity sha512-QYCcX+w6NP3SxWnQEHDhODXPncaTl2IwMb2hWK+UxRLEUnoLBoyCj14/+nNINEQ9ogSkFp1zqgeuRcAtIzo+lg==
+testcafe-legacy-api@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-5.0.0.tgz#dde9dc2ee9e9490afed58b83df23cf2e01a6c303"
+  integrity sha512-Peb5NJLP7g6HTihMrrGKV7YnGvD6xw4eNPA7Fx44r1GzncuVY/fV1lIL0EQyr8uz0bS5+Hgr0fHSiZ/E4hCjeQ==
   dependencies:
     async "0.2.6"
     dedent "^0.6.0"
@@ -14210,9 +14179,9 @@ testcafe-reporter-xunit@^2.1.0:
   integrity sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=
 
 testcafe@^1.8.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.13.0.tgz#1ee3577ee2916c3c3316bf737b47e50146dfc65d"
-  integrity sha512-zJt+opIZ+JolTklgqVePBFGSSz6Ld6ySb/7AUUhMwJ+e8ob4P+eMjGjGosgMeCJIPHzDMFDqYfULTANi3CXsKw==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.14.0.tgz#cd267ba31ac8fe75fb1614e9f55084a8fd5422af"
+  integrity sha512-k2Cj7TYtIkraa+te9LB52VeiSWlA68KWm5A6Er37hf01Ke0XtloKLB7OlojJKrcMi/76fEaya6hCXMAHxSiQeA==
   dependencies:
     "@babel/core" "^7.12.1"
     "@babel/plugin-proposal-async-generator-functions" "^7.12.1"
@@ -14289,8 +14258,8 @@ testcafe@^1.8.1:
     source-map-support "^0.5.16"
     strip-bom "^2.0.0"
     testcafe-browser-tools "2.0.15"
-    testcafe-hammerhead "19.5.0"
-    testcafe-legacy-api "4.2.5"
+    testcafe-hammerhead "21.0.0"
+    testcafe-legacy-api "5.0.0"
     testcafe-reporter-json "^2.1.0"
     testcafe-reporter-list "^2.1.0"
     testcafe-reporter-minimal "^2.1.0"
@@ -14549,9 +14518,9 @@ tslib@^1.9.0, tslib@^1.9.3:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.1, tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -14779,9 +14748,9 @@ unist-util-remove-position@^2.0.0:
     unist-util-visit "^2.0.0"
 
 unist-util-remove@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-2.0.1.tgz#fa13c424ff8e964f3aa20d1098b9a690c6bfaa39"
-  integrity sha512-YtuetK6o16CMfG+0u4nndsWpujgsHDHHLyE0yGpJLLn5xSjKeyGyzEBOI2XbmoUHCYabmNgX52uxlWoQhcvR7Q==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-2.1.0.tgz#b0b4738aa7ee445c402fda9328d604a02d010588"
+  integrity sha512-J8NYPyBm4baYLdCbjmf1bhPu45Cr1MWTm77qd9istEkzWpnN6O9tMsEbB2JhNnBCqGENRqEWomQ+He6au0B27Q==
   dependencies:
     unist-util-is "^4.0.0"
 
@@ -15509,9 +15478,9 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
-  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.2.tgz#c504495ba9b59230dd60226d1dd89c3c0a1b745e"
+  integrity sha512-DnBDwcL54b5xWMM/7RfFg4xs5amYxq2ot49aUfLjQSAracXkGvlZq0txzqr3Pa6Q0ayuCxBcwTzrPUScKY0O8w==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds setSearch to be passed through to the `reset filters` This will ensure the search is clear when someone clicks `clearAll`
#### Where should the reviewer start?
lists
#### What testing has been done on this PR?
local
#### How should this be manually tested?
check to see if the search is cleared out 
#### Any background context you want to provide?

#### What are the relevant issues?
issue #1535 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible