### PR TITLE
add background for theme context

### DIFF
--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -182,7 +182,7 @@ export const Example = ({
       >
         {/* prevent theme from overriding the desired background color */}
         <ThemeContext.Extend
-          value={{ ...(scaledTheme || theme), background: 'background' }}
+          value={{ ...(scaledTheme || theme), background: 'background-front' }}
         >
           <ResponsiveContext.Provider value={viewPort}>
             {cloneElement(children, {

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -180,7 +180,7 @@ export const Example = ({
         width={width}
         ref={inlineRef}
       >
-        {/* need to overrid theme background so its not resetting */}
+        {/* prevent theme from overriding the desired background color */}
         <ThemeContext.Extend
           value={{ ...(scaledTheme || theme), background: 'background' }}
         >

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -180,6 +180,7 @@ export const Example = ({
         width={width}
         ref={inlineRef}
       >
+        {/* need to overrid theme background so its not resetting */}
         <ThemeContext.Extend
           value={{ ...(scaledTheme || theme), background: 'background' }}
         >

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -180,7 +180,9 @@ export const Example = ({
         width={width}
         ref={inlineRef}
       >
-        <ThemeContext.Extend value={scaledTheme || theme}>
+        <ThemeContext.Extend
+          value={{ ...(scaledTheme || theme), background: 'background' }}
+        >
           <ResponsiveContext.Provider value={viewPort}>
             {cloneElement(children, {
               containerRef: inlineRef,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2348--keen-mayer-a86c8b.netlify.app/components/datatable?q=data)

#### What does this PR do?
This PR fixes the `datatable` header color by adding `backgroud` to `theme.context`
#### Where should the reviewer start?
Example.js
#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [x] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [x] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?
The `Header` of the `pinned` DataTable turned into a grey color. 
When the `Theme.Context` was added to the Example.js was when this regression happened. 
With the  `Theme.Context` wrapper it is looking at the theme background color instead of the 
background color of the example wrapper which is the `background-back`


#### What are the relevant issues?
closes #2325 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible