### PR TITLE
Populating Components pages metadata

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -318,7 +318,7 @@ export const components = [
       component: () => <CheckBoxPreview />,
       background: 'background-front',
     },
-    tags: ['check box', 'toggle', 'input type'],
+    tags: ['check box', 'toggle', 'input type', 'indeterminate'],
   },
   {
     name: 'CheckBoxGroup',

--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -28,12 +28,21 @@ export const components = [
     category: 'Controls',
     description: 'Used with text based navigation, such as inline text.',
     seoDescription: 'Used with text based navigation, such as inline text.',
-    sections: [],
+    sections: [
+      'Usage of Anchor vs. Button',
+      'Anchor Labeling',
+      'Inline Anchor',
+      'Anchor to external site',
+      'Anchor in a form',
+      'Disabled Anchor',
+      'Anchor with weight',
+    ],
     preview: {
       component: () => <AnchorPreview />,
       background: 'background-front',
     },
     relatedContent: ['Button', 'Typography', 'Forms'],
+    tags: ['hyperlinks', 'links', 'linking', 'navigation'],
   },
   {
     name: 'Button',
@@ -43,15 +52,25 @@ export const components = [
       'Buttons are used to indicate actions that can be performed.',
     relatedContent: ['Anchor', 'Menu', 'Tabs'],
     sections: [
+      'About Button',
+      'Button Labeling',
+      'Buttons vs. Anchors',
+      'Toggle Buttons',
+      'Toggle Buttons with Icons',
       'Default Button',
       'Primary Button',
       'Secondary Button',
       'Toolbar Button',
+      'Color Button',
+      'Button with Icon',
+      'Button States',
+      'Button Sizes',
     ],
     preview: {
       component: () => <ButtonPreview />,
       background: 'background-front',
     },
+    tags: ['buttons', 'actions', 'button style'],
   },
   {
     name: 'Card',
@@ -70,7 +89,17 @@ export const components = [
       },
     },
     relatedContent: ['Lists', 'Dashboards', 'Navigation'],
-    sections: [],
+    sections: [
+      'What makes up a Card',
+      'Dashboard Example',
+      'Navigation Example',
+      'Card as a Dashboard Element',
+      'Card with an Image',
+      'Card with a Footer',
+      'Grid, List, or Table',
+      'More Examples of a Card',
+    ],
+    tags: ['tiles', 'widgets', 'containers', 'cards'],
   },
   {
     name: 'Tabs',
@@ -79,12 +108,13 @@ export const components = [
       'Tabs allow a user to access content while maintaining the existing context.',
     seoDescription:
       'Tabs allow a user to access content while maintaining the existing context.',
-    sections: [],
+    sections: ['Tabs with icons', 'Tab states'],
     preview: {
       component: () => <TabsPreview />,
       background: 'background-front',
     },
     relatedContent: ['Button', 'Menu'],
+    tags: ['tabs', 'tab panels', 'navigation', 'containers'],
   },
   {
     name: 'DateInput',
@@ -94,11 +124,24 @@ export const components = [
     seoDescription:
       'A widget which allows the user to select a date or range of dates from a calendar.',
     relatedContent: ['Forms', 'TextInput', 'MaskedInput'],
-    sections: [],
+    sections: [
+      'When using Date Input, you should',
+      'Single Date',
+      'Date Range',
+    ],
     preview: {
       component: () => <DateInputPreview />,
       background: 'background-front',
     },
+    tags: [
+      'date input',
+      'date picker',
+      'picker',
+      'calendar',
+      'calendar input',
+      'select date',
+      'select date range',
+    ],
   },
   {
     name: 'FileInput',
@@ -106,7 +149,7 @@ export const components = [
     description: 'An input used to upload one or more files.',
     seoDescription: 'An input used to upload one or more files.',
     relatedContent: ['Forms', 'Select', 'TextInput', 'MaskedInput'],
-    sections: [],
+    sections: ['FileInput with multiple files', 'FileInput within a Form'],
     preview: {
       image: {
         src: {
@@ -117,6 +160,14 @@ export const components = [
         fit: 'contain',
       },
     },
+    tags: [
+      'input fields',
+      'input types',
+      'file input',
+      'upload files',
+      'file upload',
+      'files',
+    ],
   },
   {
     name: 'TextArea',
@@ -131,6 +182,13 @@ export const components = [
       background: 'background-front',
     },
     relatedContent: ['Forms', 'TextInput', 'MaskedInput'],
+    tags: [
+      'input fields',
+      'input types',
+      'large text',
+      'text area',
+      'text input',
+    ],
   },
   {
     name: 'TextInput',
@@ -139,12 +197,24 @@ export const components = [
       'The TextInput component allows the user to input shorter forms of data and content.',
     seoDescription:
       'The TextInput component allows the user to input shorter forms of data and content.',
-    sections: [],
+    sections: [
+      'About TextInput',
+      'Password',
+      'With suggestions',
+      'Labeled by icon',
+    ],
     preview: {
       component: () => <TextInputPreview />,
       background: 'background-front',
     },
     relatedContent: ['Forms', 'TextArea', 'MaskedInput'],
+    tags: [
+      'text input',
+      'input type text',
+      'text field',
+      'password',
+      'enter password',
+    ],
   },
   {
     name: 'Tip',
@@ -153,7 +223,13 @@ export const components = [
       'A Tip is used to specify extra information when the user moves the mouse pointer over the element.',
     seoDescription:
       'A Tip is used to specify extra information when the user moves the mouse pointer over the element.',
-    sections: [],
+    sections: [
+      'Truncation with Tip',
+      'Truncated Table Cell Content',
+      'Tip with icons',
+      'Tip with exit',
+      'Tip Content Length',
+    ],
     preview: {
       image: {
         src: {
@@ -163,19 +239,41 @@ export const components = [
         alt: 'HPE Tip preview',
       },
     },
-    relatedContent: ['Layer', 'Button', 'Header', 'Persistent Navigation'],
+    relatedContent: [
+      'Layer',
+      'Button',
+      'Header',
+      'Persistent Navigation',
+      'Table',
+    ],
+    tags: [
+      'tooltip',
+      'tool tip',
+      'hover',
+      'hover text',
+      'hint',
+      'truncation',
+      'truncate',
+    ],
   },
   {
     name: 'Search',
     category: 'Controls',
     description: 'Find content corresponding to keyword queries.',
     seoDescription: 'HPE Design System Search input design and code examples.',
-    sections: [],
+    sections: [
+      'Auto-suggestions',
+      'Returning search results',
+      'Search with Auto Suggestions',
+      'Simple Search',
+      'Icon Position',
+    ],
     preview: {
       component: () => <SearchPreview />,
       background: 'background-front',
     },
     relatedContent: ['TextInput', 'Header'],
+    tags: ['search input'],
   },
   {
     name: 'Select',
@@ -184,7 +282,7 @@ export const components = [
       'Flexible input allowing users to choose from a list of options.',
     seoDescription:
       'Select input component allows users to choose from a list of options.',
-    sections: [],
+    sections: ['When to use Select', 'Multi-Select', 'Select with Search'],
     preview: {
       component: () => <SelectPreview />,
       background: 'background-front',
@@ -197,6 +295,15 @@ export const components = [
       'TextInput',
       'MaskedInput',
     ],
+    tags: [
+      'select options',
+      'dropdown',
+      'drop-down',
+      'drop down',
+      'option list',
+      'multi select',
+      'multiple values',
+    ],
   },
   {
     name: 'CheckBox',
@@ -205,12 +312,13 @@ export const components = [
       'When the user needs to select one or more options, use a checkbox.',
     seoDescription:
       'Checkbox component for HPE Design System. UX usage examples and guidance on how to ensure a checkbox maintains accessiblity.',
-    sections: [],
+    sections: ['Toggle', 'CheckBox with Description'],
     relatedContent: ['CheckBoxGroup', 'Forms', 'RadioButtonGroup', 'Select'],
     preview: {
       component: () => <CheckBoxPreview />,
       background: 'background-front',
     },
+    tags: ['check box', 'toggle', 'input type'],
   },
   {
     name: 'CheckBoxGroup',
@@ -219,12 +327,13 @@ export const components = [
       'When the user needs to select one or more options from a set of options, use a CheckBoxGroup.',
     seoDescription:
       'CheckBoxGroup component for HPE Design System. UX usage examples and guidance on how to ensure a checkbox maintains accessiblity.',
-    sections: [],
+    sections: ['With options as array of objects', 'Scroll'],
     relatedContent: ['Forms', 'RadioButtonGroup', 'CheckBox', 'Select'],
     preview: {
       component: () => <CheckBoxGroupPreview />,
       background: 'background-front',
     },
+    tags: ['checkbox', 'checkbox group', 'check box group', 'grouped'],
   },
   {
     name: 'Accordion',
@@ -243,7 +352,8 @@ export const components = [
     relatedContent: ['Layer', 'Lists', 'Tabs'],
     seoDescription:
       'The accordion affords content to be delivered progressively.',
-    sections: [],
+    sections: ['About Accordion'],
+    tags: ['accordian', 'acordion', 'collapse', 'panel', 'expand'],
   },
   {
     name: 'Header',
@@ -252,12 +362,23 @@ export const components = [
       'Header is a Box with a set of preset properties for introductory content.',
     seoDescription:
       'Header is a Box with a set of preset properties for introductory content.',
-    sections: [],
+    sections: [
+      'About Header',
+      'Application Header',
+      'Page Header',
+      'Header with navigation buttons',
+      'Header with main action',
+      'Header with search',
+      'Header with avatar',
+      'Header with search and actions',
+      'Header for a single page',
+    ],
     preview: {
       component: () => <HeaderPreview />,
       justify: 'start',
     },
     relatedContent: ['Button', 'Menu', 'TextInput', 'Dashboards', 'Search'],
+    tags: ['app headers', 'navigation', 'page sections', 'page layouts'],
   },
   {
     name: 'Footer',
@@ -266,12 +387,18 @@ export const components = [
       'Footer is a Box with a set of preset properties. Box properties allow you to customize the footer.',
     seoDescription:
       'Footer is a Box with a set of preset properties. Box properties allow you to customize the footer.',
-    sections: [],
+    sections: [
+      'Application Footer',
+      'Page Footer',
+      'Footer for a single page',
+      'App footer with page footer',
+    ],
     preview: {
       component: () => <FooterPreview />,
       justify: 'end',
     },
     relatedContent: ['Header', 'Button', 'Dashboards'],
+    tags: ['app footers', 'navigation', 'page sections', 'page layouts'],
   },
   {
     name: 'Menu',
@@ -286,6 +413,7 @@ export const components = [
       background: 'background-front',
     },
     relatedContent: ['Header', 'Dashboards', 'Select'],
+    tags: ['dropdown', 'drop down', 'actions', 'navigation'],
   },
   {
     name: 'Box',
@@ -299,6 +427,7 @@ export const components = [
       component: () => <BoxPreview />,
       background: 'background-front',
     },
+    tags: ['sections', 'containers', 'content containers', 'layout', 'flexbox'],
   },
   {
     name: 'Grid',
@@ -312,6 +441,7 @@ export const components = [
     seoDescription:
       'The Grid component is used to layout content. Responsive grid is important to consider in every use case.',
     sections: [],
+    tags: ['layouts', 'page layouts', 'responsive layout', 'CSS grid'],
   },
   {
     name: 'Layer',
@@ -323,11 +453,21 @@ export const components = [
     },
     seoDescription:
       'The Layer component is flexible and can be used in multiple use cases such as modal, dialogs, or notifications.',
-    sections: [],
+    sections: ['Using Headings in Layer', 'Side Drawer Modal', 'Center Modal'],
     preview: {
       component: () => <LayerPreview />,
     },
     relatedContent: ['Forms', 'Button', 'Icons'],
+    tags: [
+      'slideout',
+      'panels',
+      'drawers',
+      'modals',
+      'side panel',
+      'side drawer',
+      'drop',
+      'z-index',
+    ],
   },
   {
     name: 'Main',
@@ -337,6 +477,8 @@ export const components = [
     seoDescription:
       'The Main component is where you define the location and layout of the primary context of your content.',
     sections: [],
+    relatedContent: ['Header', 'Footer', 'Grid', 'Box'],
+    tags: ['layouts', 'page sections', 'header', 'footer'],
   },
   {
     name: 'MaskedInput',
@@ -345,17 +487,37 @@ export const components = [
       'MaskedInput allows you to specify formalized text within a form field.',
     seoDescription:
       'MaskedInput allows you to specify formalized text within a form field.',
-    sections: [],
+    sections: [
+      'IP Address',
+      'IP Range',
+      'Size with units',
+      'Email',
+      'Time',
+      'Date',
+    ],
     preview: {
       component: () => <MaskedInputPreview />,
       background: 'background-front',
     },
-    relatedContent: ['TextInput', 'Forms', 'Select'],
+    relatedContent: ['TextInput', 'Forms', 'Select', 'DateInput'],
+    tags: [
+      'input mask',
+      'edit mask',
+      'formatted input',
+      'entry format',
+      'input format',
+      'format',
+      'data entry',
+      'validation',
+      'form validation',
+      'form inputs',
+    ],
   },
   {
     name: 'Notification',
     category: 'Visualizations',
-    description: 'Notifications deliver transparent clarity for task and system statuses.',
+    description:
+      'Notifications deliver transparent clarity for task and system statuses.',
     preview: {
       image: {
         src: {
@@ -371,8 +533,25 @@ export const components = [
     designs, and guidance for how HPE applications can deliver end users 
     confidence and assurance by keeping them informed with timely, relevant 
     status of their systems and tasks.`,
-    sections: [],
+    sections: [
+      'State v.s. Status',
+      'Notification Systems',
+      'Toast Notification',
+    ],
     relatedContent: ['Status Indicator', 'Toast Notifications', 'Stack'],
+    tags: [
+      'banner',
+      'toast',
+      'alert',
+      'badge',
+      'system notification',
+      'global notification',
+      'inline notification',
+      'success message',
+      'status message',
+      'notification center',
+      'taxonomy',
+    ],
   },
   {
     name: 'RadioButtonGroup',
@@ -381,12 +560,13 @@ export const components = [
       'When one option of a set of options can be specified, use the RadioButtonGroup component.',
     seoDescription:
       'When one option of a set of options can be specified, use the RadioButtonGroup component.',
-    sections: [],
+    sections: ['When to use RadioButtonGroup'],
     preview: {
       component: () => <RadioButtonGroupPreview />,
       background: 'background-front',
     },
     relatedContent: ['CheckBoxGroup', 'Select', 'Forms'],
+    tags: ['grouped radio button', 'radio button group', 'radio button'],
   },
   {
     name: 'RangeInput',
@@ -400,6 +580,7 @@ export const components = [
       component: () => <RangeInputPreview />,
       background: 'background-front',
     },
+    tags: ['slider', 'slider input', 'volume control', 'range input'],
   },
   {
     name: 'Stack',
@@ -413,6 +594,7 @@ export const components = [
     seoDescription:
       'A Stack component is a container that stacks content on top of each other.',
     sections: [],
+    tags: ['containers', 'layers', 'z-index'],
   },
   {
     name: 'Spinner',
@@ -429,7 +611,24 @@ export const components = [
     },
     seoDescription: 'A loading state for quick asynchronous tasks.',
     relatedContent: ['Lists', 'Table', 'Forms'],
-    sections: [],
+    sections: [
+      'When to use Spinner',
+      'Spinner within a list',
+      'Spinner with announcement on screen reader',
+      'Spinner loading content',
+    ],
+    tags: [
+      'loading',
+      'loading indicator',
+      'transition',
+      'pinwheel',
+      'waiting',
+      'throbber',
+      'spinning wheel',
+      'progress indicator',
+      'progress bar',
+      'splash screen',
+    ],
   },
   {
     name: 'Table',
@@ -447,7 +646,38 @@ export const components = [
     },
     relatedContent: ['Filtering', 'Lists', 'Card', 'Pagination'],
     seoDescription: 'Data presentation in column and row format.',
-    sections: [],
+    sections: [
+      'What makes up a table',
+      'Finding a specific record',
+      'Narrowing a result set',
+      'Browsing a result set',
+      'Assembling a data set',
+      'Setting the width of the table',
+      'Wrapping and truncating',
+      'Truncation',
+      'Options for Positioning Truncation',
+      'Wrapping',
+      'Table behaviors and actions',
+      'Sorting',
+      'Resizeable columns',
+      'Searching and filtering tables',
+      'Navigation via table',
+      'Selecting multiple records & batch actions',
+      'Paginated',
+      'Fixing header row and/or columns',
+      'Column summaries & aggregation',
+      'Use pagination or infinite scroll with tables',
+    ],
+    tags: [
+      'data table',
+      'sorting columns',
+      'sort data',
+      'filtering',
+      'colums',
+      'rows',
+      'tables',
+      'truncation',
+    ],
   },
   {
     name: 'Pagination',
@@ -467,8 +697,17 @@ export const components = [
     },
     seoDescription: `Pagination divides content into separate pages in order to 
     enhance navigation to specific items.`,
-    sections: [],
+    sections: [
+      'When to use Pagination',
+      'Number of results per page',
+      'Placement of pagination component',
+      'Showing summary of results',
+      'Paginated Table',
+      'Paginated List',
+      'Paginated Cards',
+    ],
     relatedContent: ['Table', 'Lists', 'Card'],
+    tags: ['paginated results', 'paginated data'],
   },
   {
     name: 'All Components',
@@ -487,7 +726,32 @@ export const components = [
       },
     },
     seoDescription: 'View all HPE Design System and Grommet components.',
-    sections: [],
+    sections: [
+      'Sidebar',
+      'Markdown',
+      'Drop',
+      'RangeSelector',
+      'Avatar',
+      'Calendar',
+      'Clock',
+      'DataChart',
+      'Diagram',
+      'Meter',
+      'WorldMap',
+      'Media',
+      'Carousel',
+      'Image',
+      'Video',
+      'Utilities',
+      'AnnounceContext',
+      'Collapsible',
+      'Grommet',
+      'InfiniteScroll',
+      'Keyboard',
+      'ResponsiveContext',
+      'SkipLinks',
+      'ThemeContext',
+    ],
     relatedContent: [],
   },
 ];

--- a/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
+++ b/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
@@ -2,28 +2,23 @@ import React from 'react';
 import { Box, CheckBoxGroup, Form, FormField } from 'grommet';
 
 export const CheckBoxGroupScrollExample = () => (
-    <Form>
-      <FormField
-        pad="xsmall"
-        name="scroll-checkbox"
-        label="Label"
-        htmlFor="scroll-checkbox"
-      >
-        <Box width="medium" overflow="auto" height="small">
-          <CheckBoxGroup
-            name="scroll-checkbox"
-            id="scroll-checkbox"
-            options={[
-              'Option 1',
-              'Option 2',
-              'Option 3',
-              'Option4',
-              'Option5',
-              'Option6',
-              'Option7',
-            ]}
-          />
-        </Box>
-      </FormField>
-    </Form>
-  );
+  <Form>
+    <FormField name="scroll-checkbox" label="Label" htmlFor="scroll-checkbox">
+      <Box width="medium" overflow="auto" height="small">
+        <CheckBoxGroup
+          name="scroll-checkbox"
+          id="scroll-checkbox"
+          options={[
+            'Option 1',
+            'Option 2',
+            'Option 3',
+            'Option4',
+            'Option5',
+            'Option6',
+            'Option7',
+          ]}
+        />
+      </Box>
+    </FormField>
+  </Form>
+);

--- a/aries-site/src/examples/components/spinner/ListSpinnerExample.js
+++ b/aries-site/src/examples/components/spinner/ListSpinnerExample.js
@@ -41,14 +41,14 @@ export const ListSpinnerExample = () => (
     <List
       background="background-front"
       data={data}
-      action={item => <Text>{item.option}</Text>}
+      action={item => <Text key={item.name}>{item.option}</Text>}
       onClickItem={e => {
         // eslint-disable-next-line no-alert
         alert(`You clicked on ${e.item.name}`);
       }}
     >
-      {(datum, index) => (
-        <Box direction="row" gap="small" align="center" key={index}>
+      {datum => (
+        <Box key={datum.name} direction="row" gap="small" align="center">
           {datum.icon}
           <Text weight="bold">{datum.name}</Text>
         </Box>

--- a/aries-site/src/examples/templates/list-views/ListIconIdentifierExample.js
+++ b/aries-site/src/examples/templates/list-views/ListIconIdentifierExample.js
@@ -37,22 +37,22 @@ const data = [
 ];
 
 export const ListIconIdentifierExample = () => (
-    <Box width={{ max: 'xxlarge' }} margin="auto" fill>
-      <List
-        background="background-front"
-        data={data}
-        action={item => <Text>{item.option}</Text>}
-        onClickItem={e => {
-          // eslint-disable-next-line no-alert
-          alert(`You clicked on ${e.item.name}`);
-        }}
-      >
-        {(datum, index) => (
-          <Box direction="row" gap="small" align="center" key={index}>
-            {datum.icon}
-            <Text weight="bold">{datum.name}</Text>
-          </Box>
-        )}
-      </List>
-    </Box>
-  );
+  <Box width={{ max: 'xxlarge' }} margin="auto" fill>
+    <List
+      background="background-front"
+      data={data}
+      action={item => <Text key={item.name}>{item.option}</Text>}
+      onClickItem={e => {
+        // eslint-disable-next-line no-alert
+        alert(`You clicked on ${e.item.name}`);
+      }}
+    >
+      {datum => (
+        <Box key={datum.name} direction="row" gap="small" align="center">
+          {datum.icon}
+          <Text weight="bold">{datum.name}</Text>
+        </Box>
+      )}
+    </List>
+  </Box>
+);

--- a/aries-site/src/pages/components/footer.mdx
+++ b/aries-site/src/pages/components/footer.mdx
@@ -27,7 +27,7 @@ The most common footer is an [App footer](#app-footer) which is contains legal a
 
 The other type of footer is a [Page footer](#page-footer) which contains additional actions or resources specific to a single page of an application.
 
-### App Footer
+### Application Footer
 
 A simple, clean and straightforward app footer displays useful information for the user that couldn’t be displayed on the header. This Footer is typically present on every screen of an application and its contents are universal to the entire application.
 

--- a/aries-site/src/pages/components/header.mdx
+++ b/aries-site/src/pages/components/header.mdx
@@ -54,11 +54,11 @@ While Header is flexible in its composition, there are some important guidelines
 - Contains brand logo and application/service name
 - Links to the landing page of your application
 
-### App Header
+### Application Header
 
 An app-level Header sets the context for an entire application. It should contain the HPE or Aruba logo alongside text that provides the application name on the left side of the Header.
 
-**Here are some elements that are appropriate for an App Header:**
+**Here are some elements that are appropriate for an Application Header:**
 
 - Application navigation structure
 - Profile Avatar button that leads to account information

--- a/aries-site/src/pages/components/pagination.mdx
+++ b/aries-site/src/pages/components/pagination.mdx
@@ -13,7 +13,7 @@ import {
   <PaginationExample />
 </Example>
 
-## When to use
+## When to use Pagination
 
 Use pagination when a user’s goal is to find a specific item rather than to peruse the full set of data. By breaking the data up into smaller, consistently sized groups, the user is more easily able to jump to specific sections of the data.
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- To expand searchable surface, populates the sections and tags metadata for Components pages.
- Also opportunistic clean up of examples throwing console warnings

Related to https://github.com/grommet/hpe-design-system/issues/1849

#### Where should the reviewer start?

data/structures/components.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

Related to https://github.com/grommet/hpe-design-system/issues/1849

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
