### PR TITLE
Page layouts - Add wide page container example

### DIFF
--- a/aries-site/src/examples/templates/page-layouts/PageContainerInteractive.js
+++ b/aries-site/src/examples/templates/page-layouts/PageContainerInteractive.js
@@ -1,0 +1,64 @@
+import { useContext } from 'react';
+import { Header, Main, ResponsiveContext } from 'grommet';
+
+import { AppContainer, PageContainer, pageContainer } from './components';
+import { ContentArea } from './anatomy/components';
+
+// `demoStyle` is specific for the Design System site and is used
+// as a visual aid to help present layout concepts. Remove from
+// your implementation.
+const demoStyle = {
+  border: { style: 'dashed' },
+  flex: true,
+  gap: 'small',
+  pad: 'small',
+  round: { size: 'xsmall' },
+};
+
+export const PageContainerInteractive = () => {
+  const size = useContext(ResponsiveContext);
+  /* Children of PageContainer should maintain horizontal whitespace on
+   * each side of the child so that the content has room to breathe and
+   * is not tightly condensed against the browser window's edge.
+   *
+   * Spacing is executed as the padding on each child to allow background
+   * colors and scroll regions to behave properly.
+   */
+  const containerPad = pageContainer.pad[size];
+
+  return (
+    <AppContainer
+      /* `as`, `title`, and `demoStyle` for Design System site demonstration.
+         Remove from your implementation */
+      as={ContentArea}
+      title="AppContainer"
+      {...demoStyle}
+    >
+      {/* ContentArea is specific for the Design System site and is used
+       * as a visual aid to help present layout concepts. Remove from your
+       * implementation.
+       */}
+      <ContentArea title="Global Header" background="status-unknown" />
+      <PageContainer
+        kind="wide"
+        /* `as`, `title`, and `demoStyle` for Design System site demonstration.
+           Remove from your implementation */
+        as={ContentArea}
+        title="PageContainer"
+        {...demoStyle}
+      >
+        <Header pad={containerPad}>
+          {/* Typically, the Header will contain elements such as the page's
+           * h1, any "ascending a.k.a. back to parent" navigation, and/or
+           * page-level menu, action buttons, etc.
+           */}
+          <ContentArea title="Page Header" background="purple!" fill />
+        </Header>
+        <Main flex pad={containerPad}>
+          <ContentArea title="Page Content" background="orange" border fill />
+        </Main>
+      </PageContainer>
+      <ContentArea title="Global Footer" background="status-unknown" />
+    </AppContainer>
+  );
+};

--- a/aries-site/src/examples/templates/page-layouts/PageContainerInteractive.js
+++ b/aries-site/src/examples/templates/page-layouts/PageContainerInteractive.js
@@ -1,7 +1,11 @@
 import { useContext } from 'react';
-import { Header, Main, ResponsiveContext } from 'grommet';
+import { Header, Main } from 'grommet';
 
-import { AppContainer, PageContainer, pageContainer } from './components';
+import {
+  AppContainer,
+  PageContainer,
+  PageContainerContext,
+} from './components';
 import { ContentArea } from './anatomy/components';
 
 // `demoStyle` is specific for the Design System site and is used
@@ -16,7 +20,6 @@ const demoStyle = {
 };
 
 export const PageContainerInteractive = () => {
-  const size = useContext(ResponsiveContext);
   /* Children of PageContainer should maintain horizontal whitespace on
    * each side of the child so that the content has room to breathe and
    * is not tightly condensed against the browser window's edge.
@@ -24,7 +27,8 @@ export const PageContainerInteractive = () => {
    * Spacing is executed as the padding on each child to allow background
    * colors and scroll regions to behave properly.
    */
-  const containerPad = pageContainer.pad[size];
+  // const containerPad = pageContainer.pad[size];
+  const { pad: containerPad } = useContext(PageContainerContext);
 
   return (
     <AppContainer

--- a/aries-site/src/examples/templates/page-layouts/anatomy/AppAnatomy.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/AppAnatomy.js
@@ -22,7 +22,7 @@ export const AppAnatomy = () => {
         background="status-unknown"
         flex={false}
       />
-      <ContentArea title="Page Container" border fill />
+      <ContentArea title="Page Container" border flex />
       <ContentArea
         title="Global Footer"
         background="status-unknown"

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageAnatomy.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageAnatomy.js
@@ -18,7 +18,7 @@ export const PageAnatomy = () => {
       width={width}
     >
       <ContentArea title="Page Header" background="purple!" flex={false} />
-      <ContentArea title="Page Content" background="orange" border fill />
+      <ContentArea title="Page Content" background="orange" border flex />
     </ContentArea>
   );
 };

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,64 +1,100 @@
 import { useContext } from 'react';
-import { Header, Main, ResponsiveContext } from 'grommet';
+import { Box, Diagram, Stack, Text, ThemeContext } from 'grommet';
+import { LinkPrevious, LinkNext } from 'grommet-icons';
 
-import { AppContainer, PageContainer, pageContainer } from '../components';
 import { ContentArea } from './components';
 
-// `demoStyle` is specific for the Design System site and is used
-// as a visual aid to help present layout concepts. Remove from
-// your implementation.
-const demoStyle = {
-  border: { style: 'dashed' },
-  flex: true,
-  gap: 'small',
-  pad: 'small',
-  round: { size: 'xsmall' },
-};
+const connections = [
+  {
+    fromTarget: 'left-edge',
+    toTarget: 'label',
+    anchor: 'horizontal',
+    color: 'text-strong',
+  },
+  {
+    fromTarget: 'right-edge',
+    toTarget: 'label',
+    anchor: 'horizontal',
+    color: 'text-strong',
+  },
+];
+
+const PAGE_CONTAINER_WIDTH = '1608px';
+const PAGE_CONTAINER_SCALE = '80%';
 
 export const PageContainerWide = () => {
-  const size = useContext(ResponsiveContext);
-  /* Children of PageContainer should maintain horizontal whitespace on
-   * each side of the child so that the content has room to breathe and
-   * is not tightly condensed against the browser window's edge.
-   *
-   * Spacing is executed as the padding on each child to allow background
-   * colors and scroll regions to behave properly.
-   */
-  const containerPad = { horizontal: pageContainer.pad[size].horizontal };
+  const theme = useContext(ThemeContext);
+  const diagramHeight = theme.global.size.medium;
+  const diagramWidth = `${(diagramHeight.replace('px', '') * 4) / 3}px`;
+  const annotationMargin = `${(100 - PAGE_CONTAINER_SCALE.replace('%', '')) /
+    2}%`;
+
+  const widthAnnnotation = (
+    <Box
+      direction="row"
+      align="center"
+      justify="between"
+      fill="vertical"
+      margin={{ horizontal: annotationMargin }}
+      pad={{ top: 'xlarge' }}
+    >
+      <LinkPrevious id="left-edge" color="text-strong" />
+      <Box id="label" pad={{ horizontal: 'xsmall' }} background="orange">
+        <Text color="text-strong" weight="bold">
+          {PAGE_CONTAINER_WIDTH}
+        </Text>
+      </Box>
+      <LinkNext id="right-edge" color="text-strong" />
+    </Box>
+  );
 
   return (
-    <AppContainer
-      /* `as`, `title`, and `demoStyle` for Design System site demonstration.
-         Remove from your implementation */
-      as={ContentArea}
-      title="AppContainer"
-      {...demoStyle}
-    >
-      {/* ContentArea is specific for the Design System site and is used
-       * as a visual aid to help present layout concepts. Remove from your
-       * implementation.
-       */}
-      <ContentArea title="Global Header" background="status-unknown" />
-      <PageContainer
-        kind="wide"
-        /* `as`, `title`, and `demoStyle` for Design System site demonstration.
-           Remove from your implementation */
-        as={ContentArea}
-        title="PageContainer"
-        {...demoStyle}
+    <Stack>
+      <ContentArea
+        title="App Container"
+        border
+        flex={false}
+        gap="small"
+        round="xsmall"
+        width={diagramWidth}
       >
-        <Header pad={containerPad}>
-          {/* Typically, the Header will contain elements such as the page's
-           * h1, any "ascending a.k.a. back to parent" navigation, and/or
-           * page-level menu, action buttons, etc.
-           */}
-          <ContentArea title="Page Header" background="purple!" fill />
-        </Header>
-        <Main flex pad={containerPad}>
-          <ContentArea title="Page Content" background="orange" border fill />
-        </Main>
-      </PageContainer>
-      <ContentArea title="Global Footer" background="status-unknown" />
-    </AppContainer>
+        <ContentArea
+          title="Global Header"
+          background="status-unknown"
+          flex={false}
+        />
+        <Stack>
+          <Box>
+            <ContentArea
+              title="Page Container"
+              alignSelf="center"
+              border
+              flex={false}
+              gap="small"
+              width={PAGE_CONTAINER_SCALE}
+            >
+              <ContentArea
+                title="Page Header"
+                background="purple!"
+                flex={false}
+              />
+              <ContentArea
+                title="Page Content"
+                background="orange"
+                border
+                height="small"
+              />
+            </ContentArea>
+          </Box>
+          {widthAnnnotation}
+        </Stack>
+        <ContentArea
+          title="Global Footer"
+          background="status-unknown"
+          flex={false}
+        />
+      </ContentArea>
+      <Diagram connections={connections} />
+    </Stack>
   );
 };

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -55,9 +55,7 @@ export const PageContainerWide = () => {
           <ContentArea title="Page Header" background="purple!" fill />
         </Header>
         <Main flex pad={containerPad}>
-          <ContentArea title="Page Content" background="orange" border fill>
-            {size}
-          </ContentArea>
+          <ContentArea title="Page Content" background="orange" border fill />
         </Main>
       </PageContainer>
       <ContentArea title="Global Footer" background="status-unknown" />

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,5 +1,5 @@
-import { useContext } from 'react';
-import { Header, Main, ResponsiveContext } from 'grommet';
+import { useContext, useRef } from 'react';
+import { Header, Main, ResponsiveContext, ThemeContext } from 'grommet';
 
 import { AppContainer, PageContainer } from '../components';
 import { ContentArea } from './components';
@@ -16,8 +16,11 @@ const demoStyle = {
 
 export const PageContainerWide = () => {
   const size = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
+  const appContainerRef = useRef();
+
   return (
-    <AppContainer {...demoStyle}>
+    <AppContainer ref={appContainerRef} {...demoStyle}>
       <ContentArea title="Global Header" background="status-unknown" />
       <PageContainer {...demoStyle}>
         <Header>
@@ -31,7 +34,14 @@ export const PageContainerWide = () => {
           <ContentArea title="Page Header" background="purple!" fill />
         </Header>
         <Main flex>
-          <ContentArea title="Page Content" background="orange" border fill />
+          <ContentArea title="Page Content" background="orange" border fill>
+            {size} - {JSON.stringify(theme.global.breakpoints[size].value)}
+            <br />
+            {appContainerRef.current &&
+              JSON.stringify(
+                appContainerRef.current.getBoundingClientRect().width,
+              )}
+          </ContentArea>
         </Main>
       </PageContainer>
       <ContentArea title="Global Footer" background="status-unknown" />

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,7 +1,7 @@
 import { useContext, useRef } from 'react';
 import { Header, Main, ResponsiveContext, ThemeContext } from 'grommet';
 
-import { AppContainer, PageContainer } from '../components';
+import { AppContainer, PageContainer, pageContainer } from '../components';
 import { ContentArea } from './components';
 
 // `demoStyle` is specific for the Design System site and is used
@@ -17,23 +17,37 @@ const demoStyle = {
 export const PageContainerWide = () => {
   const size = useContext(ResponsiveContext);
   const theme = useContext(ThemeContext);
+  // Debugging - remove ref
   const appContainerRef = useRef();
+  /* Children of PageContainer should maintain horizontal whitespace on
+   * each side of the child so that the content has room to breathe and
+   * is not tightly condensed against the browser window's edge.
+   *
+   * Spacing is executed as the padding on each child to allow background
+   * colors and scroll regions to behave properly.
+   */
+  const containerPad = { horizontal: pageContainer.pad[size].horizontal };
 
   return (
-    <AppContainer ref={appContainerRef} {...demoStyle}>
+    <AppContainer
+      // Debugging - remove ref
+      ref={appContainerRef}
+      {...demoStyle}
+    >
+      {/* ContentArea is specific for the Design System site and is used
+       * as a visual aid to help present layout concepts. Remove from your
+       * implementation.
+       */}
       <ContentArea title="Global Header" background="status-unknown" />
       <PageContainer {...demoStyle}>
-        <Header>
-          {/* ContentArea is specific for the Design System site and is used
-           * as a visual aid to help present layout concepts. Remove from your
-           * implementation.
-           * Typically, the Header will contain elements such as the page's
-           * h1, any "ascending / back to parent" navigation, and/or page-level
-           * menu, action buttons, etc.
+        <Header pad={containerPad}>
+          {/* Typically, the Header will contain elements such as the page's
+           * h1, any "ascending a.k.a. back to parent" navigation, and/or
+           * page-level menu, action buttons, etc.
            */}
           <ContentArea title="Page Header" background="purple!" fill />
         </Header>
-        <Main flex>
+        <Main flex pad={containerPad}>
           <ContentArea title="Page Content" background="orange" border fill>
             {size} - {JSON.stringify(theme.global.breakpoints[size].value)}
             <br />

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,5 +1,5 @@
-import { useContext, useRef } from 'react';
-import { Header, Main, ResponsiveContext, ThemeContext } from 'grommet';
+import { useContext } from 'react';
+import { Header, Main, ResponsiveContext } from 'grommet';
 
 import { AppContainer, PageContainer, pageContainer } from '../components';
 import { ContentArea } from './components';
@@ -9,6 +9,7 @@ import { ContentArea } from './components';
 // your implementation.
 const demoStyle = {
   border: { style: 'dashed' },
+  flex: true,
   gap: 'small',
   pad: 'small',
   round: { size: 'xsmall' },
@@ -16,9 +17,6 @@ const demoStyle = {
 
 export const PageContainerWide = () => {
   const size = useContext(ResponsiveContext);
-  const theme = useContext(ThemeContext);
-  // Debugging - remove ref
-  const appContainerRef = useRef();
   /* Children of PageContainer should maintain horizontal whitespace on
    * each side of the child so that the content has room to breathe and
    * is not tightly condensed against the browser window's edge.
@@ -30,8 +28,10 @@ export const PageContainerWide = () => {
 
   return (
     <AppContainer
-      // Debugging - remove ref
-      ref={appContainerRef}
+      /* `as`, `title`, and `demoStyle` for Design System site demonstration.
+         Remove from your implementation */
+      as={ContentArea}
+      title="AppContainer"
       {...demoStyle}
     >
       {/* ContentArea is specific for the Design System site and is used
@@ -39,7 +39,14 @@ export const PageContainerWide = () => {
        * implementation.
        */}
       <ContentArea title="Global Header" background="status-unknown" />
-      <PageContainer {...demoStyle}>
+      <PageContainer
+        kind="wide"
+        /* `as`, `title`, and `demoStyle` for Design System site demonstration.
+           Remove from your implementation */
+        as={ContentArea}
+        title="PageContainer"
+        {...demoStyle}
+      >
         <Header pad={containerPad}>
           {/* Typically, the Header will contain elements such as the page's
            * h1, any "ascending a.k.a. back to parent" navigation, and/or
@@ -49,12 +56,7 @@ export const PageContainerWide = () => {
         </Header>
         <Main flex pad={containerPad}>
           <ContentArea title="Page Content" background="orange" border fill>
-            {size} - {JSON.stringify(theme.global.breakpoints[size].value)}
-            <br />
-            {appContainerRef.current &&
-              JSON.stringify(
-                appContainerRef.current.getBoundingClientRect().width,
-              )}
+            {size}
           </ContentArea>
         </Main>
       </PageContainer>

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { Header, Main, ResponsiveContext } from 'grommet';
 
-import { PageContainer } from '../components';
+import { AppContainer, PageContainer } from '../components';
 import { ContentArea } from './components';
 
 // `demoStyle` is specific for the Design System site and is used
@@ -9,6 +9,7 @@ import { ContentArea } from './components';
 // your implementation.
 const demoStyle = {
   border: { style: 'dashed' },
+  gap: 'small',
   pad: 'small',
   round: { size: 'xsmall' },
 };
@@ -16,7 +17,7 @@ const demoStyle = {
 export const PageContainerWide = () => {
   const size = useContext(ResponsiveContext);
   return (
-    <ContentArea title="App Container" gap="small" fill {...demoStyle}>
+    <AppContainer {...demoStyle}>
       <ContentArea title="Global Header" background="status-unknown" />
       <PageContainer {...demoStyle}>
         <Header>
@@ -34,6 +35,6 @@ export const PageContainerWide = () => {
         </Main>
       </PageContainer>
       <ContentArea title="Global Footer" background="status-unknown" />
-    </ContentArea>
+    </AppContainer>
   );
 };

--- a/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,100 +1,39 @@
 import { useContext } from 'react';
-import { Box, Diagram, Stack, Text, ThemeContext } from 'grommet';
-import { LinkPrevious, LinkNext } from 'grommet-icons';
+import { Header, Main, ResponsiveContext } from 'grommet';
 
+import { PageContainer } from '../components';
 import { ContentArea } from './components';
 
-const connections = [
-  {
-    fromTarget: 'left-edge',
-    toTarget: 'label',
-    anchor: 'horizontal',
-    color: 'text-strong',
-  },
-  {
-    fromTarget: 'right-edge',
-    toTarget: 'label',
-    anchor: 'horizontal',
-    color: 'text-strong',
-  },
-];
-
-const PAGE_CONTAINER_WIDTH = '1608px';
-const PAGE_CONTAINER_SCALE = '80%';
+// `demoStyle` is specific for the Design System site and is used
+// as a visual aid to help present layout concepts. Remove from
+// your implementation.
+const demoStyle = {
+  border: { style: 'dashed' },
+  pad: 'small',
+  round: { size: 'xsmall' },
+};
 
 export const PageContainerWide = () => {
-  const theme = useContext(ThemeContext);
-  const diagramHeight = theme.global.size.medium;
-  const diagramWidth = `${(diagramHeight.replace('px', '') * 4) / 3}px`;
-  const annotationMargin = `${(100 - PAGE_CONTAINER_SCALE.replace('%', '')) /
-    2}%`;
-
-  const widthAnnnotation = (
-    <Box
-      direction="row"
-      align="center"
-      justify="between"
-      fill="vertical"
-      margin={{ horizontal: annotationMargin }}
-      pad={{ top: 'xlarge' }}
-    >
-      <LinkPrevious id="left-edge" color="text-strong" />
-      <Box id="label" pad={{ horizontal: 'xsmall' }} background="orange">
-        <Text color="text-strong" weight="bold">
-          {PAGE_CONTAINER_WIDTH}
-        </Text>
-      </Box>
-      <LinkNext id="right-edge" color="text-strong" />
-    </Box>
-  );
-
+  const size = useContext(ResponsiveContext);
   return (
-    <Stack>
-      <ContentArea
-        title="App Container"
-        border
-        flex={false}
-        gap="small"
-        round="xsmall"
-        width={diagramWidth}
-      >
-        <ContentArea
-          title="Global Header"
-          background="status-unknown"
-          flex={false}
-        />
-        <Stack>
-          <Box>
-            <ContentArea
-              title="Page Container"
-              alignSelf="center"
-              border
-              flex={false}
-              gap="small"
-              width={PAGE_CONTAINER_SCALE}
-            >
-              <ContentArea
-                title="Page Header"
-                background="purple!"
-                flex={false}
-              />
-              <ContentArea
-                title="Page Content"
-                background="orange"
-                border
-                height="small"
-              />
-            </ContentArea>
-          </Box>
-          {widthAnnnotation}
-        </Stack>
-        <ContentArea
-          title="Global Footer"
-          background="status-unknown"
-          flex={false}
-        />
-      </ContentArea>
-      <Diagram connections={connections} />
-    </Stack>
+    <ContentArea title="App Container" gap="small" fill {...demoStyle}>
+      <ContentArea title="Global Header" background="status-unknown" />
+      <PageContainer {...demoStyle}>
+        <Header>
+          {/* ContentArea is specific for the Design System site and is used
+           * as a visual aid to help present layout concepts. Remove from your
+           * implementation.
+           * Typically, the Header will contain elements such as the page's
+           * h1, any "ascending / back to parent" navigation, and/or page-level
+           * menu, action buttons, etc.
+           */}
+          <ContentArea title="Page Header" background="purple!" fill />
+        </Header>
+        <Main flex>
+          <ContentArea title="Page Content" background="orange" border fill />
+        </Main>
+      </PageContainer>
+      <ContentArea title="Global Footer" background="status-unknown" />
+    </ContentArea>
   );
 };

--- a/aries-site/src/examples/templates/page-layouts/anatomy/components/ContentArea.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/components/ContentArea.js
@@ -15,6 +15,7 @@ export const ContentArea = ({
     border={
       border === true ? { color: 'border-strong', style: 'dashed' } : border
     }
+    flex={false}
     pad={pad}
     round={round}
     {...rest}

--- a/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
@@ -1,4 +1,3 @@
-import { forwardRef } from 'react';
 import { Box } from 'grommet';
 
 // Theme-like object specifying alignment, width, and spacing for
@@ -7,7 +6,6 @@ export const appContainer = {
   gap: 'large',
 };
 
-// Debugging - remove forwardRef
-export const AppContainer = forwardRef(({ ...rest }, ref) => (
-  <Box ref={ref} fill="vertical" gap={appContainer.gap} {...rest} />
-));
+export const AppContainer = ({ ...rest }) => (
+  <Box fill="vertical" gap={appContainer.gap} {...rest} />
+);

--- a/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
@@ -1,0 +1,11 @@
+import { Box } from 'grommet';
+
+// Theme-like object specifying alignment, width, and spacing for
+// an AppContainer.
+const appContainer = {
+  gap: 'large',
+};
+
+export const AppContainer = ({ ...rest }) => (
+  <Box fill gap={appContainer.gap} {...rest} />
+);

--- a/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
@@ -3,10 +3,11 @@ import { Box } from 'grommet';
 
 // Theme-like object specifying alignment, width, and spacing for
 // an AppContainer.
-const appContainer = {
+export const appContainer = {
   gap: 'large',
 };
 
+// Debugging - remove forwardRef
 export const AppContainer = forwardRef(({ ...rest }, ref) => (
-  <Box ref={ref} fill gap={appContainer.gap} {...rest} />
+  <Box ref={ref} fill="vertical" gap={appContainer.gap} {...rest} />
 ));

--- a/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/AppContainer.js
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { Box } from 'grommet';
 
 // Theme-like object specifying alignment, width, and spacing for
@@ -6,6 +7,6 @@ const appContainer = {
   gap: 'large',
 };
 
-export const AppContainer = ({ ...rest }) => (
-  <Box fill gap={appContainer.gap} {...rest} />
-);
+export const AppContainer = forwardRef(({ ...rest }, ref) => (
+  <Box ref={ref} fill gap={appContainer.gap} {...rest} />
+));

--- a/aries-site/src/examples/templates/page-layouts/components/PageContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/PageContainer.js
@@ -1,0 +1,60 @@
+import { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { Box, ResponsiveContext } from 'grommet';
+
+// Theme-like object specifying alignment, width, and spacing for
+// a PageContainer.
+const pageContainer = {
+  wide: {
+    align: 'center',
+    width: {
+      max: 'xxlarge', // 1536 --> needs to adjust to 1536 + 72
+    },
+  },
+  narrow: {
+    align: 'center',
+    width: {
+      max: 'large', // 768
+    },
+  },
+  full: {
+    align: 'start',
+    width: {
+      max: '100%',
+    },
+  },
+  gap: {
+    xsmall: 'medium',
+    small: 'medium',
+    medium: 'medium',
+    large: 'medium',
+    xlarge: 'medium',
+  },
+  pad: {
+    xsmall: { horizontal: 'medium', vertical: 'medium' },
+    small: { horizontal: 'large', vertical: 'medium' },
+    medium: { horizontal: 'medium', vertical: 'medium' },
+    large: { horizontal: 'large', vertical: 'medium' },
+    xlarge: { horizontal: 'large', vertical: 'medium' },
+  },
+};
+
+export const PageContainer = ({ kind = 'wide', ...rest }) => {
+  const size = useContext(ResponsiveContext);
+
+  return (
+    <Box
+      alignSelf={pageContainer[kind].align}
+      fill
+      gap={pageContainer.gap[size]}
+      margin="auto"
+      pad={{ vertical: pageContainer.pad[size].vertical }}
+      width={pageContainer[kind].width}
+      {...rest}
+    />
+  );
+};
+
+PageContainer.propTypes = {
+  kind: PropTypes.oneOf(['full', 'narrow', 'wide']),
+};

--- a/aries-site/src/examples/templates/page-layouts/components/PageContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/PageContainer.js
@@ -1,6 +1,8 @@
-import { useContext } from 'react';
+import { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, ResponsiveContext } from 'grommet';
+
+export const PageContainerContext = createContext({});
 
 // Theme-like object specifying alignment, width, and spacing for
 // a PageContainer.
@@ -30,27 +32,32 @@ export const pageContainer = {
     large: 'medium',
     xlarge: 'medium',
   },
-  pad: {
-    xsmall: { horizontal: 'medium' },
-    small: { horizontal: 'large' },
-    medium: { horizontal: 'medium' },
-    large: { horizontal: 'large' },
-    xlarge: { horizontal: 'large' },
+  children: {
+    pad: {
+      xsmall: { horizontal: 'medium' },
+      small: { horizontal: 'large' },
+      medium: { horizontal: 'medium' },
+      large: { horizontal: 'large' },
+      xlarge: { horizontal: 'large' },
+    },
   },
 };
 
 export const PageContainer = ({ kind = 'wide', ...rest }) => {
   const size = useContext(ResponsiveContext);
+  const pad = pageContainer.children.pad[size];
 
   return (
-    <Box
-      alignSelf={pageContainer[kind].align}
-      fill
-      gap={pageContainer.gap[size]}
-      margin="auto"
-      width={pageContainer[kind].width}
-      {...rest}
-    />
+    <PageContainerContext.Provider value={{ pad }}>
+      <Box
+        alignSelf={pageContainer[kind].align}
+        fill
+        gap={pageContainer.gap[size]}
+        margin="auto"
+        width={pageContainer[kind].width}
+        {...rest}
+      />
+    </PageContainerContext.Provider>
   );
 };
 

--- a/aries-site/src/examples/templates/page-layouts/components/PageContainer.js
+++ b/aries-site/src/examples/templates/page-layouts/components/PageContainer.js
@@ -4,7 +4,7 @@ import { Box, ResponsiveContext } from 'grommet';
 
 // Theme-like object specifying alignment, width, and spacing for
 // a PageContainer.
-const pageContainer = {
+export const pageContainer = {
   wide: {
     align: 'center',
     width: {
@@ -31,11 +31,11 @@ const pageContainer = {
     xlarge: 'medium',
   },
   pad: {
-    xsmall: { horizontal: 'medium', vertical: 'medium' },
-    small: { horizontal: 'large', vertical: 'medium' },
-    medium: { horizontal: 'medium', vertical: 'medium' },
-    large: { horizontal: 'large', vertical: 'medium' },
-    xlarge: { horizontal: 'large', vertical: 'medium' },
+    xsmall: { horizontal: 'medium' },
+    small: { horizontal: 'large' },
+    medium: { horizontal: 'medium' },
+    large: { horizontal: 'large' },
+    xlarge: { horizontal: 'large' },
   },
 };
 
@@ -48,7 +48,6 @@ export const PageContainer = ({ kind = 'wide', ...rest }) => {
       fill
       gap={pageContainer.gap[size]}
       margin="auto"
-      pad={{ vertical: pageContainer.pad[size].vertical }}
       width={pageContainer[kind].width}
       {...rest}
     />

--- a/aries-site/src/examples/templates/page-layouts/components/index.js
+++ b/aries-site/src/examples/templates/page-layouts/components/index.js
@@ -1,0 +1,1 @@
+export * from './PageContainer';

--- a/aries-site/src/examples/templates/page-layouts/components/index.js
+++ b/aries-site/src/examples/templates/page-layouts/components/index.js
@@ -1,1 +1,2 @@
+export * from './AppContainer';
 export * from './PageContainer';

--- a/aries-site/src/examples/templates/page-layouts/index.js
+++ b/aries-site/src/examples/templates/page-layouts/index.js
@@ -1,4 +1,5 @@
 export * from './anatomy';
 export * from './HeaderFooterExample';
 export * from './HeaderOnlyExample';
+export * from './PageContainerInteractive';
 export * from './StickyHeaderExample';

--- a/aries-site/src/layouts/content/Example/BrowserWrapper.js
+++ b/aries-site/src/layouts/content/Example/BrowserWrapper.js
@@ -11,7 +11,7 @@ export const BrowserWrapper = forwardRef(({ screen, ...rest }, ref) => {
 
   return (
     <Box
-      margin={{ bottom: 'medium' }}
+      // margin={{ bottom: 'medium' }}
       elevation="medium"
       round="xsmall"
       overflow="hidden"

--- a/aries-site/src/layouts/content/Example/BrowserWrapper.js
+++ b/aries-site/src/layouts/content/Example/BrowserWrapper.js
@@ -11,7 +11,6 @@ export const BrowserWrapper = forwardRef(({ screen, ...rest }, ref) => {
 
   return (
     <Box
-      // margin={{ bottom: 'medium' }}
       elevation="medium"
       round="xsmall"
       overflow="hidden"

--- a/aries-site/src/layouts/content/Example/Container.js
+++ b/aries-site/src/layouts/content/Example/Container.js
@@ -24,8 +24,7 @@ export const Container = ({
 
   let height;
   if (heightProp) height = heightProp;
-  else if (template) height = aspectHeight;
-  else if (screenContainer) height = heightProp || aspectHeight;
+  else if (template || screenContainer) height = heightProp || aspectHeight;
   else if (!plain) height = { min: 'medium' };
   else height = undefined;
 

--- a/aries-site/src/layouts/content/Example/Container.js
+++ b/aries-site/src/layouts/content/Example/Container.js
@@ -37,13 +37,7 @@ export const Container = ({
       height={height}
       justify="center"
       margin={showResponsiveControls ? { top: 'xsmall' } : undefined}
-      pad={
-        pad ||
-        (template
-          ? // || screenContainer
-            { horizontal: 'large', top: 'large' }
-          : 'large')
-      }
+      pad={pad || (template ? { horizontal: 'large', top: 'large' } : 'large')}
       round={
         !horizontalLayout &&
         (designer || docs || figma || guidance || screenContainer || template)

--- a/aries-site/src/layouts/content/Example/Container.js
+++ b/aries-site/src/layouts/content/Example/Container.js
@@ -24,7 +24,8 @@ export const Container = ({
 
   let height;
   if (heightProp) height = heightProp;
-  else if (template || screenContainer) height = aspectHeight;
+  else if (template) height = aspectHeight;
+  else if (screenContainer) height = heightProp || aspectHeight;
   else if (!plain) height = { min: 'medium' };
   else height = undefined;
 
@@ -38,8 +39,9 @@ export const Container = ({
       margin={showResponsiveControls ? { top: 'xsmall' } : undefined}
       pad={
         pad ||
-        (template || screenContainer
-          ? { horizontal: 'large', top: 'large' }
+        (template
+          ? // || screenContainer
+            { horizontal: 'large', top: 'large' }
           : 'large')
       }
       round={

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -115,15 +115,21 @@ export const Example = ({
         inlineRef.current && inlineRef.current.getBoundingClientRect().width;
       const { breakpoints } = theme.global;
       let breakpoint;
-      Object.entries(breakpoints).forEach(obj => {
-        if (!breakpoint) [breakpoint] = obj;
-        else if (
-          containerWidth > breakpoints[breakpoint].value &&
-          containerWidth < obj[1].value
-        ) {
-          [breakpoint] = obj;
-        }
-      });
+      Object.entries(breakpoints)
+        .sort((a, b) => {
+          if (a[1].value < b[1].value) return -1;
+          if (a[1].value > b[1].value) return 1;
+          return 0;
+        })
+        .forEach(obj => {
+          if (!breakpoint) [breakpoint] = obj;
+          if (
+            containerWidth > breakpoints[breakpoint].value &&
+            containerWidth < obj[1].value
+          ) {
+            [breakpoint] = obj;
+          }
+        });
       viewPort = breakpoint;
     }
   } else viewPort = undefined;

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -1,6 +1,13 @@
 import React, { useCallback, useContext, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Button, Keyboard, Layer, ResponsiveContext } from 'grommet';
+import {
+  Box,
+  Button,
+  Keyboard,
+  Layer,
+  ResponsiveContext,
+  ThemeContext,
+} from 'grommet';
 import { Contract } from 'grommet-icons';
 import {
   BrowserWrapper,
@@ -50,6 +57,7 @@ export const Example = ({
   const [screen, setScreen] = React.useState(screens.laptop);
   const [fullscreen, setFullscreen] = React.useState(false);
   const size = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
   const inlineRef = useRef();
   const layerRef = useRef();
 
@@ -100,7 +108,25 @@ export const Example = ({
   let viewPort;
   if (screen === screens.mobile) viewPort = 'small';
   else if (!screenContainer && !showResponsiveControls) viewPort = size;
-  else viewPort = undefined;
+  else if (screenContainer) {
+    if (fullscreen) viewPort = size;
+    else if (!fullscreen) {
+      const containerWidth =
+        inlineRef.current && inlineRef.current.getBoundingClientRect().width;
+      const { breakpoints } = theme.global;
+      let breakpoint;
+      Object.entries(breakpoints).forEach(obj => {
+        if (!breakpoint) [breakpoint] = obj;
+        else if (
+          containerWidth > breakpoints[breakpoint].value &&
+          containerWidth < obj[1].value
+        ) {
+          [breakpoint] = obj;
+        }
+      });
+      viewPort = breakpoint;
+    }
+  } else viewPort = undefined;
 
   // when Layer is open, we remove the inline Example to avoid
   // repeat id tags that may impede interactivity of inputs

--- a/aries-site/src/pages/templates/page-layouts.mdx
+++ b/aries-site/src/pages/templates/page-layouts.mdx
@@ -92,8 +92,9 @@ will be displayed around the perimeter of the content.
   caption='Diagram displaying how a "wide" Page Container scales horizontally relative to 
     the App Container. The App Container fills the viewport while the "wide" 
     Page Container reaches a maximum width.'
-  pad="none"
-  previewWidth="min-content"
+    screenContainer
+    showResponsiveControls={['desktop', 'laptop', 'mobile', 'fullScreen']}
+    height={{min: '625px'}}
 >
   <PageContainerWide />
 </Example>

--- a/aries-site/src/pages/templates/page-layouts.mdx
+++ b/aries-site/src/pages/templates/page-layouts.mdx
@@ -94,6 +94,7 @@ will be displayed around the perimeter of the content.
     Page Container reaches a maximum width.'
     screenContainer
     showResponsiveControls={['fullScreen']}
+    // height value chosen to best visually represent the page layout diagram concept
     height={{min: '625px'}}
 >
   <PageContainerWide />

--- a/aries-site/src/pages/templates/page-layouts.mdx
+++ b/aries-site/src/pages/templates/page-layouts.mdx
@@ -93,7 +93,7 @@ will be displayed around the perimeter of the content.
     the App Container. The App Container fills the viewport while the "wide" 
     Page Container reaches a maximum width.'
     screenContainer
-    showResponsiveControls={['desktop', 'laptop', 'mobile', 'fullScreen']}
+    showResponsiveControls={['fullScreen']}
     height={{min: '625px'}}
 >
   <PageContainerWide />

--- a/aries-site/src/pages/templates/page-layouts.mdx
+++ b/aries-site/src/pages/templates/page-layouts.mdx
@@ -7,6 +7,7 @@ import {
   AppAnatomy, 
   PageAnatomy, 
   PageContainerFull, 
+  PageContainerInteractive, 
   PageContainerNarrow, 
   PageContainerWide 
 } from '../../examples';
@@ -92,10 +93,8 @@ will be displayed around the perimeter of the content.
   caption='Diagram displaying how a "wide" Page Container scales horizontally relative to 
     the App Container. The App Container fills the viewport while the "wide" 
     Page Container reaches a maximum width.'
-    screenContainer
-    showResponsiveControls={['fullScreen']}
-    // height value chosen to best visually represent the page layout diagram concept
-    height={{min: '625px'}}
+  pad="none"
+  previewWidth="min-content"
 >
   <PageContainerWide />
 </Example>
@@ -146,6 +145,22 @@ Page Content will be left aligned to the edge of the screen.
 - Charts 
 - Maps 
 - Tables
+
+### Page Container Widths Demonstration
+
+Open the following example in "fullscreen mode" and resize your browser window to see how 
+each [page container width's](/templates/page-layouts#page-container-widths) maximum width, 
+contents padding, and alignment gracefully adjust across screens ranging from very narrow 
+to very wide. 
+
+<Example
+  screenContainer
+  showResponsiveControls={['fullScreen']}
+  // height value chosen to best visually represent the page layout diagram concept
+  height={{min: '625px'}}
+>
+  <PageContainerInteractive />
+</Example>
 
 For specific guidelines and templates regarding Page Content, see [Content Layout](/templates/content-layout).
 

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -1,11 +1,56 @@
 import { hpe } from 'grommet-theme-hpe';
 import { deepMerge } from 'grommet/utils';
 
+const baseSpacing = 24;
+
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
   // To be stripped out once theme changes are made in grommet-theme-hpe
   // keeping file for use as playground for future theme adjusments that need
   // to be quickly tested
+  global: {
+    breakpoints: {
+      xsmall: {
+        value: baseSpacing * 24, // 576
+        borderSize: {
+          xsmall: '1px',
+          small: '2px',
+          medium: `${baseSpacing / 6}px`, // 4
+          large: `${baseSpacing / 4}px`, // 6
+          xlarge: `${baseSpacing / 2}px`, // 12
+        },
+        edgeSize: {
+          none: '0px',
+          hair: '1px', // for Chart
+          xxsmall: '2px',
+          xsmall: `${baseSpacing / 8}px`, // 3
+          small: `${baseSpacing / 4}px`, // 6
+          medium: `${baseSpacing / 2}px`, // 12
+          large: `${baseSpacing}px`, // 24
+          xlarge: `${baseSpacing * 2}px`, // 48
+        },
+        size: {
+          xxsmall: `${baseSpacing}px`, // 24
+          xsmall: `${baseSpacing * 2}px`, // 48
+          small: `${baseSpacing * 4}px`, // 96
+          medium: `${baseSpacing * 8}px`, // 192
+          large: `${baseSpacing * 16}px`, // 384
+          xlarge: `${baseSpacing * 32}px`, // 768
+          full: '100%',
+        },
+      },
+      small: {
+        value: baseSpacing * 32, // 768
+      },
+      medium: {
+        value: baseSpacing * 45, // 1080
+      },
+      large: {
+        value: baseSpacing * 60, // 1440
+      },
+      xlarge: {}, // anything larger than 1440,
+    },
+  },
 });
 
 export const { colors } = aries.global;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2257--keen-mayer-a86c8b.netlify.app/templates/page-layouts)

#### What does this PR do?

Adds:
- Coded example for PageContainerWide (narrow and full will follow once the rest of the Example component work is finalized)
- AppContainer component
- PageContainer component
- Modified `breakpoints` in `aries.js`

#### Where should the reviewer start?

[Page Layouts page](https://deploy-preview-2257--keen-mayer-a86c8b.netlify.app/templates/page-layouts)

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [ ] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
