### PR TITLE
Apply scale factor to rest of theme attributes

### DIFF
--- a/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
+++ b/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
@@ -1,5 +1,15 @@
 import React, { useContext } from 'react';
-import { Box, Grid, Header, Heading, ResponsiveContext } from 'grommet';
+import {
+  Box,
+  Card,
+  CardBody,
+  CardHeader,
+  Grid,
+  Header,
+  Heading,
+  ResponsiveContext,
+  Text,
+} from 'grommet';
 import {
   AppContainer,
   PageContainer,
@@ -19,11 +29,13 @@ export const ResponsiveContentLayoutExample = () => (
 );
 
 const PageHeader = () => {
+  const size = useContext(ResponsiveContext);
   const { pad } = useContext(PageContainerContext);
   return (
     <Header pad={pad}>
       <Heading level={1} margin="none" size="small">
-        Dashboard
+        {/* for dev purposes, will be replaced with dashboard content */}
+        Dashboard @ '{size}' Breakpoint
       </Heading>
     </Header>
   );
@@ -83,10 +95,19 @@ const PageContent = () => {
       {(size === 'small' || size === 'xsmall') && <ContentBlock title="1" />}
       <Grid gap={firstChildGrid.gap}>
         <Grid columns={firstChildGrid.columns[size]} gap={firstChildGrid.gap}>
-          <ContentBlock
-            title="2"
-            height={size !== 'xsmall' && size !== 'small' ? 'xsmall' : 'small'}
-          />
+          {/* Card is for demonstrating scaled heading and text.
+          Will be replaced with dashboard content in subsequent pull request.
+           */}
+          <Card>
+            <CardHeader>
+              <Heading level={2} size="small" margin="none">
+                Scaled H2, size 'small'
+              </Heading>
+            </CardHeader>
+            <CardBody>
+              <Text>Scaled Text</Text>
+            </CardBody>
+          </Card>
           <ContentBlock
             title="3"
             height={size !== 'xsmall' && size !== 'small' ? 'xsmall' : 'small'}

--- a/aries-site/src/examples/templates/page-layouts/anatomy/components/ContentArea.js
+++ b/aries-site/src/examples/templates/page-layouts/anatomy/components/ContentArea.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
-import { Box, Text } from 'grommet';
+import { Box, Text, ThemeContext } from 'grommet';
+import { aries } from '../../../../../themes/aries';
 
 export const ContentArea = ({
   background = 'background-front',
@@ -10,21 +11,26 @@ export const ContentArea = ({
   title,
   ...rest
 }) => (
-  <Box
-    background={background}
-    border={
-      border === true ? { color: 'border-strong', style: 'dashed' } : border
-    }
-    flex={false}
-    pad={pad}
-    round={round}
-    {...rest}
-  >
-    <Text color="text-strong" size="small" weight="bold">
-      {title}
-    </Text>
-    {children}
-  </Box>
+  // If the ThemeContext is scaled, as it can be in the mock browser, we do
+  // not want the scaled theme to be applied to ContentArea. This resets
+  // to scale = 1.
+  <ThemeContext.Extend value={aries}>
+    <Box
+      background={background}
+      border={
+        border === true ? { color: 'border-strong', style: 'dashed' } : border
+      }
+      flex={false}
+      pad={pad}
+      round={round}
+      {...rest}
+    >
+      <Text color="text-strong" size="small" weight="bold">
+        {title}
+      </Text>
+      {children}
+    </Box>
+  </ThemeContext.Extend>
 );
 
 ContentArea.propTypes = {

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -142,9 +142,8 @@ export const Example = ({
     else if (!fullscreen) {
       const containerWidth = mockBrowserRect.width;
       scaledTheme = screenContainer.scale
-        ? scaled(theme, screenContainer.scale)
+        ? scaled(undefined, screenContainer.scale)
         : theme;
-
       const { breakpoints } = scaledTheme.global;
       let breakpoint;
       Object.entries(breakpoints)

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -142,7 +142,7 @@ export const Example = ({
     else if (!fullscreen) {
       const containerWidth = mockBrowserRect.width;
       scaledTheme = screenContainer.scale
-        ? scaled(undefined, screenContainer.scale)
+        ? scaled(screenContainer.scale)
         : theme;
       const { breakpoints } = scaledTheme.global;
       let breakpoint;

--- a/aries-site/src/pages/templates/content-layouts.mdx
+++ b/aries-site/src/pages/templates/content-layouts.mdx
@@ -18,10 +18,11 @@ Specifying layout content in this way will also ensure that it is interepreted a
 <Example 
   showResponsiveControls={['fullScreen']}
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js"
-  screenContainer={{ scale: 0.5 }}
-  // height anad width value chosen to best visually represent the example
+  // height, width, and screenContainer.scale value chosen to best visually 
+  // represent the example
   height="650px"
   width="100%"
+  screenContainer={{ scale: 0.57 }}
 >
   <ResponsiveContentLayoutExample />
 </Example>

--- a/aries-site/src/themes/scaled.js
+++ b/aries-site/src/themes/scaled.js
@@ -2,11 +2,11 @@ import { generate } from 'grommet/themes/base';
 import { deepMerge } from 'grommet/utils';
 import { aries } from './aries';
 
-export const scaled = (theme = aries, scale = 1, baseSpacing = 24) => {
+export const scaled = (scale = 1, baseSpacing = 24) => {
   // scales everything in base
   const scaledBase = generate(baseSpacing * scale);
   // merges theme, but overwrites scale for particular attributes
-  const source = deepMerge(scaledBase, theme);
+  const source = deepMerge(scaledBase, aries);
   const scaledTheme = { ...source };
   // define attributes which need to be re-scaled; essentially any
   // size which is staticly set in hpe/aries theme

--- a/aries-site/src/themes/scaled.js
+++ b/aries-site/src/themes/scaled.js
@@ -1,26 +1,87 @@
-import { base } from 'grommet/themes';
+import { generate } from 'grommet/themes/base';
 import { deepMerge } from 'grommet/utils';
 import { aries } from './aries';
 
-export const scaled = (theme = aries, scale = 1) => {
-  const source = deepMerge(base, theme);
+export const scaled = (theme = aries, scale = 1, baseSpacing = 24) => {
+  // scales everything in base
+  const scaledBase = generate(baseSpacing * scale);
+  // merges theme, but overwrites scale for particular attributes
+  const source = deepMerge(scaledBase, theme);
   const scaledTheme = { ...source };
+  // define attributes which need to be re-scaled; essentially any
+  // size which is staticly set in hpe/aries theme
   const scaleAttributes = [
     source.global.breakpoints,
-    source.global.edgeSize,
-    source.global.size,
+    source.global.drop.border,
+    source.global.input.padding,
+    source.button.secondary.border,
+    source.button.toolbar.border,
+    source.button.option.border,
+    source.button.disabled.primary.border,
+    source.button.hover.secondary.border,
+    source.button.size.small.border,
+    source.button.size.small.pad,
+    source.button.size.medium.border,
+    source.button.size.medium.pad,
+    source.button.size.large.border,
+    source.button.size.large.pad,
+    source.button.border,
+    source.button.padding,
+    source.calendar.small,
+    source.calendar.medium,
+    source.calendar.large,
+    source.checkBox.border,
+    source.checkBox.check,
+    source.fileInput.button.border,
+    source.fileInput.button.pad,
+    source.heading.level[1].small,
+    source.heading.level[1].medium,
+    source.heading.level[1].large,
+    source.heading.level[1].xlarge,
+    source.heading.level[2].small,
+    source.heading.level[2].medium,
+    source.heading.level[2].large,
+    source.heading.level[2].xlarge,
+    source.heading.level[3].small,
+    source.heading.level[3].medium,
+    source.heading.level[3].large,
+    source.heading.level[3].xlarge,
+    source.heading.level[4].small,
+    source.heading.level[4].medium,
+    source.heading.level[4].large,
+    source.heading.level[4].xlarge,
+    source.heading.level[5].small,
+    source.heading.level[5].medium,
+    source.heading.level[5].large,
+    source.heading.level[5].xlarge,
+    source.heading.level[6].small,
+    source.heading.level[6].medium,
+    source.heading.level[6].large,
+    source.heading.level[6].xlarge,
+    source.icon.size,
+    source.paragraph.small,
+    source.paragraph.medium,
+    source.paragraph.large,
+    source.paragraph.xlarge,
+    source.paragraph.xxlarge,
+    source.text.xsmall,
+    source.text.small,
+    source.text.medium,
+    source.text.large,
+    source.text.xlarge,
+    source.text.xxlarge,
   ];
 
   scaleAttributes.forEach(attr => {
     Object.keys(attr).forEach(key => {
+      /* eslint-disable no-param-reassign */
       if (attr[key].value) {
-        /* eslint-disable no-param-reassign */
         // eslint-disable-next-line operator-assignment
-        attr[key].value = attr[key].value * scale;
+        attr[key].value = Math.ceil(attr[key].value * scale);
       } else if (typeof attr[key] === 'string' && attr[key].includes('px')) {
         attr[key] = `${Math.ceil(parseInt(attr[key], 10) * scale)}px`;
-        /* eslint-enable no-param-reassign */
       }
+      /* eslint-enable no-param-reassign */
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6732,9 +6732,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488, electron-to-chromium@^1.4.17:
-  version "1.4.59"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.59.tgz#657f2588c048fb95975779f8fea101fad854de89"
-  integrity sha512-AOJ3cAE0TWxz4fQ9zkND5hWrQg16nsZKVz9INOot1oV//u4wWu5xrj9CQMmPTYskkZRunSRc9sAnr4EkexXokg==
+  version "1.4.60"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.60.tgz#2b824d862f068a9794b2b75d66ad40ff44745f18"
+  integrity sha512-h53hbEiKC6hijelDgxgkgAUC3PKyR7TmIfvjHnBjUGPMg/3sBuTyG6eDormw+lY24uUJvHkUPzB8dpK8b2u3Sw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2303--keen-mayer-a86c8b.netlify.app/templates/content-layouts#prioritizing-content-needs)

#### What does this PR do?

Applies `screenContainer` scaling to Text, Heading, and other theme attributes so that scaled examples present proportionally.

**Background**
As we populate dashboard examples with hi-fidelity content and present them in a scaled view, we would like all components scaled proportionally. Prior scaling was only applied to size, edgeSize, and breakpoints. This PR applies scale factor broadly.

#### Where should the reviewer start?

scaled.js

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [ ] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [x] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
