### PR TITLE
Add formatting for table related elements in markdown

### DIFF
--- a/aries-site/src/components/content/MarkdownComponents.js
+++ b/aries-site/src/components/content/MarkdownComponents.js
@@ -85,21 +85,33 @@ export const components = {
   ),
   table: props => (
     <Box align="start" width={{ max: 'xlarge' }}>
-      <Box background="background-front" pad="medium" round="xxsmall">
+      <Box
+        background="background-front"
+        pad={{ horizontal: 'medium', top: 'medium', bottom: 'large' }}
+        round="xxsmall"
+      >
         <Table {...props} />
       </Box>
     </Box>
   ),
   tbody: props => <TableBody {...props} />,
   thead: props => <TableHeader {...props} />,
-  td: props => <TableCell verticalAlign="top" {...props} />,
+  td: props => (
+    <TableCell
+      border={{ side: 'bottom', color: 'border-weak' }}
+      verticalAlign="top"
+      {...props}
+    />
+  ),
   th: props => (
     <TableCell
       scope="col"
       pad={{ horizontal: 'small', vertical: 'xsmall' }}
       {...props}
     >
-      <Text weight="bold">{props.children}</Text>
+      <Text color="text-strong" weight="bold">
+        {props.children}
+      </Text>
     </TableCell>
   ),
   tr: props => <TableRow {...props} />,

--- a/aries-site/src/components/content/MarkdownComponents.js
+++ b/aries-site/src/components/content/MarkdownComponents.js
@@ -1,7 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
-import { Anchor, Box, Heading, Paragraph } from 'grommet';
+import {
+  Anchor,
+  Box,
+  Heading,
+  Paragraph,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Text,
+} from 'grommet';
 
 import { SubsectionHeader } from '../../layouts';
 import { SubsectionText } from '.';
@@ -72,8 +83,32 @@ export const components = {
       fill="horizontal"
     />
   ),
+  table: props => (
+    <Box align="start" width={{ max: 'xlarge' }}>
+      <Box background="background-front" pad="medium" round="xxsmall">
+        <Table {...props} />
+      </Box>
+    </Box>
+  ),
+  tbody: props => <TableBody {...props} />,
+  thead: props => <TableHeader {...props} />,
+  td: props => <TableCell verticalAlign="top" {...props} />,
+  th: props => (
+    <TableCell
+      scope="col"
+      pad={{ horizontal: 'small', vertical: 'xsmall' }}
+      {...props}
+    >
+      <Text weight="bold">{props.children}</Text>
+    </TableCell>
+  ),
+  tr: props => <TableRow {...props} />,
 };
 
 components.a.propTypes = {
   href: PropTypes.string.isRequired,
+};
+
+components.th.propTypes = {
+  children: PropTypes.node,
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds formatting for html table elements in markdown.

#### Where should the reviewer start?

`MarkdownComponent.js`

#### What testing has been done on this PR?

local

#### How should this be manually tested?

local, add a table to an `.mdx` page such as:
```


| Voice                         | Tone                                        |
| ----------------------------- | ------------------------------------------- |
| Who they hear		              | What they hear                              |
| Personality		                | Attitude                                    |
| How you are doing the writing	| Who they hear                               |
| Style		                      | How your message comes across               |
| What makes us uniquely us		  | How we communicate to our specific audience |

```

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/pull/1720

#### Screenshots (if appropriate)

![Screen Shot 2021-07-13 at 1 51 22 PM](https://user-images.githubusercontent.com/1756948/125532467-488591ee-4a4b-48d5-8c41-8c3c80e56845.png)
![Screen Shot 2021-07-13 at 1 51 58 PM](https://user-images.githubusercontent.com/1756948/125532474-c54f66ac-171c-41e8-99de-780d802b0159.png)



#### Should this PR be mentioned in Design System updates?

no

#### Is this change backwards compatible or is it a breaking change?

backwards
