### PR TITLE
Fixed content policy to allow global headers scripts on FF and Safari

### DIFF
--- a/aries-site/src/components/seo/Meta.js
+++ b/aries-site/src/components/seo/Meta.js
@@ -96,7 +96,7 @@ export const Meta = ({ title, description, canonicalUrl, socialImageUrl }) => {
         connect-src 'self' *.githubusercontent.com/grommet/hpe-design-system/ https://www.google-analytics.com https://www.github.com/grommet/ https://eyes.applitools.com *.hpe.com/hpe/api/;
         media-src 'self' https://d3hq6blov2iije.cloudfront.net/media/HPE+Design+System-v3.mp4;
         img-src 'self' https://www.google-analytics.com https://images.unsplash.com/ http://s.gravatar.com/avatar/ *.hpe.com/hfws-static/5/;
-        script-src-elem 'self' *.hpe.com https://www.google-analytics.com/analytics.js;
+        script-src 'self' *.hpe.com https://www.google-analytics.com/analytics.js;
         font-src *.hpe.com hpefonts.s3.amazonaws.com https://d3hq6blov2iije.cloudfront.net/fonts/;
         object-src 'none';"
       />


### PR DESCRIPTION
#### What does this PR do?
Changed the Content-Security-Policy to use scripts-src instead of scripts-src-elem to whitelist scripts from the global header and google analytics. Firefox and Safari don't recognize scripts-src-elem.

#### Where should the reviewer start?
Meta.js

#### What testing has been done on this PR?
FF, Chrome and Firefox.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #1610 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
