### PR TITLE
Fix Grid render on Safari

### DIFF
--- a/aries-site/src/examples/components/layouts/GridExample.js
+++ b/aries-site/src/examples/components/layouts/GridExample.js
@@ -2,31 +2,31 @@ import React from 'react';
 import { Box, Grid, Text } from 'grommet';
 
 export const GridExample = () => (
-    <Grid
-      rows={['xxsmall', 'flex', 'xxsmall']}
-      columns={['1/4', '3/4']}
-      areas={[
-        ['header', 'header'],
-        ['sidebar', 'main'],
-        ['footer', 'footer'],
-      ]}
-      gap="small"
-      fill
-    >
-      <Box background="green" gridArea="header" justify="center" pad="small">
-        <Text weight="bold">Header</Text>
-      </Box>
+  <Grid
+    rows={['xxsmall', 'flex', 'xxsmall']}
+    columns={['1/4', '3/4']}
+    areas={[
+      ['header', 'header'],
+      ['sidebar', 'main'],
+      ['footer', 'footer'],
+    ]}
+    gap="small"
+    fill
+  >
+    <Box background="green" gridArea="header" justify="center" pad="small">
+      <Text weight="bold">Header</Text>
+    </Box>
 
-      <Box background="yellow" gridArea="sidebar" pad="small">
-        <Text weight="bold">Sidebar</Text>
-      </Box>
+    <Box background="yellow" gridArea="sidebar" pad="small">
+      <Text weight="bold">Sidebar</Text>
+    </Box>
 
-      <Box background="blue" gridArea="main" pad="small">
-        <Text weight="bold">Main</Text>
-      </Box>
+    <Box background="blue" gridArea="main" pad="small">
+      <Text weight="bold">Main</Text>
+    </Box>
 
-      <Box background="green" gridArea="footer" justify="center" pad="small">
-        <Text weight="bold">Footer</Text>
-      </Box>
-    </Grid>
-  );
+    <Box background="green" gridArea="footer" justify="center" pad="small">
+      <Text weight="bold">Footer</Text>
+    </Box>
+  </Grid>
+);

--- a/aries-site/src/pages/components/grid.mdx
+++ b/aries-site/src/pages/components/grid.mdx
@@ -6,6 +6,8 @@ import { GridExample } from '../../examples';
   figma="https://www.figma.com/file/OvLyDPjqHbwoDI97r2nD8j/HPE-Grid-Component?node-id=177%3A12"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/layouts/GridExample.js"
   width="100%"
+  showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <GridExample />
 </Example>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7960,8 +7960,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.1"
-  uid "2790f7faca7b1ae07cd025dce8e30d1a35fdd231"
-  resolved "https://github.com/grommet/grommet/tarball/stable#2790f7faca7b1ae07cd025dce8e30d1a35fdd231"
+  uid "3f32db834f5393a079a980513296241e2ebab9e2"
+  resolved "https://github.com/grommet/grommet/tarball/stable#3f32db834f5393a079a980513296241e2ebab9e2"
   dependencies:
     grommet-icons "^4.5.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the way Grid example renders to stay within Example bounds. Leverages `template` prop to allow Grid to take a bigger height so the dimensions match the app-type grid it's demoing. 

Also only showing "Laptop" and "Mobile" responsive controls since nothing was changing between laptop and desktop.

#### Where should the reviewer start?
aries-site/src/pages/components/grid.mdx

#### What testing has been done on this PR?
tested locally on Safari, Firefox, and Chrome.

#### How should this be manually tested?
check deploy.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #1563 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.