### PR TITLE
add button hover theme changes for review

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -2,6 +2,35 @@ import { hpe } from 'grommet-theme-hpe';
 import { deepMerge } from 'grommet/utils';
 
 export const aries = deepMerge(hpe, {
+  button: {
+    hover: {
+      primary: {
+        // Designs call for using text-strong for the text color.
+        // Keeping the label color the same on hover to maintain readablility.
+        color: hpe.global.colors['text-strong'].light,
+        background: {
+          dark: 'validation-ok',
+          // Designs call for using a lower opacity of exisiting green!
+          // instead of creating a new color name for this single usecase.
+          light: {
+            color: 'green!',
+            opacity: 0.75,
+          },
+        },
+        extend: ({ colorValue, primary, theme }) => `
+      ${primary &&
+        colorValue &&
+        `:hover {
+        background-color: ${
+          theme.dark
+            ? theme.global.colors[colorValue].dark
+            : theme.global.colors[colorValue].light
+        };
+      }`}
+    `,
+      },
+    },
+  },
   defaultMode: 'dark',
   // To be stripped out once theme changes are made in grommet-theme-hpe
   // keeping file for use as playground for future theme adjusments that need


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR add theme for `hover` on `primary` buttons
#### Where should the reviewer start?
ariestheme
#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
button page on design system site
#### Any background context you want to provide?

There is still going to be work done with the `colored` button so to keep backward capability I put in the `extend` to not change the color on hover until that work is completed on the design side and research is complete. 

```
        extend: ({ colorValue, primary, theme }) => `
      ${primary &&
        colorValue &&
        `:hover {
        background-color: ${
          theme.dark
            ? theme.global.colors[colorValue].dark
            : theme.global.colors[colorValue].light
        };
      }`}
    `,
      },
```

I needed to add the `dark mode text color` to be black in order to align with the designs. without explicitly giving the text color black it was taking our contrast grey color for the text color as you can see below in the screenshot. 

<img width="200" alt="Screen Shot 2021-12-15 at 3 31 23 PM" src="https://user-images.githubusercontent.com/42451602/146275023-d7245b9d-c177-4f3e-97ef-490fb02e255f.png">

#### What are the relevant issues?
closes #2122 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
yes in theme updates
#### Is this change backwards compatible or is it a breaking change?
backwards compatible