### PR TITLE
Adjust paginated table to be template

### DIFF
--- a/aries-site/src/examples/components/pagination/PaginationTableExample.js
+++ b/aries-site/src/examples/components/pagination/PaginationTableExample.js
@@ -557,9 +557,9 @@ export const PaginationTableExample = () => {
             border: 'top',
             direction: 'row',
             fill: 'horizontal',
+            flex: false,
             justify: size !== 'small' ? 'end' : 'center',
             pad: { top: 'xsmall' },
-            flex: false,
           }}
           step={10}
           sortable

--- a/aries-site/src/examples/components/pagination/PaginationTableExample.js
+++ b/aries-site/src/examples/components/pagination/PaginationTableExample.js
@@ -559,6 +559,7 @@ export const PaginationTableExample = () => {
             fill: 'horizontal',
             justify: size !== 'small' ? 'end' : 'center',
             pad: { top: 'xsmall' },
+            flex: false,
           }}
           step={10}
           sortable

--- a/aries-site/src/pages/components/table.mdx
+++ b/aries-site/src/pages/components/table.mdx
@@ -234,6 +234,8 @@ With long sets of data, pagination can help to create a more efficient means of 
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/pagination/PaginationTableExample.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
+  height="auto"
 >
   <PaginationTableExample />
 </Example>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7960,8 +7960,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.1"
-  uid "2790f7faca7b1ae07cd025dce8e30d1a35fdd231"
-  resolved "https://github.com/grommet/grommet/tarball/stable#2790f7faca7b1ae07cd025dce8e30d1a35fdd231"
+  uid "3f32db834f5393a079a980513296241e2ebab9e2"
+  resolved "https://github.com/grommet/grommet/tarball/stable#3f32db834f5393a079a980513296241e2ebab9e2"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adjusts the way that the DS site renders the paginated table example so that it's considered a "template". This overrides the "align="center"" that gets applied to component examples (intended for smaller components to align nicely in the example region). Also adds a `flex: false` onto the pagination to ensure that it keeps its dimensions even as the window height shrinks.

#### Where should the reviewer start?
aries-site/src/pages/components/table.mdx

#### What testing has been done on this PR?
Tested locally in Fullscreen Mode. Shrink window height.

#### How should this be manually tested?
Saem as above.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #1548 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.