### PR TITLE
fix status-indicator links & linting errors

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -355,7 +355,7 @@ export const components = [
   {
     name: 'Notification',
     category: 'Visualizations',
-    description: `Notifications deliver transparent clarity for task and system statuses.`,
+    description: 'Notifications deliver transparent clarity for task and system statuses.',
     preview: {
       image: {
         src: {

--- a/aries-site/src/data/structures/templates.js
+++ b/aries-site/src/data/structures/templates.js
@@ -1,4 +1,7 @@
-import { StatusIndicatorPreview, ToastPreview } from '../../examples/cardPreviews';
+import {
+  StatusIndicatorPreview,
+  ToastPreview,
+} from '../../examples/cardPreviews';
 
 export const templates = [
   {
@@ -243,12 +246,16 @@ export const templates = [
   {
     name: 'Status Indicator',
     available: true,
-    description: 'Quickly provide peace-of-mind or call attention to items requiring a user\'s action.',
+    description: `Quickly provide peace-of-mind or call attention to items 
+      requiring a user's action.`,
     preview: {
       component: () => <StatusIndicatorPreview />,
       background: 'background-front',
     },
-    seoDescription: 'Highlight notification messages and alerts which require a user\'s attention. Status indicators provide peace-of-mind when all is well or call attention to items when a user needs to take action',
+    seoDescription: `Highlight notification messages and alerts which 
+      require a user's attention. Status indicators provide peace-of-mind 
+      when all is well or call attention to items when a user needs to take 
+      action`,
     relatedContent: ['Notification', 'Toast Notifications', 'Stack'],
     sections: [],
   },
@@ -276,14 +283,16 @@ export const templates = [
   {
     name: 'Toast Notifications',
     available: true,
-    description: `Toast notifications are used to communicate low severity level 
-    information to users in an unobtrusive way.`,
+    description: `Toast notifications are used to communicate low severity 
+      level information to users in an unobtrusive way.`,
     preview: {
-      component: () => <ToastPreview card title="Hooray" message="Your toast is done!" />,
+      component: () => (
+        <ToastPreview card title="Hooray" message="Your toast is done!" />
+      ),
       background: 'background-back',
     },
-    seoDescription: `Toast notifications are used to communicate low severity level 
-    information to users in an unobtrusive way.`,
+    seoDescription: `Toast notifications are used to communicate low 
+    severity level information to users in an unobtrusive way.`,
     sections: [],
     relatedContent: ['Notification', 'Status Indicator', 'Stack'],
   },

--- a/aries-site/src/examples/cardPreviews/status-indicator.js
+++ b/aries-site/src/examples/cardPreviews/status-indicator.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import { StatusGoodSmall } from 'grommet-icons/icons/StatusGoodSmall';
 import { StatusWarningSmall } from 'grommet-icons/icons/StatusWarningSmall';
 import { StatusCriticalSmall } from 'grommet-icons/icons/StatusCriticalSmall';
@@ -7,33 +9,39 @@ import { StatusUnknownSmall } from 'grommet-icons/icons/StatusUnknownSmall';
 import { Box } from 'grommet';
 
 export const StatusIndicatorPreview = () => (
-    <Box align="center" justify="center" fill background="background-back">
-        <Box direction="row" gap="small">
-            <StatusGoodSmall color="status-ok" />
-            <StatusWarningSmall color="status-warning" />
-            <StatusCriticalSmall color="status-critical" />
-            <StatusUnknownSmall color="status-unknown" />
-        </Box>
+  <Box align="center" justify="center" fill background="background-back">
+    <Box direction="row" gap="small">
+      <StatusGoodSmall color="status-ok" />
+      <StatusWarningSmall color="status-warning" />
+      <StatusCriticalSmall color="status-critical" />
+      <StatusUnknownSmall color="status-unknown" />
     </Box>
+  </Box>
 );
 
-export const StatusBox = ({toast}) => (
-    <Box direction="row" gap="large" pad={{bottom: 'medium'}}>
-        <Box align="center">
-            <StatusGoodSmall color="status-ok" />
-            Normal
-        </Box>
-        <Box align="center">
-            <StatusWarningSmall color="status-warning" />
-            Warning
-        </Box>
-        {!toast && <Box align="center">
-            <StatusCriticalSmall color="status-critical" />
-            Critical
-        </Box>}
-        <Box align="center">
-            <StatusUnknownSmall color="status-unknown" />
-            Unknown
-        </Box>
+export const StatusBox = ({ toast }) => (
+  <Box direction="row" gap="large" pad={{ bottom: 'medium' }}>
+    <Box align="center">
+      <StatusGoodSmall color="status-ok" />
+      Normal
     </Box>
+    <Box align="center">
+      <StatusWarningSmall color="status-warning" />
+      Warning
+    </Box>
+    {!toast && (
+      <Box align="center">
+        <StatusCriticalSmall color="status-critical" />
+        Critical
+      </Box>
+    )}
+    <Box align="center">
+      <StatusUnknownSmall color="status-unknown" />
+      Unknown
+    </Box>
+  </Box>
 );
+
+StatusBox.propTypes = {
+  toast: PropTypes.bool,
+};

--- a/aries-site/src/examples/cardPreviews/toast-notification.js
+++ b/aries-site/src/examples/cardPreviews/toast-notification.js
@@ -39,7 +39,7 @@ export const ToastPreview = ({ card, message, title }) => (
 );
 
 ToastPreview.propTypes = {
-  card: PropTypes.string,
+  card: PropTypes.boolean,
   message: PropTypes.string,
   title: PropTypes.string,
 };

--- a/aries-site/src/examples/cardPreviews/toast-notification.js
+++ b/aries-site/src/examples/cardPreviews/toast-notification.js
@@ -1,17 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { StatusGoodSmall } from 'grommet-icons/icons/StatusGoodSmall';
 import { FormClose } from 'grommet-icons/icons/FormClose';
 
 import { Box, Text } from 'grommet';
 
-export const ToastPreview = ({card, message, title}) => (
+export const ToastPreview = ({ card, message, title }) => (
   <Box background="background-back">
-    <Box 
-      elevation="medium" 
-      round="xsmall" 
+    <Box
+      elevation="medium"
+      round="xsmall"
       width={card ? null : 'medium'}
-      pad={{ horizontal: 'small', vertical: 'xsmall' }} 
+      pad={{ horizontal: 'small', vertical: 'xsmall' }}
       background={{ color: 'background-front' }}
     >
       <Box direction="row">
@@ -27,7 +28,7 @@ export const ToastPreview = ({card, message, title}) => (
           fill
         >
           <Box>
-            <Text weight="bold" >{title}</Text>
+            <Text weight="bold">{title}</Text>
             <Text>{message}</Text>
           </Box>
           <FormClose id="close-button" />
@@ -36,3 +37,9 @@ export const ToastPreview = ({card, message, title}) => (
     </Box>
   </Box>
 );
+
+ToastPreview.propTypes = {
+  card: PropTypes.string,
+  message: PropTypes.string,
+  title: PropTypes.string,
+};

--- a/aries-site/src/examples/components/notifications/StateVsStatusDiagram.js
+++ b/aries-site/src/examples/components/notifications/StateVsStatusDiagram.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ToastPreview } from '../../../examples/cardPreviews';
 import { Box, Text, Diagram, Stack } from 'grommet';
+import { ToastPreview } from '../../cardPreviews';
 
 const color = 'text-strong';
 const anchor = 'vertical';
@@ -8,37 +8,37 @@ const thickness = 'xxxsmall';
 const type = 'rectilinear';
 
 const connections = [
-    {
-        anchor,
-        type,
-        color,
-        thickness,
-        fromTarget: '1',
-        toTarget: 'status-indicator',
-    },
-    {
-        anchor,
-        type,
-        color,
-        thickness,
-        fromTarget: '2',
-        toTarget: 'content',
-    },
+  {
+    anchor,
+    type,
+    color,
+    thickness,
+    fromTarget: '1',
+    toTarget: 'status-indicator',
+  },
+  {
+    anchor,
+    type,
+    color,
+    thickness,
+    fromTarget: '2',
+    toTarget: 'content',
+  },
 ];
 
 export const StateVsStatusDiagram = () => (
-    <Stack>
-        <Box gap="medium" pad={{bottom: 'medium'}}>
-        <Box gap="large">
-            <Box id="2" pad="small" width="small" background="background-front">
-                <Text>The state of this task is successful</Text>
-            </Box>
-            <ToastPreview title="Invitation sent to user!" onClose />
-            <Box id="1" pad="small" width="small" background="background-front">
-                <Text>The status is normal because the state is successful</Text>
-            </Box>
+  <Stack>
+    <Box gap="medium" pad={{ bottom: 'medium' }}>
+      <Box gap="large">
+        <Box id="2" pad="small" width="small" background="background-front">
+          <Text>The state of this task is successful</Text>
         </Box>
+        <ToastPreview title="Invitation sent to user!" onClose />
+        <Box id="1" pad="small" width="small" background="background-front">
+          <Text>The status is normal because the state is successful</Text>
         </Box>
-        <Diagram connections={connections} />
-    </Stack>
+      </Box>
+    </Box>
+    <Diagram connections={connections} />
+  </Stack>
 );

--- a/aries-site/src/examples/components/notifications/TaxonomyTable.js
+++ b/aries-site/src/examples/components/notifications/TaxonomyTable.js
@@ -2,139 +2,167 @@ import React from 'react';
 import { Box, DataTable, Text } from 'grommet';
 
 const data = [
-    {
-        type: 'Information',
-        state: 'In-Progress',
-        status: 'Critical',
-        attentionLevel: 'High',
-        actions: 'Dismiss',
-        persistence: 'Dismissable',
-        placement: 'Banner',
-        insight: 'Support',
-    },
-    {
-        type: 'Task',
-        state: 'Starting',
-        status: 'Normal',
-        attentionLevel: 'Medium',
-        actions: 'Read',
-        persistence: 'Clearable',
-        placement: 'Browser',
-        insight: 'Progress Update',
-    },
-    {
-        type: 'Event',
-        state: 'Stopped',
-        status: 'Warning',
-        attentionLevel: 'Low',
-        actions: 'Unread',
-        persistence: 'Action Required',
-        placement: 'Email',
-        insight: 'Status/Task Tracking',
-    },
-    {
-        type: '',
-        state: 'Pending',
-        status: 'Unknown',
-        attentionLevel: '',
-        actions: 'Yes',
-        persistence: 'Temporary',
-        placement: 'Toast',
-        insight: 'Created',
-    },
-    {
-        type: '',
-        state: 'Success',
-        status: '',
-        attentionLevel: '',
-        actions: 'No',
-        persistence: '',
-        placement: 'Bell',
-        insight: 'Request Received',
-    },
-    {
-        type: '',
-        state: 'Failure',
-        status: '',
-        attentionLevel: '',
-        actions: '',
-        persistence: '',
-        placement: 'Badging',
-        insight: '',
-    },
-    {
-        type: '',
-        state: '',
-        status: '',
-        attentionLevel: '',
-        actions: '',
-        persistence: '',
-        placement: 'System',
-        insight: '',
-    },
-    {
-        type: '',
-        state: '',
-        status: '',
-        attentionLevel: '',
-        actions: '',
-        persistence: '',
-        placement: 'Global',
-        insight: '',
-    },
-    {
-        type: '',
-        state: '',
-        status: '',
-        attentionLevel: '',
-        actions: '',
-        persistence: '',
-        placement: 'Inline',
-        insight: '',
-    },
+  {
+    type: 'Information',
+    state: 'In-Progress',
+    status: 'Critical',
+    attentionLevel: 'High',
+    actions: 'Dismiss',
+    persistence: 'Dismissable',
+    placement: 'Banner',
+    insight: 'Support',
+  },
+  {
+    type: 'Task',
+    state: 'Starting',
+    status: 'Normal',
+    attentionLevel: 'Medium',
+    actions: 'Read',
+    persistence: 'Clearable',
+    placement: 'Browser',
+    insight: 'Progress Update',
+  },
+  {
+    type: 'Event',
+    state: 'Stopped',
+    status: 'Warning',
+    attentionLevel: 'Low',
+    actions: 'Unread',
+    persistence: 'Action Required',
+    placement: 'Email',
+    insight: 'Status/Task Tracking',
+  },
+  {
+    type: '',
+    state: 'Pending',
+    status: 'Unknown',
+    attentionLevel: '',
+    actions: 'Yes',
+    persistence: 'Temporary',
+    placement: 'Toast',
+    insight: 'Created',
+  },
+  {
+    type: '',
+    state: 'Success',
+    status: '',
+    attentionLevel: '',
+    actions: 'No',
+    persistence: '',
+    placement: 'Bell',
+    insight: 'Request Received',
+  },
+  {
+    type: '',
+    state: 'Failure',
+    status: '',
+    attentionLevel: '',
+    actions: '',
+    persistence: '',
+    placement: 'Badging',
+    insight: '',
+  },
+  {
+    type: '',
+    state: '',
+    status: '',
+    attentionLevel: '',
+    actions: '',
+    persistence: '',
+    placement: 'System',
+    insight: '',
+  },
+  {
+    type: '',
+    state: '',
+    status: '',
+    attentionLevel: '',
+    actions: '',
+    persistence: '',
+    placement: 'Global',
+    insight: '',
+  },
+  {
+    type: '',
+    state: '',
+    status: '',
+    attentionLevel: '',
+    actions: '',
+    persistence: '',
+    placement: 'Inline',
+    insight: '',
+  },
 ];
 
 export const columns = [
-    {
-        property: 'type',
-        header: <Text color="text-strong" weight="bold">Type</Text>,
-    },
-    {
-        property: 'state',
-        header: <Text color="text-strong" weight="bold">State</Text>,
-    },
-    {
-        property: 'status',
-        header: <Text color="text-strong" weight="bold">Status</Text>,
-    },
-    {
-        property: 'attentionLevel',
-        header: <Text color="text-strong" weight="bold">Attention Level</Text>,
-    },
-    {
-        property: 'actions',
-        header: <Text color="text-strong" weight="bold">Actions</Text>,
-    },
-    {
-        property: 'persistence',
-        header: <Text color="text-strong" weight="bold">Persistence</Text>,
-    },
-    {
-        property: 'placement',
-        header: <Text color="text-strong" weight="bold">Placement</Text>,
-    },
-    {
-        property: 'insight',
-        header: <Text color="text-strong" weight="bold">Insight</Text>,
-    },
-  ];
+  {
+    property: 'type',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Type
+      </Text>
+    ),
+  },
+  {
+    property: 'state',
+    header: (
+      <Text color="text-strong" weight="bold">
+        State
+      </Text>
+    ),
+  },
+  {
+    property: 'status',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Status
+      </Text>
+    ),
+  },
+  {
+    property: 'attentionLevel',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Attention Level
+      </Text>
+    ),
+  },
+  {
+    property: 'actions',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Actions
+      </Text>
+    ),
+  },
+  {
+    property: 'persistence',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Persistence
+      </Text>
+    ),
+  },
+  {
+    property: 'placement',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Placement
+      </Text>
+    ),
+  },
+  {
+    property: 'insight',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Insight
+      </Text>
+    ),
+  },
+];
 
 export const TaxonomyTable = () => (
-    <Box pad="small" background="background-front" round="small" overflow="auto" >
-        <DataTable 
-            columns={columns} 
-            data={data} 
-            primaryKey={false} 
-        />
-    </Box>
+  <Box pad="small" background="background-front" round="small" overflow="auto">
+    <DataTable columns={columns} data={data} primaryKey={false} />
+  </Box>
 );

--- a/aries-site/src/examples/templates/toast-notifications/ToastDiagram.js
+++ b/aries-site/src/examples/templates/toast-notifications/ToastDiagram.js
@@ -36,7 +36,7 @@ const connections = [
 
 export const ToastDiagram = () => (
     <Stack>
-      <Box gap="medium" pad={{bottom: 'medium'}}>
+      <Box gap="medium" pad={{ bottom: 'medium' }}>
         <Box direction="row" gap="xlarge">
           <Box 
             id="1" 

--- a/aries-site/src/pages/components/notification.mdx
+++ b/aries-site/src/pages/components/notification.mdx
@@ -37,7 +37,7 @@ Keep in mind that a status **derives** from a state.
 
 The following types of notifications are used to provide users with full transparent clarity on tasks and system statuses:
 
-- [Status Indicators](/components/status-indicator) are used within all types of notifications. They capture a user’s attention based on the notification’s level of severity.
+- [Status Indicators](/templates/status-indicator) are used within all types of notifications. They capture a user’s attention based on the notification’s level of severity.
 - For low priority and non-action-oriented notifications, [Toast Notifications](/templates/toast-notifications) are a great way to inform users unobtrusively. 
 
 ## Variants

--- a/aries-site/src/pages/templates/toast-notifications.mdx
+++ b/aries-site/src/pages/templates/toast-notifications.mdx
@@ -59,7 +59,7 @@ The status indicators used for toasts are strictly for Normal, Warning, and Unkn
 
 <StatusBox toast />
 
-You can read more guidance about [status indicators](/components/status-indicator).
+You can read more guidance about [status indicators](/templates/status-indicator).
 
 ### Content (Title + Message)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,13 +53,6 @@
   dependencies:
     cross-fetch "3.1.2"
 
-"@applitools/dom-capture@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-capture/-/dom-capture-7.3.0.tgz#f9d747f3185c643234fb660cef62a150c754d1a9"
-  integrity sha512-jB9Cmmo901i2ogjTMF/iPGuG6R+NAhhXnYA4KMFL8N2WHRDyi9+U6X3E1Duv3KNsLNWSSQyJSHAy3E0T8I2diA==
-  dependencies:
-    "@applitools/functional-commons" "1.5.4"
-
 "@applitools/dom-capture@8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@applitools/dom-capture/-/dom-capture-8.0.0.tgz#71c6eb7f7fd21f518330878eeba4d28c5204605f"
@@ -73,14 +66,6 @@
   resolved "https://registry.yarnpkg.com/@applitools/dom-shared/-/dom-shared-1.0.4.tgz#1a59116f3f29fb140ac031949547531348c9d972"
   integrity sha512-WRGko/7pJLwcDbQ5r0q2KD58VemIHm+JyKeXSflQhJvQqA5ONYyBX6cZo0h3o1SqdlzQnWM5REzoxoOpOGflzQ==
 
-"@applitools/dom-snapshot@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.1.0.tgz#24be90ef39eba3cf31f91fad29d5b0666fea78b6"
-  integrity sha512-xqI6emGbvMqnOIM4TLXNgmQMS+kzJ5FvKmQMX/KLjEX5wHalMRl2YLeosJVbgjZx/3G+CyVGtZoMNG/dw+08lA==
-  dependencies:
-    "@applitools/functional-commons" "1.6.0"
-    css-tree "^1.0.0-alpha.39"
-
 "@applitools/dom-snapshot@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.2.0.tgz#72254be14ff073f6a2b05144e10dd2f1ae1ba93f"
@@ -90,25 +75,6 @@
     "@applitools/functional-commons" "1.6.0"
     css-tree "1.0.0-alpha.39"
     pako "1.0.11"
-
-"@applitools/eyes-sdk-core@12.2.9":
-  version "12.2.9"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes-sdk-core/-/eyes-sdk-core-12.2.9.tgz#a23acb0e04d350584689e12be76940cf718da267"
-  integrity sha512-oIE35m1YASLbWDkUoCO2ao8zltzMam4sR1JKUzPHttCy6n/c15aHKo20RoPjpCAUWcaOyS4xMFKcsRvPvUDpbw==
-  dependencies:
-    "@applitools/dom-capture" "7.3.0"
-    "@applitools/dom-snapshot" "4.1.0"
-    "@applitools/isomorphic-fetch" "3.0.0"
-    "@applitools/snippets" "2.0.1"
-    axios "0.19.2"
-    chalk "3.0.0"
-    cosmiconfig "6.0.0"
-    dateformat "3.0.3"
-    debug "4.2.0"
-    deepmerge "4.2.2"
-    png-async "0.9.4"
-    stack-trace "0.0.10"
-    tunnel "0.0.6"
 
 "@applitools/eyes-sdk-core@12.3.0":
   version "12.3.0"
@@ -140,11 +106,6 @@
     "@applitools/visual-grid-client" "15.0.9"
     chalk "^2.4.2"
     rimraf "^2.7.1"
-
-"@applitools/functional-commons@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@applitools/functional-commons/-/functional-commons-1.5.4.tgz#d32f2bbc6a2598872b3a385d054fcf8e40c30a40"
-  integrity sha512-R+p4fliS8j6YlZNSLgsx6cBpjlmZaec67v9PpophPW5vXnOJFVcELnoeO21AVG1kbHu0FeAk025xr99EUTppFw==
 
 "@applitools/functional-commons@1.6.0", "@applitools/functional-commons@^1.5.5":
   version "1.6.0"
@@ -209,11 +170,6 @@
   integrity sha512-rzEOvGoiEF4KnK0PJ9I0btdwnaNlIPLYhjF1vTEG15PoucbbKpix9fYusxWlDG7kMiZya8ZycVPc0woVlNaHRQ==
   dependencies:
     debug "^4.1.0"
-
-"@applitools/snippets@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@applitools/snippets/-/snippets-2.0.1.tgz#16d641c8d8c42ab13a0fb88979dda084e9a38087"
-  integrity sha512-oDgRfaKUfqY16GqKrLYKY8M/urBd/+DSWzZd1TOrXGwr8dX0hZ5bikJbApoOBPIp6wFmNNXvH4waPGR2MwD5FQ==
 
 "@applitools/snippets@2.0.3":
   version "2.0.3"
@@ -5859,7 +5815,7 @@ css-tree@1.0.0-alpha.39:
     mdn-data "2.0.6"
     source-map "^0.6.1"
 
-css-tree@^1.0.0-alpha.39, css-tree@^1.1.2:
+css-tree@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Fixes broken links to the Status Indicators page from [Notification](https://deploy-preview-1814--keen-mayer-a86c8b.netlify.app/components/notification) and [Toast Notifications](https://deploy-preview-1814--keen-mayer-a86c8b.netlify.app/templates/toast-notifications)
- Also applies linter rules which weren't applied/checked post-commit / pre-merge

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
