### PR TITLE
Fix yarn lint import error

### DIFF
--- a/aries-site/src/examples/cardPreviews/code-blocks.js
+++ b/aries-site/src/examples/cardPreviews/code-blocks.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Box } from 'grommet';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { useDarkMode } from '../../utils';
 import { prism } from 'grommet-theme-hpe';
+import { useDarkMode } from '../../utils';
 
 export const CodeBlocksPreview = () => {
   const themeMode = useDarkMode().value ? 'dark' : 'light';

--- a/aries-site/src/examples/templates/code-blocks/CodeBlocks.js
+++ b/aries-site/src/examples/templates/code-blocks/CodeBlocks.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Box } from 'grommet';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { useDarkMode } from '../../../utils';
 import { prism } from 'grommet-theme-hpe';
+import { useDarkMode } from '../../../utils';
 
 export const CodeBlockExample = () => {
   const themeMode = useDarkMode().value ? 'dark' : 'light';


### PR DESCRIPTION
#### What does this PR do?
Fixes a yarn lint error introduced from my code-blocks PR
`error 'grommet-theme-hpe' import should occur before import of '../../../utils'  import/order`
#### Where should the reviewer start?

#### What testing has been done on this PR?
`yarn lint`

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible