### PR TITLE
Update form example headings

### DIFF
--- a/aries-site/src/examples/templates/forms/ChangePasswordExample.js
+++ b/aries-site/src/examples/templates/forms/ChangePasswordExample.js
@@ -5,8 +5,8 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   ResponsiveContext,
-  Text,
   TextInput,
 } from 'grommet';
 
@@ -50,9 +50,14 @@ export const ChangePasswordExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Change Password
-        </Text>
+        </Heading>
       </Header>
       <Box
         // Padding used to prevent focus from being cutoff

--- a/aries-site/src/examples/templates/forms/CustomizeExample.js
+++ b/aries-site/src/examples/templates/forms/CustomizeExample.js
@@ -6,6 +6,7 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   RadioButtonGroup,
   ResponsiveContext,
   Text,
@@ -28,9 +29,14 @@ export const CustomizeExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Customize
-        </Text>
+        </Heading>
         <Text>your HPE Edgeline Server </Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/FilterExample.js
+++ b/aries-site/src/examples/templates/forms/FilterExample.js
@@ -5,8 +5,8 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   Select,
-  Text,
   TextInput,
 } from 'grommet';
 
@@ -54,9 +54,14 @@ export const FilterExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Filter
-        </Text>
+        </Heading>
       </Header>
       <Box
         // Padding used to prevent focus from being cutoff

--- a/aries-site/src/examples/templates/forms/PayExample.js
+++ b/aries-site/src/examples/templates/forms/PayExample.js
@@ -6,6 +6,7 @@ import {
   FormField,
   MaskedInput,
   Header,
+  Heading,
   Text,
   TextInput,
   ResponsiveContext,
@@ -102,9 +103,14 @@ export const PayExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Pay
-        </Text>
+        </Heading>
         <Text>for your HPE products</Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
+++ b/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
@@ -7,6 +7,7 @@ import {
   FormField,
   FileInput,
   Header,
+  Heading,
   Select,
   ResponsiveContext,
   Text,
@@ -48,9 +49,14 @@ export const RequiredFieldsExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
-          Form Header
-        </Text>
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
+          Form Heading
+        </Heading>
       </Header>
       <Box
         // Padding used to prevent focus from being cutoff

--- a/aries-site/src/examples/templates/forms/SettingsExample.js
+++ b/aries-site/src/examples/templates/forms/SettingsExample.js
@@ -6,6 +6,7 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   RangeInput,
   ResponsiveContext,
   Text,
@@ -33,9 +34,14 @@ export const SettingsExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Settings
-        </Text>
+        </Heading>
         <Text>for HPE Service</Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/ShippingExample.js
+++ b/aries-site/src/examples/templates/forms/ShippingExample.js
@@ -6,6 +6,7 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   MaskedInput,
   ResponsiveContext,
   Select,
@@ -182,9 +183,14 @@ export const ShippingExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Shipping
-        </Text>
+        </Heading>
         <Text>for your HPE products</Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -8,6 +8,7 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   Layer,
   ResponsiveContext,
   Text,
@@ -136,9 +137,14 @@ export const SignInExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Sign In
-        </Text>
+        </Heading>
         <Text>to Hewlett Packard Enterprise</Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -8,6 +8,7 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   MaskedInput,
   Text,
   TextInput,
@@ -114,9 +115,14 @@ export const SignUpExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Sign Up
-        </Text>
+        </Heading>
         <Text>for a Hewlett Packard Enterprise account</Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -8,6 +8,7 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   MaskedInput,
   Text,
   TextInput,
@@ -114,9 +115,14 @@ export const SimpleSignUpExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Sign Up
-        </Text>
+        </Heading>
         <Text>for a Hewlett Packard Enterprise account</Text>
       </Header>
       <Box

--- a/aries-site/src/examples/templates/forms/SortExample.js
+++ b/aries-site/src/examples/templates/forms/SortExample.js
@@ -4,9 +4,9 @@ import {
   Form,
   FormField,
   Header,
+  Heading,
   RadioButtonGroup,
   Select,
-  Text,
 } from 'grommet';
 
 const sortFeatures = ['Featured', 'Price', 'Users'];
@@ -34,9 +34,14 @@ export const SortExample = () => {
         gap="xxsmall"
         pad={{ horizontal: 'xxsmall' }}
       >
-        <Text size="xxlarge" weight="bold">
+        {/* Use semantically correct heading level and adjust size as 
+        needed. In this instance, this example is presented within an 
+        HTML section element and this is the first heading within the 
+        section, therefor h2 is the semantically correct heading. For 
+        additional detail, see https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels). */}
+        <Heading level={2} margin="none">
           Sort
-        </Text>
+        </Heading>
       </Header>
       <Box
         // Padding used to prevent focus from being cutoff

--- a/aries-site/src/pages/templates/forms.mdx
+++ b/aries-site/src/pages/templates/forms.mdx
@@ -107,7 +107,7 @@ All Form input elements need to be contained within a FormField.
   <SignUpExample />
 </Example>
 
-## Sign in
+## Sign In
 
 <Example
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/forms/SignInExample.js"

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -52,6 +52,10 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 
 <!-- BEGIN: What's New Entries -->
 
+## July 26-30, 2021
+
+- Updated Form examples on Design System site [to use semantically correct headings and font color](/templates/forms).
+
 ## June 14-18, 2021
 
 - Released grommet-icons v4.6.0! Check out the [Release Notes](https://github.com/grommet/grommet-icons/releases/tag/v4.6.0).


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

[Preview](https://deploy-preview-1746--keen-mayer-a86c8b.netlify.app/templates/forms)

#### What does this PR do?

- Applies `<Heading />` to all form titles.
- Includes code comment instructing implementors to use semantically correct heading level.
- Minor cleanups.

#### Where should the reviewer start?

/templates/forms

#### What testing has been done on this PR?

- Manual
- Test suite

#### How should this be manually tested?

- View [preview](https://deploy-preview-1746--keen-mayer-a86c8b.netlify.app/templates/forms) in light/dark modes.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes https://github.com/grommet/hpe-design-system/issues/1739

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

Yes, add to what's new.

#### Is this change backwards compatible or is it a breaking change?

Backwards
