### PR TITLE
Add aria-describedBy to the DataTable examples

### DIFF
--- a/aries-site/src/examples/components/pagination/PaginationTableExample.js
+++ b/aries-site/src/examples/components/pagination/PaginationTableExample.js
@@ -541,11 +541,16 @@ export const PaginationTableExample = () => {
 
   return (
     <Box pad="small">
-      <Heading level={3} margin={{ bottom: 'small', top: 'none' }}>
+      <Heading
+        id="storage-pools-heading"
+        level={3}
+        margin={{ bottom: 'small', top: 'none' }}
+      >
         Storage Pools
       </Heading>
       <Box>
         <DataTable
+          aria-describedby="storage-pools-heading"
           data={data}
           columns={[
             {

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -294,11 +294,16 @@ export const TableExample = () => {
 
   return (
     <>
-      <Heading level={3} margin={{ bottom: 'small', top: 'none' }}>
+      <Heading
+        id="storage-pools-heading"
+        level={3}
+        margin={{ bottom: 'small', top: 'none' }}
+      >
         Storage Pools
       </Heading>
       <Box height="medium" overflow="auto">
         <DataTable
+          aria-describedby="storage-pools-heading"
           data={data}
           columns={[
             {

--- a/aries-site/src/examples/components/table/TableFixedHeaderExample.js
+++ b/aries-site/src/examples/components/table/TableFixedHeaderExample.js
@@ -228,19 +228,28 @@ const columns = [
 ];
 
 export const TableFixedHeaderExample = () => (
-    <>
-      <Heading level={3} margin={{ bottom: 'medium', top: 'none' }}>
-        Connected Devices
-      </Heading>
-      <Box
-        align="start"
-        // restricting height to demonstrate pinned header behavior
-        height="medium"
-        // restricting width to demonstrate pinned column behavior
-        width={{ min: 'medium', max: 'large' }}
-        overflow="auto"
-      >
-        <DataTable data={data} columns={columns} pin />
-      </Box>
-    </>
-  );
+  <>
+    <Heading
+      id="connected-heading"
+      level={3}
+      margin={{ bottom: 'medium', top: 'none' }}
+    >
+      Connected Devices
+    </Heading>
+    <Box
+      align="start"
+      // restricting height to demonstrate pinned header behavior
+      height="medium"
+      // restricting width to demonstrate pinned column behavior
+      width={{ min: 'medium', max: 'large' }}
+      overflow="auto"
+    >
+    <DataTable
+      aria-describedby="connected-heading"
+      data={data}
+      columns={columns}
+      pin
+    />
+    </Box>
+  </>
+);

--- a/aries-site/src/examples/components/table/TableMultiSelectExample.js
+++ b/aries-site/src/examples/components/table/TableMultiSelectExample.js
@@ -232,12 +232,13 @@ export const TableMultiSelectExample = () => {
 
   return (
     <>
-      <Heading level={3} margin="none">
+      <Heading id="orders-heading" level={3} margin="none">
         Manage Orders
       </Heading>
       <TableControls selected={selected} />
       <Box height={{ max: 'large' }} overflow="auto">
         <DataTable
+          aria-describedby="orders-heading"
           data={data}
           primaryKey="id"
           columns={[

--- a/aries-site/src/examples/components/table/TableResizeColumnsExample.js
+++ b/aries-site/src/examples/components/table/TableResizeColumnsExample.js
@@ -174,18 +174,28 @@ const columns = [
 ];
 
 export const TableResizeColumnsExample = () => (
-    <>
-      <Heading level={3} margin={{ bottom: 'medium', top: 'none' }}>
-        Contact Information
-      </Heading>
-      <Box
-        align="start"
-        // restricting height to demonstrate pinned header behavior
-        height="medium"
-        overflow="auto"
-        fill="horizontal"
-      >
-        <DataTable data={data} columns={columns} pin resizeable />
-      </Box>
-    </>
-  );
+         <>
+           <Heading
+             id="contact-info-heading"
+             level={3}
+             margin={{ bottom: 'medium', top: 'none' }}
+           >
+             Contact Information
+           </Heading>
+           <Box
+             align="start"
+             // restricting height to demonstrate pinned header behavior
+             height="medium"
+             overflow="auto"
+             fill="horizontal"
+           >
+             <DataTable
+               aria-describedby="contact-info-heading"
+               data={data}
+               columns={columns}
+               pin
+               resizeable
+             />
+           </Box>
+         </>
+       );

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -222,11 +222,16 @@ export const TableSingleSelectExample = () => {
 
   return !pageDetails.id ? (
     <>
-      <Heading level={3} margin={{ bottom: 'small', top: 'none' }}>
+      <Heading
+        id="orders-heading"
+        level={3}
+        margin={{ bottom: 'small', top: 'none' }}
+      >
         Orders
       </Heading>
       <Box overflow="auto">
         <DataTable
+          aria-describedby="orders-heading"
           data={data}
           columns={[
             { property: 'id', header: 'Id', pin: size === 'small' },

--- a/aries-site/src/examples/components/table/TableSortable.js
+++ b/aries-site/src/examples/components/table/TableSortable.js
@@ -154,11 +154,16 @@ export const TableSortable = () => {
 
   return (
     <>
-      <Heading level={3} margin={{ bottom: 'small', top: 'none' }}>
+      <Heading
+        id="sortable-heading"
+        level={3}
+        margin={{ bottom: 'small', top: 'none' }}
+      >
         Sortable Items
       </Heading>
       <Box align="start" margin={{ right: 'auto' }} overflow="auto">
         <DataTable
+          aria-describedby="sortable-heading"
           data={formatData(data)}
           columns={[
             {

--- a/aries-site/src/examples/components/table/TableSummaryExample.js
+++ b/aries-site/src/examples/components/table/TableSummaryExample.js
@@ -121,7 +121,11 @@ export const TableSummaryExample = () => {
 
   return (
     <>
-      <Heading level={3} margin={{ bottom: 'small', top: 'none' }}>
+      <Heading
+        id="service-adoption-heading"
+        level={3}
+        margin={{ bottom: 'small', top: 'none' }}
+      >
         Service Adoption
       </Heading>
       <Box
@@ -131,6 +135,7 @@ export const TableSummaryExample = () => {
         overflow="auto"
       >
         <DataTable
+          aria-describedby="service-adoption-heading"
           data={enhancedData}
           columns={[
             {

--- a/aries-site/src/examples/templates/filtering/FilteringTable/FilteringTable.js
+++ b/aries-site/src/examples/templates/filtering/FilteringTable/FilteringTable.js
@@ -43,7 +43,7 @@ export const FilteringTable = () => {
 
   return (
     <Box background="background-front" pad="small" gap="medium" fill>
-      <Heading level={2} margin="none">
+      <Heading id="servers-heading" level={2} margin="none">
         Servers
       </Heading>
       <FiltersProvider>
@@ -102,6 +102,7 @@ const ServerResults = () => {
   return (
     <Box height="medium" overflow="auto">
       <DataTable
+        aria-describedby="servers-heading"
         data={filteredResults}
         columns={[
           {

--- a/aries-site/src/examples/templates/table-customization/components/TableCustomizationExample.js
+++ b/aries-site/src/examples/templates/table-customization/components/TableCustomizationExample.js
@@ -102,7 +102,7 @@ export const TableCustomizationExample = () => {
       <FiltersProvider>
         <Header pad={{ top: 'medium' }}>
           <Box gap="xsmall" fill="horizontal">
-            <Heading level={2} margin="none">
+            <Heading id="users-heading" level={2} margin="none">
               Users
             </Heading>
             <Box direction="row" justify="between">
@@ -144,6 +144,7 @@ const Results = ({ columns }) => {
   return (
     <Box fill overflow="auto">
       <DataTable
+        aria-describedby="users-heading"
         data={filteredResults}
         background="background"
         columns={columns}

--- a/aries-site/src/pages/components/table.mdx
+++ b/aries-site/src/pages/components/table.mdx
@@ -218,6 +218,17 @@ Wrapping should be used when:
 - The entirety of the content must be available at all times.
 - Long numerical values need to be displayed.
 
+### Accessibility
+
+To ensure screen readers are able to associate a page heading with a given table, apply an `id` to the Heading and `aria-describedBy` to the DataTable, where the same string value is applied to both attributes. When a screen reader reaches the table, it will announce the Heading content which provides the user with better context about the table data and purpose.
+
+For example, if on the Heading you apply `id="storage-pools-heading"`, on the DataTable you would apply `aria-describedBy="storage-pools-heading"`. In this example, the screen reader would properly associate "Storage Pools" as the description for the table.
+
+```
+<Heading id="storage-pools-heading">Storage Pools</Heading>
+<DataTable aria-describedBy="storage-pools-heading" />
+```
+
 ## Table behaviors & actions
 
 ### Sorting


### PR DESCRIPTION

#### What does this PR do?
This change helps screen readers identify the contents of a table by linking the heading for the table to table itself. This is one of the alternatives from the [WAI table recommendations](https://www.w3.org/WAI/tutorials/tables/caption-summary/).

#### Where should the reviewer start?
TableExample.js

#### What testing has been done on this PR?
Tested with NVDA screen reader

#### How should this be manually tested?
Visit the Table component and filtering example pages with a screenreader enabled like NVDA, JAWS or VoiceOver.

#### Any background context you want to provide?
This is intended to help developers that copy these examples address accessibility as well.

#### What are the relevant issues?
Fixes #1683 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
Not necessary

#### Is this change backwards compatible or is it a breaking change?
