### PR TITLE
Add fullscreen mode to responsive controls

### DIFF
--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -247,7 +247,7 @@ export const Example = ({
                 animation={{
                   type: 'fadeIn',
                   delay: 200,
-                  duration: 1500,
+                  duration: 800,
                 }}
                 background={
                   ExampleWrapper === ResponsiveContainer && background

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -141,6 +141,7 @@ export const Example = ({
       guidance={guidance}
       horizontalLayout={horizontalLayout}
       setFullscreen={value => setFullscreen(value)}
+      showResponsiveControls={showResponsiveControls}
     />
   );
 
@@ -211,7 +212,7 @@ export const Example = ({
             setScreen(screens.laptop);
           }}
         >
-          <Layer full animation="fadeIn">
+          <Layer full>
             <Box fill background="background">
               <Box
                 direction="row"
@@ -233,7 +234,7 @@ export const Example = ({
                   />
                 )}
                 <Button
-                  title="Leave fullscreen"
+                  tip="Leave Fullscreen"
                   icon={<Contract />}
                   onClick={() => {
                     setFullscreen(false);
@@ -243,6 +244,11 @@ export const Example = ({
                 />
               </Box>
               <Box
+                animation={{
+                  type: 'fadeIn',
+                  delay: 200,
+                  duration: 1500,
+                }}
                 background={
                   ExampleWrapper === ResponsiveContainer && background
                     ? background

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -48,7 +48,7 @@ export const Example = ({
   ...rest
 }) => {
   const [screen, setScreen] = React.useState(screens.laptop);
-  const [showLayer, setShowLayer] = React.useState(false);
+  const [fullscreen, setFullscreen] = React.useState(false);
   const size = useContext(ResponsiveContext);
   const inlineRef = useRef();
   const layerRef = useRef();
@@ -59,7 +59,7 @@ export const Example = ({
   const forceUpdate = useCallback(() => updateState({}), []);
   React.useEffect(() => {
     forceUpdate();
-  }, [showLayer, forceUpdate]);
+  }, [fullscreen, forceUpdate]);
 
   // If plain, we remove the Container that creates a padded
   // box with rounded corners around Example content
@@ -104,7 +104,7 @@ export const Example = ({
 
   // when Layer is open, we remove the inline Example to avoid
   // repeat id tags that may impede interactivity of inputs
-  let content = !showLayer && (
+  let content = !fullscreen && (
     <ExampleContainer as="section" {...containerProps}>
       <ExampleWrapper
         background={
@@ -119,7 +119,7 @@ export const Example = ({
         <ResponsiveContext.Provider value={viewPort}>
           {React.cloneElement(children, {
             containerRef: inlineRef,
-            designSystemDemo: showLayer,
+            designSystemDemo: fullscreen,
           })}
         </ResponsiveContext.Provider>
       </ExampleWrapper>
@@ -140,7 +140,7 @@ export const Example = ({
       grommetSource={grommetSource}
       guidance={guidance}
       horizontalLayout={horizontalLayout}
-      setShowLayer={value => setShowLayer(value)}
+      setFullscreen={value => setFullscreen(value)}
     />
   );
 
@@ -182,6 +182,8 @@ export const Example = ({
               controls={showResponsiveControls}
               onSetScreen={setScreen}
               screen={screen}
+              fullscreen={fullscreen}
+              setFullscreen={setFullscreen}
             />
           )}
           {horizontalLayout ? (
@@ -202,10 +204,10 @@ export const Example = ({
           )}
         </>
       </Box>
-      {showLayer && (
+      {fullscreen && (
         <Keyboard
           onEsc={() => {
-            setShowLayer(false);
+            setFullscreen(false);
             setScreen(screens.laptop);
           }}
         >
@@ -226,13 +228,15 @@ export const Example = ({
                     controls={showResponsiveControls}
                     onSetScreen={setScreen}
                     screen={screen}
+                    fullscreen={fullscreen}
+                    setFullscreen={setFullscreen}
                   />
                 )}
                 <Button
-                  title="Leave full screen"
+                  title="Leave fullscreen"
                   icon={<Contract />}
                   onClick={() => {
-                    setShowLayer(false);
+                    setFullscreen(false);
                     setScreen(screens.laptop);
                   }}
                   hoverIndicator
@@ -262,7 +266,7 @@ export const Example = ({
                     <ResponsiveContext.Provider value={viewPort}>
                       {React.cloneElement(children, {
                         containerRef: layerRef,
-                        designSystemDemo: showLayer,
+                        designSystemDemo: fullscreen,
                       })}
                     </ResponsiveContext.Provider>
                   </Box>

--- a/aries-site/src/layouts/content/Example/ExampleControls.js
+++ b/aries-site/src/layouts/content/Example/ExampleControls.js
@@ -18,7 +18,7 @@ export const ExampleControls = ({
   grommetSource,
   guidance,
   horizontalLayout,
-  setShowLayer,
+  setFullscreen,
 }) => {
   const size = useContext(ResponsiveContext);
   const isSmall = size === 'small';
@@ -111,7 +111,7 @@ export const ExampleControls = ({
           <FullscreenButton
             buttonSize={buttonSize}
             horizontalLayout={horizontalLayout}
-            setShowLayer={setShowLayer}
+            setFullscreen={setFullscreen}
           />
         )}
       </Box>
@@ -120,7 +120,7 @@ export const ExampleControls = ({
           <FullscreenButton
             buttonSize={buttonSize}
             horizontalLayout={horizontalLayout}
-            setShowLayer={setShowLayer}
+            setFullscreen={setFullscreen}
           />
         </Box>
       )}
@@ -136,20 +136,20 @@ ExampleControls.propTypes = {
   grommetSource: PropTypes.string,
   guidance: PropTypes.string,
   horizontalLayout: PropTypes.bool,
-  setShowLayer: PropTypes.func,
+  setFullscreen: PropTypes.func,
 };
 
-const FullscreenButton = ({ buttonSize, setShowLayer }) => (
+const FullscreenButton = ({ buttonSize, setFullscreen }) => (
   <Button
     icon={<Expand />}
     a11yTitle="See Fullscreen"
     tip="See Fullscreen"
-    onClick={() => setShowLayer(true)}
+    onClick={() => setFullscreen(true)}
     size={buttonSize}
   />
 );
 
 FullscreenButton.propTypes = {
   buttonSize: PropTypes.string,
-  setShowLayer: PropTypes.func,
+  setFullscreen: PropTypes.func,
 };

--- a/aries-site/src/layouts/content/Example/ExampleControls.js
+++ b/aries-site/src/layouts/content/Example/ExampleControls.js
@@ -19,10 +19,12 @@ export const ExampleControls = ({
   guidance,
   horizontalLayout,
   setFullscreen,
+  showResponsiveControls,
 }) => {
   const size = useContext(ResponsiveContext);
   const isSmall = size === 'small';
   const buttonSize = isSmall ? 'small' : undefined;
+  const fullscreenControl = !(horizontalLayout || showResponsiveControls);
 
   const boxProps = !horizontalLayout
     ? {
@@ -115,7 +117,7 @@ export const ExampleControls = ({
           />
         )}
       </Box>
-      {!horizontalLayout && (
+      {fullscreenControl && (
         <Box flex={false} alignSelf={isSmall ? 'end' : 'start'}>
           <FullscreenButton
             buttonSize={buttonSize}
@@ -137,6 +139,10 @@ ExampleControls.propTypes = {
   guidance: PropTypes.string,
   horizontalLayout: PropTypes.bool,
   setFullscreen: PropTypes.func,
+  showResponsiveControls: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.array,
+  ]),
 };
 
 const FullscreenButton = ({ buttonSize, setFullscreen }) => (

--- a/aries-site/src/layouts/content/Example/ResponsiveControls.js
+++ b/aries-site/src/layouts/content/Example/ResponsiveControls.js
@@ -1,21 +1,36 @@
-import React from 'react';
 import { Box, Button } from 'grommet';
 import PropTypes from 'prop-types';
-import { Desktop, PhoneVertical, PersonalComputer } from 'grommet-icons';
+import {
+  Desktop,
+  Expand,
+  PhoneVertical,
+  PersonalComputer,
+} from 'grommet-icons';
+
 import { screens } from '..';
 
-export const ResponsiveControls = ({ controls, onSetScreen, screen }) => {
-  // If controls is a boolean, we want all screen options to show by default
-  let desktop = true;
-  let laptop = true;
-  let mobile = true;
+export const ResponsiveControls = ({
+  controls: controlsProp,
+  onSetScreen,
+  screen,
+  fullscreen: displayingFullscreen,
+  setFullscreen,
+}) => {
+  // default controls to display
+  const controls = {
+    desktop: true,
+    laptop: true,
+    mobile: true,
+    fullScreen: false,
+  };
 
-  // Only show controls that are specified by the Example
-  if (Array.isArray(controls)) {
-    if (!controls.includes(screens.desktop)) desktop = false;
-    if (!controls.includes(screens.laptop)) laptop = false;
-    if (!controls.includes(screens.mobile)) mobile = false;
-  }
+  Object.entries(controls).forEach(([key]) => {
+    if (controlsProp === false) controls[key] = false;
+    else if (Array.isArray(controlsProp))
+      controls[key] = controlsProp.includes(key);
+  });
+
+  const { desktop, laptop, mobile, fullScreen } = controls;
 
   return (
     <Box direction="row" gap="xsmall">
@@ -49,6 +64,13 @@ export const ResponsiveControls = ({ controls, onSetScreen, screen }) => {
           }}
         />
       )}
+      {fullScreen && !displayingFullscreen && (
+        <Button
+          label="Interact in Fullscreen"
+          icon={<Expand />}
+          onClick={() => setFullscreen(true)}
+        />
+      )}
     </Box>
   );
 };
@@ -60,4 +82,6 @@ ResponsiveControls.propTypes = {
   ]).isRequired,
   onSetScreen: PropTypes.func.isRequired,
   screen: PropTypes.string.isRequired,
+  fullscreen: PropTypes.bool,
+  setFullscreen: PropTypes.func,
 };

--- a/aries-site/src/layouts/content/Example/ResponsiveControls.js
+++ b/aries-site/src/layouts/content/Example/ResponsiveControls.js
@@ -33,7 +33,7 @@ export const ResponsiveControls = ({
   const { desktop, laptop, mobile, fullScreen } = controls;
 
   return (
-    <Box direction="row" gap="xsmall">
+    <Box direction="row" gap="xsmall" wrap>
       {desktop && (
         <Button
           label="Desktop"

--- a/aries-site/src/layouts/content/Example/ResponsiveControls.js
+++ b/aries-site/src/layouts/content/Example/ResponsiveControls.js
@@ -71,6 +71,13 @@ export const ResponsiveControls = ({
           onClick={() => setFullscreen(true)}
         />
       )}
+      {!fullScreen && !displayingFullscreen && (
+        <Button
+          tip="See Fullscreen"
+          icon={<Expand />}
+          onClick={() => setFullscreen(true)}
+        />
+      )}
     </Box>
   );
 };

--- a/aries-site/src/pages/templates/page-layouts.mdx
+++ b/aries-site/src/pages/templates/page-layouts.mdx
@@ -133,6 +133,7 @@ export const LayoutPreviewGrid = () => {
     >
       {layouts.map(layout => (
         <ContentPreviewCard
+          key={layout.name}
           as="a"
           style={{ textDecoration: 'none' }}
           href={`#${nameToSlug(layout.name)}`}

--- a/aries-site/src/pages/templates/page-layouts.mdx
+++ b/aries-site/src/pages/templates/page-layouts.mdx
@@ -70,6 +70,7 @@ The border around page sections is for demonstration purposes only. Remove borde
   relevantComponents={['Header', 'Footer', 'Main']}
   width="100%"
   screenContainer
+  showResponsiveControls={['fullScreen']}
 >
   <HeaderFooterExample />
 </Example>

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,13 +53,6 @@
   dependencies:
     cross-fetch "3.1.2"
 
-"@applitools/dom-capture@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-capture/-/dom-capture-7.3.0.tgz#f9d747f3185c643234fb660cef62a150c754d1a9"
-  integrity sha512-jB9Cmmo901i2ogjTMF/iPGuG6R+NAhhXnYA4KMFL8N2WHRDyi9+U6X3E1Duv3KNsLNWSSQyJSHAy3E0T8I2diA==
-  dependencies:
-    "@applitools/functional-commons" "1.5.4"
-
 "@applitools/dom-capture@8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@applitools/dom-capture/-/dom-capture-8.0.0.tgz#71c6eb7f7fd21f518330878eeba4d28c5204605f"
@@ -73,14 +66,6 @@
   resolved "https://registry.yarnpkg.com/@applitools/dom-shared/-/dom-shared-1.0.4.tgz#1a59116f3f29fb140ac031949547531348c9d972"
   integrity sha512-WRGko/7pJLwcDbQ5r0q2KD58VemIHm+JyKeXSflQhJvQqA5ONYyBX6cZo0h3o1SqdlzQnWM5REzoxoOpOGflzQ==
 
-"@applitools/dom-snapshot@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.1.0.tgz#24be90ef39eba3cf31f91fad29d5b0666fea78b6"
-  integrity sha512-xqI6emGbvMqnOIM4TLXNgmQMS+kzJ5FvKmQMX/KLjEX5wHalMRl2YLeosJVbgjZx/3G+CyVGtZoMNG/dw+08lA==
-  dependencies:
-    "@applitools/functional-commons" "1.6.0"
-    css-tree "^1.0.0-alpha.39"
-
 "@applitools/dom-snapshot@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.2.0.tgz#72254be14ff073f6a2b05144e10dd2f1ae1ba93f"
@@ -90,25 +75,6 @@
     "@applitools/functional-commons" "1.6.0"
     css-tree "1.0.0-alpha.39"
     pako "1.0.11"
-
-"@applitools/eyes-sdk-core@12.2.9":
-  version "12.2.9"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes-sdk-core/-/eyes-sdk-core-12.2.9.tgz#a23acb0e04d350584689e12be76940cf718da267"
-  integrity sha512-oIE35m1YASLbWDkUoCO2ao8zltzMam4sR1JKUzPHttCy6n/c15aHKo20RoPjpCAUWcaOyS4xMFKcsRvPvUDpbw==
-  dependencies:
-    "@applitools/dom-capture" "7.3.0"
-    "@applitools/dom-snapshot" "4.1.0"
-    "@applitools/isomorphic-fetch" "3.0.0"
-    "@applitools/snippets" "2.0.1"
-    axios "0.19.2"
-    chalk "3.0.0"
-    cosmiconfig "6.0.0"
-    dateformat "3.0.3"
-    debug "4.2.0"
-    deepmerge "4.2.2"
-    png-async "0.9.4"
-    stack-trace "0.0.10"
-    tunnel "0.0.6"
 
 "@applitools/eyes-sdk-core@12.3.0":
   version "12.3.0"
@@ -140,11 +106,6 @@
     "@applitools/visual-grid-client" "15.0.9"
     chalk "^2.4.2"
     rimraf "^2.7.1"
-
-"@applitools/functional-commons@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@applitools/functional-commons/-/functional-commons-1.5.4.tgz#d32f2bbc6a2598872b3a385d054fcf8e40c30a40"
-  integrity sha512-R+p4fliS8j6YlZNSLgsx6cBpjlmZaec67v9PpophPW5vXnOJFVcELnoeO21AVG1kbHu0FeAk025xr99EUTppFw==
 
 "@applitools/functional-commons@1.6.0", "@applitools/functional-commons@^1.5.5":
   version "1.6.0"
@@ -209,11 +170,6 @@
   integrity sha512-rzEOvGoiEF4KnK0PJ9I0btdwnaNlIPLYhjF1vTEG15PoucbbKpix9fYusxWlDG7kMiZya8ZycVPc0woVlNaHRQ==
   dependencies:
     debug "^4.1.0"
-
-"@applitools/snippets@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@applitools/snippets/-/snippets-2.0.1.tgz#16d641c8d8c42ab13a0fb88979dda084e9a38087"
-  integrity sha512-oDgRfaKUfqY16GqKrLYKY8M/urBd/+DSWzZd1TOrXGwr8dX0hZ5bikJbApoOBPIp6wFmNNXvH4waPGR2MwD5FQ==
 
 "@applitools/snippets@2.0.3":
   version "2.0.3"
@@ -6038,7 +5994,7 @@ css-tree@1.0.0-alpha.39:
     mdn-data "2.0.6"
     source-map "^0.6.1"
 
-css-tree@^1.0.0-alpha.39, css-tree@^1.1.2:
+css-tree@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
@@ -8315,7 +8271,6 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.20.0"
-  uid e2689faee5f3bc171eaa78048c555cd4da70d59c
   resolved "https://github.com/grommet/grommet/tarball/stable#e2689faee5f3bc171eaa78048c555cd4da70d59c"
   dependencies:
     grommet-icons "^4.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2240--keen-mayer-a86c8b.netlify.app/templates/page-layouts)

#### What does this PR do?

Preparatory work to make view responsive behavior calls to action more prominent.

#### Where should the reviewer start?

ResponsiveControls.js
Example.js

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [x] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [x] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

Modify an `<Example />` such as on `page-layouts.mdx` and test various configurations for the `showResponsiveControls` prop.

Should show default Desktop, Laptop, Mobile controls:
```
<Example
  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js"
  figma="https://www.figma.com/file/4rdBkUlHd5MCVq3hvUOXHd/App-Page-Layouts?node-id=90%3A6545"
  relevantComponents={['Header', 'Footer', 'Main']}
  width="100%"
  screenContainer
>
  <HeaderFooterExample />
</Example>
```

Should show only controls contained in array:
```
<Example
  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js"
  figma="https://www.figma.com/file/4rdBkUlHd5MCVq3hvUOXHd/App-Page-Layouts?node-id=90%3A6545"
  relevantComponents={['Header', 'Footer', 'Main']}
  width="100%"
  screenContainer
  showResponsiveControls={['fullScreen', 'mobile']}
>
  <HeaderFooterExample />
</Example>
```

Should not show any controls:
```
<Example
  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js"
  figma="https://www.figma.com/file/4rdBkUlHd5MCVq3hvUOXHd/App-Page-Layouts?node-id=90%3A6545"
  relevantComponents={['Header', 'Footer', 'Main']}
  width="100%"
  screenContainer
  showResponsiveControls={false}
>
  <HeaderFooterExample />
</Example>
```

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
