### PR TITLE
DO NOT MERGE Create icon deploy for grommet-icons updates

### DIFF
--- a/aries-site/src/examples/foundation/icons/IconSizeExample.js
+++ b/aries-site/src/examples/foundation/icons/IconSizeExample.js
@@ -1,11 +1,262 @@
+/* eslint-disable max-len */
 import React from 'react';
 import { Box } from 'grommet';
-import { Alarm } from 'grommet-icons';
+import {
+  Blank,
+  UploadOption,
+  Tictok,
+  Sun,
+  Sans,
+  Plug,
+  NetworkDrive,
+  Mouse,
+  Moon,
+  Memory,
+  Keyboard,
+  Gateway,
+  Flows,
+  DisabledOutline,
+  Cpu,
+  Clock,
+  CircleAlert,
+  Certificate,
+  BladesVertical,
+  BladesHorizontal,
+  Beacon,
+  AppsRounded,
+} from 'grommet-icons';
 
 export const IconSizeExample = () => (
-    <Box direction="row-responsive" gap="medium">
-      <Alarm size="xlarge" />
-      <Alarm size="large" />
-      <Alarm size="medium" />
+  <Box gap="medium">
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M3 6.2c0-1.12 0-1.68.218-2.108a2 2 0 01.874-.874C4.52 3 5.08 3 6.2 3h.6c1.12 0 1.68 0 2.108.218a2 2 0 01.874.874C10 4.52 10 5.08 10 6.2v.6c0 1.12 0 1.68-.218 2.108a2 2 0 01-.874.874C8.48 10 7.92 10 6.8 10h-.6c-1.12 0-1.68 0-2.108-.218a2 2 0 01-.874-.874C3 8.48 3 7.92 3 6.8v-.6zM14 6.2c0-1.12 0-1.68.218-2.108a2 2 0 01.874-.874C15.52 3 16.08 3 17.2 3h.6c1.12 0 1.68 0 2.108.218a2 2 0 01.874.874C21 4.52 21 5.08 21 6.2v.6c0 1.12 0 1.68-.218 2.108a2 2 0 01-.874.874C19.48 10 18.92 10 17.8 10h-.6c-1.12 0-1.68 0-2.108-.218a2 2 0 01-.874-.874C14 8.48 14 7.92 14 6.8v-.6zM3 17.2c0-1.12 0-1.68.218-2.108a2 2 0 01.874-.874C4.52 14 5.08 14 6.2 14h.6c1.12 0 1.68 0 2.108.218a2 2 0 01.874.874C10 15.52 10 16.08 10 17.2v.6c0 1.12 0 1.68-.218 2.108a2 2 0 01-.874.874C8.48 21 7.92 21 6.8 21h-.6c-1.12 0-1.68 0-2.108-.218a2 2 0 01-.874-.874C3 19.48 3 18.92 3 17.8v-.6zM14 17.2c0-1.12 0-1.68.218-2.108a2 2 0 01.874-.874C15.52 14 16.08 14 17.2 14h.6c1.12 0 1.68 0 2.108.218a2 2 0 01.874.874C21 15.52 21 16.08 21 17.2v.6c0 1.12 0 1.68-.218 2.108a2 2 0 01-.874.874C19.48 21 18.92 21 17.8 21h-.6c-1.12 0-1.68 0-2.108-.218a2 2 0 01-.874-.874C14 19.48 14 18.92 14 17.8v-.6z"
+        />
+      </Blank>
+      <AppsRounded size="large" />
     </Box>
-  );
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M12 12a3 3 0 100-6 3 3 0 000 6zm0 0v11M7.05 4.05A6.978 6.978 0 005 9c0 1.933.784 3.683 2.05 4.95m9.9 0A6.978 6.978 0 0019 9a6.978 6.978 0 00-2.05-4.95M4.222 1.222A10.966 10.966 0 001 9c0 3.037 1.231 5.787 3.222 7.778m15.556 0A10.966 10.966 0 0023 9c0-3.038-1.231-5.788-3.222-7.778"
+        />
+      </Blank>
+      <Beacon size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M3 17h4m3 0h4m3 0h4M4 21h2a1 1 0 001-1V4a1 1 0 00-1-1H4a1 1 0 00-1 1v16a1 1 0 001 1zm7 0h2a1 1 0 001-1V4a1 1 0 00-1-1h-2a1 1 0 00-1 1v16a1 1 0 001 1zm7 0h2a1 1 0 001-1V4a1 1 0 00-1-1h-2a1 1 0 00-1 1v16a1 1 0 001 1z"
+        />
+      </Blank>
+      <BladesHorizontal size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M17 3v4m0 3v4m0 3v4m4-17v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4a1 1 0 011-1h16a1 1 0 011 1zm0 7v2a1 1 0 01-1 1H4a1 1 0 01-1-1v-2a1 1 0 011-1h16a1 1 0 011 1zm0 7v2a1 1 0 01-1 1H4a1 1 0 01-1-1v-2a1 1 0 011-1h16a1 1 0 011 1z"
+        />
+      </Blank>
+      <BladesVertical size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M15 19H2V1h16v4m0 0a5 5 0 110 10 5 5 0 010-10zm-3 9v8l3-2 3 2v-8M5 8h6m-6 3h5m-5 3h2M5 5h2"
+        />
+      </Blank>
+      <Certificate size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M12 14V6m0 12v-2m0-14C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2z"
+        />
+      </Blank>
+      <CircleAlert size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          fill="#000"
+          d="M13 7a1 1 0 10-2 0v5a1 1 0 00.4.8l4 3a1 1 0 001.2-1.6L13 11.5V7z"
+        />
+        <path
+          fill="#000"
+          fillRule="evenodd"
+          d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM3 12a9 9 0 1118 0 9 9 0 01-18 0z"
+          clipRule="evenodd"
+        />
+      </Blank>
+      <Clock size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M1 18h3m-3-4h3m-3-4h3M1 6h3m16 12h3m-3-4h3m-3-4h3m-3-4h3M6 1v3m4-3v3m4-3v3m4-3v3M6 20v3m4-3v3m4-3v3m4-3v3M5 20h14a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1zm8-13h4v4h-4V7z"
+        />
+      </Blank>
+      <Cpu size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M18 12H6M4 22h16a2 2 0 002-2V4a2 2 0 00-2-2H4a2 2 0 00-2 2v16a2 2 0 002 2z"
+        />
+      </Blank>
+      <DisabledOutline size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M3 5a2 2 0 012-2h14a2 2 0 012 2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM3 16a2 2 0 012-2h14a2 2 0 012 2v3a2 2 0 01-2 2H5a2 2 0 01-2-2v-3z"
+        />
+      </Blank>
+      <Flows size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M12 20v-5m0-6V4m-7 8h5m9 0h-5m-.969-4.031L12 9.344l-1.031-1.375h2.062zm-2.062 8.07L12 14.664l1.031 1.375H10.97zM6 13.031 4.625 12 6 10.969v2.062zm12-2.062L19.375 12 18 13.031V10.97zM12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1z"
+        />
+      </Blank>
+      <Gateway size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M3 9h3m-3 3h2m-2 3h1m3 0h10m1 0h1m1 0h1m-3-3h3m-2-3h2m-5 0h2M7 9h2m1 0h2m1 0h2M5 15h1m0-3h2m1 0h2m1 0h2m1 0h2M1 7v10a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1z"
+        />
+      </Blank>
+      <Keyboard size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M10 18h4m-4-4h4m-4-4h4m-4-4h4m6 12h3m-3-4h3m-3-4h3m-3-4h3M1 18h3m-3-4h3m-3-4h3M1 6h3m11 14h4a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1zM5 20h4a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1z"
+        />
+      </Blank>
+      <Memory size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M9.874 5.008c2.728-1.68 6.604-1.014 8.25.197-2.955.84-5.11 3.267-5.242 6.415-.18 4.28 3.006 6.588 5.24 7.152-1.964 1.343-4.36 1.293-5.235 1.172-3.568-.492-6.902-3.433-7.007-7.711-.106-4.278 2.573-6.35 3.994-7.225z"
+        />
+      </Blank>
+      <Moon size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M12 4a5 5 0 0 1 5 5v6a5 5 0 0 1-10 0V9a5 5 0 0 1 5-5zm0 0v6m-6 0h12"
+        />
+      </Blank>
+      <Mouse size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M12 14v4M22 6v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h18a1 1 0 0 1 1 1zM12 21a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM6 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"
+        />
+      </Blank>
+      <NetworkDrive size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M15 6V1m-3 23v-9M9 6V1M6 6h12v7a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V6z"
+        />
+      </Blank>
+      <Plug size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M1 12h22M2 22h20a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1zM5 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"
+        />
+      </Blank>
+      <Sans size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M12 4V2m0 20v-2m8-8h2M2 12h2m13.657-5.657L19.07 4.93M4.93 19.07l1.414-1.414m0-11.314L4.93 4.93m14.14 14.14-1.414-1.414M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10z"
+        />
+      </Blank>
+      <Sun size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large" color="plain">
+        <path
+          fill="#FF004F"
+          d="M22.459 6.846v3.659c-.197 0-.433.04-.669.04a7.295 7.295 0 0 1-4.682-1.732v7.79a6.987 6.987 0 0 1-1.416 4.25 7.02 7.02 0 0 1-5.626 2.832 6.993 6.993 0 0 1-5.941-3.305c1.259 1.18 2.95 1.928 4.8 1.928a6.893 6.893 0 0 0 5.586-2.833c.866-1.18 1.417-2.636 1.417-4.249v-7.83c1.259 1.102 2.872 1.732 4.682 1.732.236 0 .433 0 .669-.04v-2.36c.354.079.669.118 1.023.118h.157z"
+        />
+        <path
+          fill="#FF004F"
+          d="M11.05 9.56v4.053a3.277 3.277 0 0 0-.866-.118c-1.732 0-3.148 1.456-3.148 3.226 0 .394.079.748.197 1.102-.787-.59-1.338-1.535-1.338-2.597 0-1.77 1.416-3.226 3.148-3.226.314 0 .59.04.865.118V9.521h.236c.315 0 .63 0 .905.04zm6.648-5.626c-.708-.63-1.22-1.495-1.495-2.4h.945v.551a6.25 6.25 0 0 0 .55 1.85z"
+        />
+        <path
+          fill="#000"
+          d="M21.318 6.767v2.36c-.197.04-.433.04-.669.04a7.295 7.295 0 0 1-4.682-1.73v7.79a6.987 6.987 0 0 1-1.416 4.248c-1.299 1.732-3.305 2.833-5.587 2.833-1.85 0-3.541-.747-4.8-1.928a7.136 7.136 0 0 1-1.062-3.737c0-3.817 3.03-6.925 6.806-7.043v2.597a3.277 3.277 0 0 0-.865-.118c-1.732 0-3.148 1.455-3.148 3.226 0 1.062.512 2.046 1.338 2.597.433 1.22 1.613 2.124 2.95 2.124 1.732 0 3.148-1.456 3.148-3.226V1.534h2.872c.276.945.787 1.77 1.495 2.4a5.397 5.397 0 0 0 3.62 2.833z"
+        />
+        <g fill="#00F7EF">
+          <path d="M9.908 8.184V9.52c-3.777.118-6.806 3.226-6.806 7.043 0 1.377.393 2.636 1.062 3.738A7.122 7.122 0 0 1 2 15.148c0-3.896 3.148-7.043 7.003-7.043.315 0 .63.04.905.079z" />
+          <path d="M16.203 1.534h-2.872v15.187c0 1.77-1.416 3.227-3.147 3.227-1.377 0-2.518-.866-2.951-2.125.511.354 1.14.59 1.81.59 1.73 0 3.147-1.416 3.147-3.187V0h3.817v.079c0 .157 0 .314.039.472 0 .315.079.669.157.983zm5.115 3.777v1.417c-1.574-.315-2.911-1.377-3.659-2.794a5.11 5.11 0 0 0 3.659 1.377z" />
+        </g>
+      </Blank>
+      <Tictok color="plain" size="large" />
+    </Box>
+    <Box direction="row" gap="small">
+      <Blank size="large">
+        <path
+          stroke="#000"
+          strokeWidth="2"
+          d="M17 12l-5-5-5 5m5-4v10m0 5c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11z"
+        />
+      </Blank>
+      <UploadOption size="large" />
+    </Box>
+  </Box>
+);

--- a/aries-site/src/pages/foundation/icons.mdx
+++ b/aries-site/src/pages/foundation/icons.mdx
@@ -54,10 +54,9 @@ Icons can be used in a variety of different ways. They are used within other com
   <IconComponentExample />
 </Example>
 
-### Icon Sizes
+### Temporary Demo of updated icons
 
-The default icon size is medium. This should be adjusted depending
-on where in your application the icon is being used.
+On the left are the new "stroke / stroke-width = 2" icons, and on the right are the existing fill icons. There should not be visual differences.
 
 <Example code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/foundation/icons/IconSizeExample.js">
   <IconSizeExample />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,14 +3028,14 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
-  version "16.7.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.8.tgz#2448be5f24fe6b77114632b6350fcd219334651e"
-  integrity sha512-8upnoQU0OPzbIkm+ZMM0zCeFCkw2s3mS0IWdx0+AAaWqm4fkBb0UJp8Edl7FVKRamYbpJC/aVsHpKWBIbiC7Zg==
+  version "16.7.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
+  integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
 "@types/node@^12.20.10":
-  version "12.20.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.21.tgz#575e91f59c2e79318c2d39a48286c6954e484fd5"
-  integrity sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA==
+  version "12.20.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.23.tgz#d0d5885bb885ee9b1ed114a04ea586540a1b2e2a"
+  integrity sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -5611,10 +5611,15 @@ core-js@^3.0.1, core-js@^3.0.4, core-js@^3.16.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.16.4.tgz#0fb1029a554fc2688c0963d7c900e188188a78e0"
   integrity sha512-Tq4GVE6XCjE+hcyW6hPy0ofN3hwtLudz5ZRdrlCnsnD/xkm/PWQRudzYHiKgZKUcefV6Q57fhDHjZHJP5dpfSg==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 corejs-upgrade-webpack-plugin@^2.2.0:
   version "2.2.0"
@@ -6534,9 +6539,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.811:
-  version "1.3.823"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.823.tgz#ebcc606e6e0c08f92e553276711dc30a7ea43c02"
-  integrity sha512-jbwqBmqo9ZBWNfz6EKDTx66rqRDt87ZbOxtUegYNpkVMX6z93PMaFbDy7/LIPRwMI/5T4GVcYkROWDPQm9Ni7A==
+  version "1.3.825"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz#5d361eeaaf591bb2ce06cfeff86354b429d662b8"
+  integrity sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -8098,8 +8103,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.5"
-  uid "7a8f8e00be4574862bd06950d759c46489a5a058"
-  resolved "https://github.com/grommet/grommet/tarball/stable#7a8f8e00be4574862bd06950d759c46489a5a058"
+  uid "4d9f7849d70121b6170b23fefd3749a4a0d19f97"
+  resolved "https://github.com/grommet/grommet/tarball/stable#4d9f7849d70121b6170b23fefd3749a4a0d19f97"
   dependencies:
     grommet-icons "^4.6.2"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Preview

We are updating the icons to use "stroke" and "stroke-width" in cases where they previously were using "fill". The updates are happening in grommet-icons, but this is just a deploy to show the new vs old for visual confirmation since snapshots changed in grommet-icons due to fill --> stroke.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
