### PR TITLE
add new prop to align list

### DIFF
--- a/aries-site/src/examples/templates/list-views/ListOrderExample.js
+++ b/aries-site/src/examples/templates/list-views/ListOrderExample.js
@@ -51,6 +51,9 @@ export const ListOrderExample = () => {
           )}
         </Box>
         <List
+          defaultItemProps={{
+            align: 'start',
+          }}
           data={ordered}
           onOrder={allowReorder ? setOrder : undefined}
           primaryKey="title"

--- a/aries-site/src/pages/templates/lists.mdx
+++ b/aries-site/src/pages/templates/lists.mdx
@@ -187,11 +187,20 @@ With long sets of data, pagination can help to create a more efficient means of 
 
 ### Item order
 
+For **multi-line** list items, they should be set to top aligned for easy scanning across a row.
+In order to align start use the prop `defaultItemsProp`.
+
+```
+<List
+defaultItemsProp={{align: 'start'}}
+...any additional props
+<List/>
+```
+
+
 Allowing the user to re-order the list by dragging items or pressing move up and down controls.
-When using OnOrder if there is multi-line content then this should be top aligned for easy scanning
-across a row. In order to aliign start you can add the prop `defaultItemsProp` to `DataTable`
-to be set as `align: 'start'`. Choose `Actions->Re-Order Items` to
-enable drag and drop of list items and move up/down controls. Press `Done` when finished.
+Choose `Actions->Re-Order Items` to enable drag and drop of list items and move up/down controls.
+Press `Done` when finished.
 
 <Example
   background="background-back"

--- a/aries-site/src/pages/templates/lists.mdx
+++ b/aries-site/src/pages/templates/lists.mdx
@@ -187,7 +187,10 @@ With long sets of data, pagination can help to create a more efficient means of 
 
 ### Item order
 
-Allowing the user to re-order the list by dragging items or pressing move up and down controls. Choose `Actions->Re-Order Items` to
+Allowing the user to re-order the list by dragging items or pressing move up and down controls.
+When using OnOrder if there is multi-line content then this should be top aligned for easy scanning
+across a row. In order to aliign start you can add the prop `defaultItemsProp` to `DataTable`
+to be set as `align: 'start'`. Choose `Actions->Re-Order Items` to
 enable drag and drop of list items and move up/down controls. Press `Done` when finished.
 
 <Example

--- a/aries-site/src/pages/templates/lists.mdx
+++ b/aries-site/src/pages/templates/lists.mdx
@@ -187,8 +187,13 @@ With long sets of data, pagination can help to create a more efficient means of 
 
 ### Item order
 
-For **multi-line** list items, they should be set to top aligned for easy scanning across a row.
-In order to align start use the prop `defaultItemsProp`.
+List supports `onOrder` property which allows the user to re-order the list by dragging items or pressing up and down controls.
+
+Choose `Actions -> Re-Order Items` to enable drag and drop of list items and move up/down controls. While in re-ordering mode,
+take note of how the row content is top-aligned. For **multi-line** list items like this use case, list items should be top-aligned
+for easy scanning across a row.
+
+To implement this, use the prop `defaultItemsProp` on List:
 
 ```
 <List
@@ -196,11 +201,6 @@ defaultItemsProp={{align: 'start'}}
 ...any additional props
 <List/>
 ```
-
-
-Allowing the user to re-order the list by dragging items or pressing move up and down controls.
-Choose `Actions->Re-Order Items` to enable drag and drop of list items and move up/down controls.
-Press `Done` when finished.
 
 <Example
   background="background-back"

--- a/aries-site/src/pages/templates/lists.mdx
+++ b/aries-site/src/pages/templates/lists.mdx
@@ -193,7 +193,7 @@ Choose `Actions -> Re-Order Items` to enable drag and drop of list items and mov
 take note of how the row content is top-aligned. For **multi-line** list items like this use case, list items should be top-aligned
 for easy scanning across a row.
 
-To implement this, use the prop `defaultItemsProp` on List:
+To implement top-alignment for multi-line lists, use the prop `defaultItemsProp` on List:
 
 ```
 <List

--- a/yarn.lock
+++ b/yarn.lock
@@ -8104,8 +8104,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.17.5"
-  uid c23eb73fdcfe909a69c40df226929d5a6ceb7992
-  resolved "https://github.com/grommet/grommet/tarball/stable#c23eb73fdcfe909a69c40df226929d5a6ceb7992"
+  uid "835ef0cdf71854dfb8a376167ab6888bead51f39"
+  resolved "https://github.com/grommet/grommet/tarball/stable#835ef0cdf71854dfb8a376167ab6888bead51f39"
   dependencies:
     grommet-icons "^4.6.2"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
utilizing the new `defaultItemProps` that was added to grommet now we can use this to align our `list` onOrder example
#### Where should the reviewer start?
templates/list-views/ListOrderExample.js 
#### What testing has been done on this PR?
site
#### How should this be manually tested?
check out the example and see it is  align start
#### Any background context you want to provide?

#### What are the relevant issues?
closes #1790 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible