### PR TITLE
Remove StyledCard

### DIFF
--- a/aries-site/src/components/cards/ContentCard.js
+++ b/aries-site/src/components/cards/ContentCard.js
@@ -6,16 +6,12 @@ import { Identifier } from 'aries-core';
 import { PreviewImageCard } from './PreviewCard';
 import { useDarkMode } from '../../utils';
 
-export const StyledCard = styled(Card)`
-  transition: all 0.2s ease-in-out;
-`;
-
 export const ContentCard = forwardRef(({ topic, minimal, ...rest }, ref) => {
   const { description, name, parent, preview, render } = topic;
   const [isFocused, setIsFocused] = React.useState(false);
   const darkMode = useDarkMode();
   return (
-    <StyledCard
+    <Card
       elevation={isFocused ? 'large' : 'medium'}
       fill
       onBlur={() => setIsFocused(false)}
@@ -71,7 +67,7 @@ export const ContentCard = forwardRef(({ topic, minimal, ...rest }, ref) => {
           <Text size="small">{description}</Text>
         </Box>
       </CardBody>
-    </StyledCard>
+    </Card>
   );
 });
 

--- a/aries-site/src/components/cards/ContentPreviewCard.js
+++ b/aries-site/src/components/cards/ContentPreviewCard.js
@@ -1,10 +1,10 @@
 import React, { forwardRef, useState } from 'react';
-import { StyledCard } from './ContentCard';
+import { Card } from 'grommet';
 
 export const ContentPreviewCard = forwardRef(({ ...rest }, ref) => {
   const [isFocused, setIsFocused] = useState(false);
   return (
-    <StyledCard
+    <Card
       align="start"
       fill="horizontal"
       background="background-front"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6581,9 +6581,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.878:
-  version "1.3.879"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.879.tgz#4aba9700cfb241fb95c6ed69e31785e3d1605a43"
-  integrity sha512-zJo+D9GwbJvM31IdFmwcGvychhk4KKbKYo2GWlsn+C/dxz2NwmbhGJjWwTfFSF2+eFH7VvfA8MCZ8SOqTrlnpw==
+  version "1.3.880"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.880.tgz#58d1a298c5267f2faf440683d038c50ab39a6401"
+  integrity sha512-iwIP/6WoeSimzUKJIQtjtpVDsK8Ir8qQCMXsUBwg+rxJR2Uh3wTNSbxoYRfs+3UWx/9MAnPIxVZCyWkm8MT0uw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -8048,9 +8048,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
-  version "13.11.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.11.0.tgz#40ef678da117fe7bd2e28f1fab24951bd0255be7"
-  integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
+  integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
   dependencies:
     type-fest "^0.20.2"
 
@@ -8132,8 +8132,8 @@ graphlib@^2.1.5:
 
 grommet-icons@^4.6.2, "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
   version "4.6.2"
-  uid dd88f115034a6f8c15afd8df6c70d15ad50fb96d
-  resolved "https://github.com/grommet/grommet-icons/tarball/stable#dd88f115034a6f8c15afd8df6c70d15ad50fb96d"
+  uid bb2272b8233c2d180be6bd1a508a10f3bbc24e60
+  resolved "https://github.com/grommet/grommet-icons/tarball/stable#bb2272b8233c2d180be6bd1a508a10f3bbc24e60"
   dependencies:
     grommet-styles "^0.2.0"
 
@@ -8144,12 +8144,12 @@ grommet-styles@^0.2.0:
 
 "grommet-theme-hpe@https://github.com/grommet/grommet-theme-hpe/tarball/stable":
   version "0.0.0"
-  resolved "https://github.com/grommet/grommet-theme-hpe/tarball/stable#dc5523aa4213b3f8dbd1f7765d5ee0b68bf73868"
+  resolved "https://github.com/grommet/grommet-theme-hpe/tarball/stable#098f57f2e036e6e3395e7662eb1b66369be9ccac"
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.18.0"
-  uid "5cc7cda4756c4aef7c6118b450735e6d54d335f9"
-  resolved "https://github.com/grommet/grommet/tarball/stable#5cc7cda4756c4aef7c6118b450735e6d54d335f9"
+  uid fa89fc32d2906c8aa08fd71dba8079876a65d8a9
+  resolved "https://github.com/grommet/grommet/tarball/stable#fa89fc32d2906c8aa08fd71dba8079876a65d8a9"
   dependencies:
     grommet-icons "^4.6.2"
     hoist-non-react-statics "^3.2.0"
@@ -10072,9 +10072,9 @@ kleur@^3.0.3:
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 klona@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
-  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
+  integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -12944,9 +12944,9 @@ requires-port@^1.0.0:
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.1.tgz#7e2c110efbf3d70df3482604bcf2bc0ab571346a"
+  integrity sha512-Jjt8Us6hAWJpjucyladHvUGR+q1mHHgWtGDXlhvvKyNyIeQ3bjuWLDX0bsTLhbm/gd4iXEACBlODUHBlLWiNnA==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-1997--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

With the addition of [card elevation to the theme](https://github.com/grommet/grommet/pull/5736), props are not being forwarded through multiple layers of Styled-Components. This PR removes `styled(Card)` which alleviates the multi-layered Styled-Components. This is intended as a stop-gap fix until a solution to the layered Styled-Components is found.

#### Where should the reviewer start?

ContentCard.js

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:
- [x] Console is free of warnings and errors
- [x] Light & dark modes
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Keyboard interactions
- [x] Screen reader experience

#### How should this be manually tested?

View instances of Cards on home page and index pages such as /components.

Confirm the desired visual and behavior, plus verify the checklist above.

#### Any background context you want to provide?

With the addition of [card elevation to the theme](https://github.com/grommet/grommet/pull/5736), props are not being forwarded through multiple layers of Styled-Components. This PR removes `styled(Card)` which alleviates the multi-layered Styled-Components. This is intended as a stop-gap fix until a solution to the layered Styled-Components is found.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

No.

#### Is this change backwards compatible or is it a breaking change?

Compatible.
