### PR TITLE
change height if example is in full screen

### DIFF
--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -304,6 +304,7 @@ export const TableExample = ({ designSystemDemo }) => {
       <Box
         // Height is restricted to keep inline doc page examples more compact.
         // In production, DataTable height should follow height guidelines.
+        // https://design-system.hpe.design/components/table#setting-the-height-of-a-table
         height={designSystemDemo ? undefined : 'small'}
         overflow="auto"
       >

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -288,7 +288,7 @@ const handleClickRow = obj => {
   `);
 };
 
-// designSystemDemo is used for DS site can be removed in production.
+// designSystemDemo is used for DS site only, can be removed in production.
 export const TableExample = ({ designSystemDemo }) => {
   const size = React.useContext(ResponsiveContext);
 

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Box,
   DataTable,
@@ -287,7 +288,8 @@ const handleClickRow = obj => {
   `);
 };
 
-export const TableExample = () => {
+// designSystemDemo is used for DS site can be removed in production.
+export const TableExample = ({ designSystemDemo }) => {
   const size = React.useContext(ResponsiveContext);
 
   return (
@@ -299,7 +301,12 @@ export const TableExample = () => {
       >
         Storage Pools
       </Heading>
-      <Box height="medium" overflow="auto">
+      <Box
+        // Height is restricted to keep doc pages more compact.
+        // In production dataTable hight should follow height guidelines
+        height={designSystemDemo ? undefined : 'medium'}
+        overflow="auto"
+      >
         <DataTable
           aria-describedby="storage-pools-heading"
           data={data}
@@ -321,4 +328,8 @@ export const TableExample = () => {
       </Box>
     </>
   );
+};
+
+TableExample.propTypes = {
+  designSystemDemo: PropTypes.bool,
 };

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -303,7 +303,7 @@ export const TableExample = ({ designSystemDemo }) => {
       </Heading>
       <Box
         // Height is restricted to keep doc pages more compact.
-        // In production dataTable hight should follow height guidelines
+        // In production, DataTable height should follow height guidelines.
         height={designSystemDemo ? undefined : 'small'}
         overflow="auto"
       >

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -304,7 +304,7 @@ export const TableExample = ({ designSystemDemo }) => {
       <Box
         // Height is restricted to keep doc pages more compact.
         // In production dataTable hight should follow height guidelines
-        height={designSystemDemo ? undefined : 'medium'}
+        height={designSystemDemo ? undefined : 'small'}
         overflow="auto"
       >
         <DataTable

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -302,7 +302,7 @@ export const TableExample = ({ designSystemDemo }) => {
         Storage Pools
       </Heading>
       <Box
-        // Height is restricted to keep doc pages more compact.
+        // Height is restricted to keep inline doc page examples more compact.
         // In production, DataTable height should follow height guidelines.
         height={designSystemDemo ? undefined : 'small'}
         overflow="auto"

--- a/aries-site/src/examples/components/table/TableExample.js
+++ b/aries-site/src/examples/components/table/TableExample.js
@@ -305,7 +305,7 @@ export const TableExample = ({ designSystemDemo }) => {
         // Height is restricted to keep inline doc page examples more compact.
         // In production, DataTable height should follow height guidelines.
         // https://design-system.hpe.design/components/table#setting-the-height-of-a-table
-        height={designSystemDemo ? undefined : 'small'}
+        height={designSystemDemo ? undefined : 'medium'}
         overflow="auto"
       >
         <DataTable

--- a/aries-site/src/examples/components/table/TableFixedHeaderExample.js
+++ b/aries-site/src/examples/components/table/TableFixedHeaderExample.js
@@ -241,8 +241,9 @@ export const TableFixedHeaderExample = ({ designSystemDemo }) => (
     <Box
       align="start"
       // restricting height to demonstrate pinned header behavior
-      // Height is restricted to keep doc pages more compact.
-      // In production dataTable hight should follow height guidelines
+      // Height is restricted to keep inline doc page examples more compact.
+      // In production, DataTable height should follow height guidelines.
+      // https://design-system.hpe.design/components/table#setting-the-height-of-a-table
       height={designSystemDemo ? undefined : 'medium'}
       // restricting width to demonstrate pinned column behavior
       width={designSystemDemo ? undefined : { min: 'medium', max: 'large' }}

--- a/aries-site/src/examples/components/table/TableFixedHeaderExample.js
+++ b/aries-site/src/examples/components/table/TableFixedHeaderExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Box, DataTable, Text, Heading } from 'grommet';
 
 const data = [
@@ -227,7 +228,7 @@ const columns = [
   },
 ];
 
-export const TableFixedHeaderExample = () => (
+export const TableFixedHeaderExample = ({ designSystemDemo }) => (
   <>
     <Heading
       id="connected-heading"
@@ -239,9 +240,11 @@ export const TableFixedHeaderExample = () => (
     <Box
       align="start"
       // restricting height to demonstrate pinned header behavior
-      height="medium"
+      // Height is restricted to keep doc pages more compact.
+      // In production dataTable hight should follow height guidelines
+      height={designSystemDemo ? undefined : 'medium'}
       // restricting width to demonstrate pinned column behavior
-      width={{ min: 'medium', max: 'large' }}
+      width={designSystemDemo ? undefined : { min: 'medium', max: 'large' }}
       overflow="auto"
     >
       <DataTable
@@ -253,3 +256,7 @@ export const TableFixedHeaderExample = () => (
     </Box>
   </>
 );
+
+TableFixedHeaderExample.propTypes = {
+  designSystemDemo: PropTypes.bool,
+};

--- a/aries-site/src/examples/components/table/TableFixedHeaderExample.js
+++ b/aries-site/src/examples/components/table/TableFixedHeaderExample.js
@@ -228,6 +228,7 @@ const columns = [
   },
 ];
 
+// designSystemDemo is used for DS site only, can be removed in production.
 export const TableFixedHeaderExample = ({ designSystemDemo }) => (
   <>
     <Heading

--- a/aries-site/src/examples/components/table/TableResizeColumnsExample.js
+++ b/aries-site/src/examples/components/table/TableResizeColumnsExample.js
@@ -174,6 +174,7 @@ const columns = [
   },
 ];
 
+// designSystemDemo is used for DS site only, can be removed in production.
 export const TableResizeColumnsExample = ({ designSystemDemo }) => (
   <>
     <Heading
@@ -186,8 +187,9 @@ export const TableResizeColumnsExample = ({ designSystemDemo }) => (
     <Box
       align="start"
       // restricting height to demonstrate pinned header behavior
-      // Height is restricted to keep doc pages more compact.
-      // In production dataTable hight should follow height guidelines
+      // Height is restricted to keep inline doc page examples more compact.
+      // In production, DataTable height should follow height guidelines.
+      // https://design-system.hpe.design/components/table#setting-the-height-of-a-table
       height={designSystemDemo ? undefined : 'medium'}
       overflow="auto"
       fill="horizontal"

--- a/aries-site/src/examples/components/table/TableResizeColumnsExample.js
+++ b/aries-site/src/examples/components/table/TableResizeColumnsExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Box, DataTable, Heading, Text } from 'grommet';
 
 const data = [
@@ -173,7 +174,7 @@ const columns = [
   },
 ];
 
-export const TableResizeColumnsExample = () => (
+export const TableResizeColumnsExample = ({ designSystemDemo }) => (
   <>
     <Heading
       id="contact-info-heading"
@@ -185,7 +186,9 @@ export const TableResizeColumnsExample = () => (
     <Box
       align="start"
       // restricting height to demonstrate pinned header behavior
-      height="medium"
+      // Height is restricted to keep doc pages more compact.
+      // In production dataTable hight should follow height guidelines
+      height={designSystemDemo ? undefined : 'medium'}
       overflow="auto"
       fill="horizontal"
     >
@@ -199,3 +202,7 @@ export const TableResizeColumnsExample = () => (
     </Box>
   </>
 );
+
+TableResizeColumnsExample.propTypes = {
+  designSystemDemo: PropTypes.bool,
+};

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -218,7 +218,7 @@ const columns = [
 
 export const TableSingleSelectExample = () => {
   const size = React.useContext(ResponsiveContext);
-  const [pageDetails, setPageDetals] = React.useState({});
+  const [pageDetails, setPageDetails] = React.useState({});
 
   return !pageDetails.id ? (
     <>
@@ -237,7 +237,7 @@ export const TableSingleSelectExample = () => {
             { property: 'id', header: 'Id', pin: size === 'small' },
             ...columns,
           ]}
-          onClickRow={({ datum }) => setPageDetals(datum)}
+          onClickRow={({ datum }) => setPageDetails(datum)}
           pin={size === 'small'}
         />
       </Box>
@@ -246,7 +246,7 @@ export const TableSingleSelectExample = () => {
     <>
       <Button
         onClick={() => {
-          setPageDetals({});
+          setPageDetails({});
         }}
         alignSelf="start"
         icon={<FormPrevious />}

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -240,15 +240,14 @@ export const TableSingleSelectExample = () => {
       </Heading>
       <Box margin={{ vertical: 'small', horizontal: 'large' }} gap="small">
         {pageDetails &&
-          Object.entries(pageDetails).map(([key, value]) => {
-            console.log(key, value);
-            return (
+          Object.entries(pageDetails).map(([key, value]) => (
               <DetailsPage
+                key={key}
                 orderDetails={key}
                 orderPageDetails={value}
                />
             );
-          })}
+         )}
       </Box>
     </>
   );

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -32,9 +32,7 @@ const data = [
     state: 'Created',
     service: 'HPE GreenLake Private Cloud',
     tenant: 'Suncor Energy',
-    contact: {
-      email: 'melinda@suncor.co',
-    },
+    email: 'melinda@suncor.co',
     orderDate: '04/30/2020',
   },
   {
@@ -44,9 +42,7 @@ const data = [
     state: 'Build Prep',
     service: 'HPE Goats as a Service',
     tenant: 'Nestle',
-    contact: {
-      email: 'wan@nestle.com',
-    },
+    email: 'wan@nestle.com',
     orderDate: '04/05/2020',
   },
   {
@@ -56,9 +52,7 @@ const data = [
     state: 'Processing',
     service: 'VMaaS for R&D',
     tenant: 'Coke',
-    contact: {
-      email: 'muhtar@coke.com',
-    },
+    email: 'muhtar@coke.com',
     orderDate: '03/04/2020',
   },
   {
@@ -68,9 +62,7 @@ const data = [
     state: 'Factory Express',
     service: 'HPE GreenLake Private Cloud',
     tenant: 'Domain',
-    contact: {
-      email: 'priyanka@domain.com',
-    },
+    email: 'priyanka@domain.com',
     orderDate: '02/28/2020',
   },
   {
@@ -80,9 +72,7 @@ const data = [
     state: 'Provisioning',
     service: 'VMaaS for R&D',
     tenant: 'Nestle',
-    contact: {
-      email: 'wan@nestle.com',
-    },
+    email: 'wan@nestle.com',
     orderDate: '02/15/2020',
   },
   {
@@ -92,9 +82,7 @@ const data = [
     state: 'In Transit',
     service: 'HPE GreenLake Private Cloud',
     tenant: 'Suncor Energy',
-    contact: {
-      email: 'melinda@suncor.co',
-    },
+    email: 'melinda@suncor.co',
     orderDate: '01/30/2020',
   },
   {
@@ -104,9 +92,7 @@ const data = [
     state: 'Cancelled',
     service: 'HPE GreenLake Private Cloud',
     tenant: 'Boeing',
-    contact: {
-      email: 'susan@boeing.com',
-    },
+    email: 'susan@boeing.com',
     orderDate: '01/15/2020',
   },
   {
@@ -116,9 +102,7 @@ const data = [
     state: 'Ready to Ship',
     service: 'HPE Goats as a Service',
     tenant: 'Coke',
-    contact: {
-      email: 'muhtar@coke.com',
-    },
+    email: 'muhtar@coke.com',
     orderDate: '12/29/2019',
   },
   {
@@ -128,9 +112,7 @@ const data = [
     state: 'Created',
     service: 'HPE GreenLake Private Cloud',
     tenant: 'Domain',
-    contact: {
-      email: 'priyanka@domain.com',
-    },
+    email: 'priyanka@domain.com',
     orderDate: '12/15/2019',
   },
   {
@@ -140,9 +122,7 @@ const data = [
     state: 'Accepted',
     service: 'VMaaS for R&D',
     tenant: 'Suncor Energy',
-    contact: {
-      email: 'melinda@suncor.co',
-    },
+    email: 'melinda@suncor.co',
     orderDate: '11/01/2019',
   },
   {
@@ -152,9 +132,7 @@ const data = [
     state: 'Processing',
     service: 'VMaaS for R&D',
     tenant: 'Coke',
-    contact: {
-      email: 'muhtar@coke.com',
-    },
+    email: 'muhtar@coke.com',
     orderDate: '11/01/2019',
   },
   {
@@ -164,9 +142,7 @@ const data = [
     state: 'Delivered',
     service: 'Mercury',
     tenant: 'Nestle',
-    contact: {
-      email: 'wan@nestle.com',
-    },
+    email: 'wan@nestle.com',
     orderDate: '11/01/2019',
   },
 ];
@@ -262,35 +238,17 @@ export const TableSingleSelectExample = () => {
       >
         Details
       </Heading>
-      <Box margin={{ horizontal: 'large' }} gap="small">
-        <DetailsPage
-          orderDetails="Order Name"
-          orderPageDetails={pageDetails.orderName}
-        />
-        <DetailsPage
-          orderDetails="Purchase Order"
-          orderPageDetails={pageDetails.purchaseOrder}
-        />
-        <DetailsPage
-          orderDetails="State"
-          orderPageDetails={pageDetails.state}
-        />
-        <DetailsPage
-          orderDetails="Services"
-          orderPageDetails={pageDetails.service}
-        />
-        <DetailsPage
-          orderDetails="Tenant"
-          orderPageDetails={pageDetails.tenant}
-        />
-        <DetailsPage
-          orderDetails="Order Date"
-          orderPageDetails={pageDetails.orderDate}
-        />
-        <DetailsPage
-          orderDetails="Contact"
-          orderPageDetails={pageDetails.contact.email}
-        />
+      <Box margin={{ vertical: 'small', horizontal: 'large' }} gap="small">
+        {pageDetails &&
+          Object.entries(pageDetails).map(([key, value]) => {
+            console.log(key, value);
+            return (
+              <DetailsPage
+                orderDetails={key}
+                orderPageDetails={value}
+              ></DetailsPage>
+            );
+          })}
       </Box>
     </>
   );

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -246,7 +246,7 @@ export const TableSingleSelectExample = () => {
               <DetailsPage
                 orderDetails={key}
                 orderPageDetails={value}
-              ></DetailsPage>
+               />
             );
           })}
       </Box>

--- a/aries-site/src/examples/components/table/TableSingleSelectExample.js
+++ b/aries-site/src/examples/components/table/TableSingleSelectExample.js
@@ -241,13 +241,12 @@ export const TableSingleSelectExample = () => {
       <Box margin={{ vertical: 'small', horizontal: 'large' }} gap="small">
         {pageDetails &&
           Object.entries(pageDetails).map(([key, value]) => (
-              <DetailsPage
-                key={key}
-                orderDetails={key}
-                orderPageDetails={value}
-               />
-            );
-         )}
+            <DetailsPage
+              key={key}
+              orderDetails={key}
+              orderPageDetails={value}
+            />
+          ))}
       </Box>
     </>
   );

--- a/aries-site/src/examples/components/table/TableSummaryExample.js
+++ b/aries-site/src/examples/components/table/TableSummaryExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Box, DataTable, Heading, ResponsiveContext, Text } from 'grommet';
 
 const data = [
@@ -116,7 +117,8 @@ const columns = [
   },
 ];
 
-export const TableSummaryExample = () => {
+// designSystemDemo is used for DS site can be removed in production.
+export const TableSummaryExample = ({ designSystemDemo }) => {
   const size = React.useContext(ResponsiveContext);
 
   return (
@@ -130,7 +132,9 @@ export const TableSummaryExample = () => {
       </Heading>
       <Box
         align="start"
-        height="medium"
+        // Height is restricted to keep doc pages more compact.
+        // In production dataTable hight should follow height guidelines
+        height={designSystemDemo ? undefined : 'medium'}
         margin={{ right: 'auto' }}
         overflow="auto"
       >
@@ -151,4 +155,8 @@ export const TableSummaryExample = () => {
       </Box>
     </>
   );
+};
+
+TableSummaryExample.propTypes = {
+  designSystemDemo: PropTypes.bool,
 };

--- a/aries-site/src/examples/components/table/TableSummaryExample.js
+++ b/aries-site/src/examples/components/table/TableSummaryExample.js
@@ -117,7 +117,7 @@ const columns = [
   },
 ];
 
-// designSystemDemo is used for DS site can be removed in production.
+// designSystemDemo is used for DS site only, can be removed in production.
 export const TableSummaryExample = ({ designSystemDemo }) => {
   const size = React.useContext(ResponsiveContext);
 
@@ -132,8 +132,8 @@ export const TableSummaryExample = ({ designSystemDemo }) => {
       </Heading>
       <Box
         align="start"
-        // Height is restricted to keep doc pages more compact.
-        // In production dataTable hight should follow height guidelines
+      // Height is restricted to keep inline doc page examples more compact.
+      // In production, DataTable height should follow height guidelines.
         height={designSystemDemo ? undefined : 'medium'}
         margin={{ right: 'auto' }}
         overflow="auto"

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -105,6 +105,7 @@ export const Example = ({
         <ResponsiveContext.Provider value={viewPort}>
           {React.cloneElement(children, {
             containerRef: inlineRef,
+            designSystemDemo: showLayer,
           })}
         </ResponsiveContext.Provider>
       </ExampleWrapper>
@@ -230,6 +231,7 @@ export const Example = ({
                     <ResponsiveContext.Provider value={viewPort}>
                       {React.cloneElement(children, {
                         containerRef: layerRef,
+                        designSystemDemo: showLayer,
                       })}
                     </ResponsiveContext.Provider>
                   </Box>

--- a/aries-site/src/pages/components/table.mdx
+++ b/aries-site/src/pages/components/table.mdx
@@ -247,6 +247,7 @@ the directionality and to which column the sort is currently applied.
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/table/TableSortable.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <TableSortable />
 </Example>
@@ -260,6 +261,7 @@ dragging the right side of its header to the left or to the right to expand the 
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/table/TableResizeColumnsExample.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <TableResizeColumnsExample />
 </Example>
@@ -284,6 +286,7 @@ This context could either be a page or a modal. In this example, clicking on a t
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/table/TableSingleSelectExample.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <TableSingleSelectExample />
 </Example>
@@ -297,6 +300,7 @@ batch actions via action control buttons or menus.
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/table/TableMultiSelectExample.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <TableMultiSelectExample />
 </Example>
@@ -324,6 +328,7 @@ maintain context across long and wide data sets.
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/table/TableFixedHeaderExample.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <TableFixedHeaderExample />
 </Example>
@@ -334,6 +339,7 @@ maintain context across long and wide data sets.
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/table/TableSummaryExample.js"
   docs="https://v2.grommet.io/datatable?theme=hpe#props"
   showResponsiveControls={['laptop', 'mobile']}
+  template
 >
   <TableSummaryExample />
 </Example>

--- a/aries-site/src/pages/components/table.mdx
+++ b/aries-site/src/pages/components/table.mdx
@@ -175,6 +175,16 @@ accessible in a tool specifically designed for analysis.
   - Align it horizontally with the rest of its layout context. Typically, this is aligned to the start of the content as opposed to stretched.
   - Align any header above the table, including heading, search, filter, actions, in the same way. This keeps an actions menu or button in the context of the table and prevents them from being orphaned. However, don't force the header above the table to align its width to the table, as that might compress the contents of the header too much.
 
+  ### Setting the height of a table
+  
+- Tables should be placed within the main content of the page, it is reccommended to use
+a good amount of space to display the data.
+- It is recommended to let the data set the height of the Table. The Table will grow as the data is larger.
+- Avoid having to condense the space in which the datatable is placed so the information does not seem cramped.
+- If space for Table has a set height then an overflow to the parent Box will need to be able to scroll to see all of the data. 
+- For larger sets of data it is advise to use Pagination to allow the user to navigate through the data.
+
+
 ### Wrapping and truncating
 
 When text exceeds the amount of space available within a table cell, [wrapping](#wrapping) or [truncation](#truncation) may be used depending on your use case. Below are some best practices to consider when implementing.

--- a/aries-site/src/pages/components/table.mdx
+++ b/aries-site/src/pages/components/table.mdx
@@ -176,14 +176,11 @@ accessible in a tool specifically designed for analysis.
   - Align any header above the table, including heading, search, filter, actions, in the same way. This keeps an actions menu or button in the context of the table and prevents them from being orphaned. However, don't force the header above the table to align its width to the table, as that might compress the contents of the header too much.
 
   ### Setting the height of a table
-  
-- Tables should be placed within the main content of the page, it is reccommended to use
-a good amount of space to display the data.
-- It is recommended to let the data set the height of the Table. The Table will grow as the data is larger.
-- Avoid having to condense the space in which the datatable is placed so the information does not seem cramped.
-- If space for Table has a set height then an overflow to the parent Box will need to be able to scroll to see all of the data. 
-- For larger sets of data it is advise to use Pagination to allow the user to navigate through the data.
 
+- Let the data set the height of the Table. The Table will grow in height as the length of data increases.
+- If it is expected a user will want to navigate to a specific portion of the data, pagination should be used. Generally, it is recommended that a page has a step of 20 records. For more information on pagination, read [Pagination guidance.](https://design-system.hpe.design/components/pagination#when-to-use)
+- Do not restrict the height of a table if the page has available space. This may introduce unnecessary scrolling.
+- If the height of a Table needs to be restricted, set `overflow=“auto”` on its parent Box to allow the user to scroll through the data.
 
 ### Wrapping and truncating
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR take shows the `table` examples when in full screen to not be shortened by the height set. 
#### Where should the reviewer start?
table/examples
#### What testing has been done on this PR?
design system
#### How should this be manually tested?
look at the examples in full screen 
#### Any background context you want to provide?
Some user may think they need to always restrict the height for the `table` however this is not true so we need to add guidance on when and when not to restrict the height. 
step one of #1826 
#### What are the relevant issues?
closes #1826
Need to add step 2 & 3 to close issue 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible