### PR TITLE
allow figcaption to display below example controls

### DIFF
--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -126,10 +126,7 @@ export const Example = ({
     </ExampleContainer>
   );
 
-  if (caption)
-    content = <FigureWrapper caption={caption}>{content}</FigureWrapper>;
-
-  const controls = (designer ||
+  const exampleControls = (designer ||
     docs ||
     figma ||
     guidance ||
@@ -146,6 +143,17 @@ export const Example = ({
       setShowLayer={value => setShowLayer(value)}
     />
   );
+
+  if (!horizontalLayout)
+    content = (
+      <>
+        {content}
+        {exampleControls}
+      </>
+    );
+
+  if (caption)
+    content = <FigureWrapper caption={caption}>{content}</FigureWrapper>;
 
   const resources = (
     <ExampleResources
@@ -176,22 +184,21 @@ export const Example = ({
               screen={screen}
             />
           )}
-          {!horizontalLayout ? (
-            <>
-              {content}
-              {controls}
-              {resources}
-            </>
-          ) : (
+          {horizontalLayout ? (
             <HorizontalExample
               content={content}
-              controls={controls}
+              controls={exampleControls}
               height={height}
               plain={plain}
               resources={resources}
               showResponsiveControls={showResponsiveControls}
               width={width}
             />
+          ) : (
+            <>
+              {content}
+              {resources}
+            </>
           )}
         </>
       </Box>

--- a/aries-site/src/pages/components/rangeinput.mdx
+++ b/aries-site/src/pages/components/rangeinput.mdx
@@ -10,7 +10,7 @@ import { RangeInputExample } from '../../examples';
     provides a handle the user can move to make changes 
     to values. It is important that the slider provides 
     a value displayed to communicate with the user. This
-    help ensure conficence in the use of the control.`,
+    help ensure confidence in the use of the control.`,
   ]}
   figma="https://www.figma.com/file/BqCjvjc0rECQ4Ln2QhyjNi/HPE-Range-Input-Component?node-id=1%3A11"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/RangeInput/RangeInput.js"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2225--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Modifies how the figcaption and exampleControls are built up. Previously, if trying to use both `caption` and example controls (figma link, grommet links, etc.), the caption would be inserted between the example and the controls, this ensures the caption is displayed below the example container.

**Before**
![Screen Shot 2022-01-18 at 3 50 32 PM](https://user-images.githubusercontent.com/1756948/150031563-2c3283de-5e3c-4a4b-a82a-88f79b9cfa77.png)

**After**
![Screen Shot 2022-01-18 at 3 49 54 PM](https://user-images.githubusercontent.com/1756948/150031547-cae2e1e8-34d9-46b1-a6b5-e7ca0d6e63d1.png)

#### Where should the reviewer start?

Example.js

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [x] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [x] Passes E2E commit checks
- [x] Visual snapshots are reasonable

#### How should this be manually tested?

Modify an Example displaying controls, add a caption, then verify caption placement visually and within the DOM (`<figcaption>` should be last child of `<figure>`).

For example:
```
<Example
  code={[
    "https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/dashboards/DashboardExample.js",  
    "https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/dashboards/components/DashboardGrid.js",
    "https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/dashboards/components/DashboardCard.js", 
    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/global-header/components/GlobalHeader.js',
    "https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/dashboards/components/data.js", 
    ]}
  template
  showResponsiveControls={['laptop', 'mobile']}
  width="100%"
  caption="test"
>
  <DashboardExample />
</Example>
```

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
