### PR TITLE
Remove supporting color guidance paragraph

### DIFF
--- a/aries-site/src/pages/foundation/color.js
+++ b/aries-site/src/pages/foundation/color.js
@@ -73,12 +73,6 @@ const Color = () => (
                 System color palette over Brand Central when identifying colors
                 for your app or web based experience.
               </SubsectionText>
-              <SubsectionText>
-                The HPE Design System team is working with HPE Brand to ensure
-                that the Brand Central color palettes (like ‘secondary colors’)
-                are updated to meet ADA accessibility and color contrast levels
-                in a large variety of user contexts.
-              </SubsectionText>
               <ButtonRow>
                 <Button
                   href="https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/hpe-design-system-library-color"


### PR DESCRIPTION
Simplifying the introduction to focus users on the language further down the page that tackles it more specifically. This helps better position the DS on HPE BrandCentral.   

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes some copy that was identified as ambiguous by HPE BrandCentral.

#### Where should the reviewer start?
Line 76

#### What testing has been done on this PR?
None!

#### How should this be manually tested?
Visually. 😁

#### Any background context you want to provide?
Just trying to get this linked to other HPE sites.

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
![Screen Shot 2021-08-03 at 10 41 04 AM](https://user-images.githubusercontent.com/1753301/128061802-3bef2a10-f749-48ef-bffd-8a9501cbe13f.png)

#### Should this PR be mentioned in Design System updates?
Nah.

#### Is this change backwards compatible or is it a breaking change?
I hope its doable, but I know this is a tricky one. It might break a lot of things! 😳