### PR TITLE
Support xsmall breakpoint for site layout and examples

### DIFF
--- a/aries-core/src/js/components/core/Nav/Nav.js
+++ b/aries-core/src/js/components/core/Nav/Nav.js
@@ -28,7 +28,9 @@ export const Nav = ({
         pad={
           pad || {
             vertical: 'small',
-            horizontal: size !== 'small' ? 'xlarge' : 'large',
+            horizontal: !['xsmall', 'small'].includes(size)
+              ? 'xlarge'
+              : 'large',
           }
         }
       >
@@ -51,13 +53,15 @@ export const Nav = ({
         <Box direction="row" gap="medium" align="center">
           {children && !collapse ? (
             children
-          ) : size !== 'small' ? (
+          ) : !['xsmall', 'small'].includes(size) ? (
             children &&
             (children.length > 1
-              ? children.map((child, index) => React.cloneElement(child, {
+              ? children.map((child, index) =>
+                  React.cloneElement(child, {
                     lastSection: index === children.length - 1,
                     key: index,
-                  }))
+                  }),
+                )
               : React.cloneElement(children, {
                   lastSection: true,
                 }))
@@ -70,14 +74,16 @@ export const Nav = ({
           )}
         </Box>
       </Box>
-      {size === 'small' && (
+      {['xsmall', 'small'].includes(size) && (
         <Collapsible background="white" open={open}>
           {children &&
             (children.length > 1
-              ? children.map((child, index) => React.cloneElement(child, {
+              ? children.map((child, index) =>
+                  React.cloneElement(child, {
                     lastSection: index === children.length - 1,
                     key: index,
-                  }))
+                  }),
+                )
               : React.cloneElement(children, {
                   lastSection: true,
                 }))}

--- a/aries-core/src/js/components/helpers/Anchors/AnchorGroup.js
+++ b/aries-core/src/js/components/helpers/Anchors/AnchorGroup.js
@@ -17,7 +17,7 @@ export const AnchorGroup = ({ items }) => {
             // label={item.label}
             // On desktop, allow final nav item to be completely right justified
             margin={
-              index === items.length - 1 && size !== 'small'
+              index === items.length - 1 && !['xsmall', 'small'].includes(size)
                 ? {
                     vertical: 'small',
                     left: 'small',

--- a/aries-core/src/js/components/helpers/NavSection/index.js
+++ b/aries-core/src/js/components/helpers/NavSection/index.js
@@ -9,17 +9,17 @@ export const NavSection = ({ children, lastSection }) => {
     <Box
       border={
         !lastSection
-          ? { side: size !== 'small' ? 'right' : 'bottom' }
+          ? { side: !['xsmall', 'small'].includes(size) ? 'right' : 'bottom' }
           : undefined
       }
       pad={
-        size !== 'small'
+        !['xsmall', 'small'].includes(size)
           ? {
               right: !lastSection ? 'medium' : undefined,
             }
           : undefined
       }
-      direction={size !== 'small' ? 'row' : 'column'}
+      direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
       gap="xsmall"
     >
       {children}

--- a/aries-site/src/components/cards/CardGrid.js
+++ b/aries-site/src/components/cards/CardGrid.js
@@ -1,50 +1,47 @@
-import React, { Fragment, useContext } from 'react';
+import React, { Fragment } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
-import { Grid, ResponsiveContext } from 'grommet';
+import { Grid } from 'grommet';
 
 import { ContentCard } from '.';
 import { nameToPath } from '../../utils';
 import { internalLink } from '..';
 
-export const CardGrid = ({ cards, minimal, ...rest }) => {
-  const size = useContext(ResponsiveContext);
-  return (
-    <Grid
-      columns={size !== 'small' ? 'medium' : '100%'}
-      rows={[['auto', 'full']]}
-      gap="medium"
-      justify="center"
-      fill
-      {...rest}
-    >
-      {cards &&
-        cards.map(topic => {
-          const href = topic.href || nameToPath(topic.name);
-          const isInternalLink = internalLink.test(href);
-          const Wrapper = isInternalLink ? Link : Fragment;
-          const wrapperProps = isInternalLink && {
-            href,
-            passHref: true,
-          };
+export const CardGrid = ({ cards, minimal, ...rest }) => (
+  <Grid
+    columns="medium"
+    rows={[['auto', 'full']]}
+    gap="medium"
+    justify="center"
+    fill
+    {...rest}
+  >
+    {cards &&
+      cards.map(topic => {
+        const href = topic.href || nameToPath(topic.name);
+        const isInternalLink = internalLink.test(href);
+        const Wrapper = isInternalLink ? Link : Fragment;
+        const wrapperProps = isInternalLink && {
+          href,
+          passHref: true,
+        };
 
-          return (
-            <Wrapper key={topic.name} {...wrapperProps}>
-              <ContentCard
-                as="a"
-                style={{ textDecoration: 'none' }}
-                topic={topic}
-                minimal={minimal}
-                target={!isInternalLink ? '_blank' : undefined}
-                // if internal link, href comes from Link wrapper
-                href={!isInternalLink ? href : undefined}
-              />
-            </Wrapper>
-          );
-        })}
-    </Grid>
-  );
-};
+        return (
+          <Wrapper key={topic.name} {...wrapperProps}>
+            <ContentCard
+              as="a"
+              style={{ textDecoration: 'none' }}
+              topic={topic}
+              minimal={minimal}
+              target={!isInternalLink ? '_blank' : undefined}
+              // if internal link, href comes from Link wrapper
+              href={!isInternalLink ? href : undefined}
+            />
+          </Wrapper>
+        );
+      })}
+  </Grid>
+);
 
 CardGrid.propTypes = {
   cards: PropTypes.arrayOf(

--- a/aries-site/src/components/cards/SectionCards.js
+++ b/aries-site/src/components/cards/SectionCards.js
@@ -1,19 +1,14 @@
-import React, { useContext } from 'react';
-import { Box, Button, Grid, ResponsiveContext } from 'grommet';
+import React from 'react';
+import { Box, Button, Grid } from 'grommet';
 import PropTypes from 'prop-types';
 import { LinkCard } from './LinkCard';
 
 export const SectionCards = ({ items, seeAllContent }) => {
-  const size = useContext(ResponsiveContext);
   const { buttonLabel, href } = seeAllContent;
 
   return (
     <Box gap="large">
-      <Grid
-        columns={size !== 'small' ? 'medium' : '100%'}
-        rows="auto"
-        gap="medium"
-      >
+      <Grid columns="medium" rows="auto" gap="medium">
         {items.map(item => (
           <LinkCard
             key={item.title}

--- a/aries-site/src/components/content/PageBackground.js
+++ b/aries-site/src/components/content/PageBackground.js
@@ -33,10 +33,10 @@ export const PageBackground = ({ backgroundImage }) => {
       ) : (
         <Box height={{ min: 'medium' }} justify="center">
           <Grid
-            gap={size !== 'small' ? 'large' : 'medium'}
+            gap={!['xsmall', 'small'].includes(size) ? 'large' : 'medium'}
             columns={{
               count: 'fit',
-              size: size !== 'small' ? 'medium' : 'fill',
+              size: !['xsmall', 'small'].includes(size) ? 'medium' : 'fill',
             }}
           >
             <Box style={style} margin={margin}>

--- a/aries-site/src/components/content/SubmitFeedback.js
+++ b/aries-site/src/components/content/SubmitFeedback.js
@@ -76,7 +76,11 @@ export const FeedbackOptions = () => {
   return (
     <Box flex={false} width="xlarge">
       <Grid
-        columns={size !== 'small' ? { count: 'fit', size: 'small' } : 'auto'}
+        columns={
+          !['xsmall', 'small'].includes(size)
+            ? { count: 'fit', size: 'small' }
+            : 'auto'
+        }
         gap="large"
       >
         <JoinConversation />

--- a/aries-site/src/components/home/Community.js
+++ b/aries-site/src/components/home/Community.js
@@ -91,7 +91,7 @@ export const Community = ({ ...rest }) => {
     <Box fill="horizontal" background="background-front">
       <Box
         fill="horizontal"
-        pad={size !== 'small' ? 'xlarge' : 'large'}
+        pad={!['xsmall', 'small'].includes(size) ? 'xlarge' : 'large'}
         gap="large"
         {...rest}
       >

--- a/aries-site/src/components/home/Featured.js
+++ b/aries-site/src/components/home/Featured.js
@@ -11,7 +11,7 @@ const FeaturedLayout = ({ ...rest }) => {
   return (
     <Box
       pad={{
-        horizontal: size !== 'small' ? 'xlarge' : 'large',
+        horizontal: !['xsmall', 'small'].includes(size) ? 'xlarge' : 'large',
         bottom: 'small',
       }}
       {...rest}

--- a/aries-site/src/components/home/Hero.js
+++ b/aries-site/src/components/home/Hero.js
@@ -96,7 +96,7 @@ export const Hero = props => {
         viewBox="0 0 786 514"
         fill="none"
         preserveAspectRatio={
-          size === 'small' ? 'xMidYMin meet' : 'xMaxYMin meet'
+          ['xsmall', 'small'].includes(size) ? 'xMidYMin meet' : 'xMaxYMin meet'
         }
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/aries-site/src/components/home/Highlights.js
+++ b/aries-site/src/components/home/Highlights.js
@@ -22,8 +22,10 @@ const HighlightsLayout = () => {
 
   return (
     <Grid
-      pad={{ horizontal: size !== 'small' ? 'medium' : 'large' }}
-      columns={size !== 'small' ? 'medium' : '100%'}
+      pad={{
+        horizontal: !['xsmall', 'small'].includes(size) ? 'medium' : 'large',
+      }}
+      columns={!['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
       gap="large"
     >
       {highlights.map(({ name, summary, image }) => {
@@ -84,7 +86,11 @@ export const Highlights = ({ ...rest }) => {
         <Box
           justify="center"
           align="center"
-          pad={{ horizontal: size !== 'small' ? 'xlarge' : 'large' }}
+          pad={{
+            horizontal: !['xsmall', 'small'].includes(size)
+              ? 'xlarge'
+              : 'large',
+          }}
           gap="large"
         >
           <Heading margin="none" level={2} size="large">

--- a/aries-site/src/components/home/WhatIs.js
+++ b/aries-site/src/components/home/WhatIs.js
@@ -58,7 +58,7 @@ export const WhatIs = ({ ...rest }) => {
       <Box
         fill
         pad={{
-          horizontal: size !== 'small' ? 'xlarge' : 'large',
+          horizontal: !['xsmall', 'small'].includes(size) ? 'xlarge' : 'large',
           top: 'large',
           bottom: 'medium',
         }}
@@ -72,30 +72,31 @@ export const WhatIs = ({ ...rest }) => {
           <Paragraph size="xlarge" fill textAlign="center" margin="none">
             The HPE Design System was created to empower designers, developers,
             and others in contributing to an evolving design language that
-            supports HPE's pursuit in making great customer app experiences.
-            For other contexts check&nbsp;
+            supports HPE's pursuit in making great customer app experiences. For
+            other contexts check&nbsp;
             <Anchor href="https://brandcentral.hpe.com/home">
               HPE Brand Central
-            </Anchor>.
+            </Anchor>
+            .
           </Paragraph>
         </Box>
         <Grid columns={{ count: 'fit', size: '160px' }} justify="center" fill>
           {whatIsContent.map(({ image, text }, index) => (
-              <Box key={`whatis-${index}`} width="120px">
-                <Box width="120px" height="120px">
-                  <Image
-                    src={
-                      darkMode.value
-                        ? image.src.dark || image.src
-                        : image.src.light || image.src
-                    }
-                    fit="contain"
-                    alt={image.alt}
-                  />
-                </Box>
-                <Paragraph size="small">{text}</Paragraph>
+            <Box key={`whatis-${index}`} width="120px">
+              <Box width="120px" height="120px">
+                <Image
+                  src={
+                    darkMode.value
+                      ? image.src.dark || image.src
+                      : image.src.light || image.src
+                  }
+                  fit="contain"
+                  alt={image.alt}
+                />
               </Box>
-            ))}
+              <Paragraph size="small">{text}</Paragraph>
+            </Box>
+          ))}
         </Grid>
       </Box>
     </Box>

--- a/aries-site/src/examples/components/button/ButtonIconExample.js
+++ b/aries-site/src/examples/components/button/ButtonIconExample.js
@@ -7,11 +7,11 @@ export const ButtonIconExample = () => {
 
   return (
     <Box
-      direction={size !== 'small' ? 'column' : 'row'}
-      gap={size !== 'small' ? 'small' : 'medium'}
+      direction={!['xsmall', 'small'].includes(size) ? 'column' : 'row'}
+      gap={!['xsmall', 'small'].includes(size) ? 'small' : 'medium'}
     >
       <Box
-        direction={size !== 'small' ? 'row' : 'column'}
+        direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
         gap="medium"
         align="center"
       >
@@ -20,7 +20,7 @@ export const ButtonIconExample = () => {
         <Button icon={<FormNext />} onClick={() => {}} />
       </Box>
       <Box
-        direction={size !== 'small' ? 'row' : 'column'}
+        direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
         gap="medium"
         align="center"
       >

--- a/aries-site/src/examples/components/button/ButtonSizingExample.js
+++ b/aries-site/src/examples/components/button/ButtonSizingExample.js
@@ -6,7 +6,7 @@ export const ButtonSizingExample = () => {
 
   return (
     <Box
-      direction={size !== 'small' ? 'row' : 'column'}
+      direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
       align="center"
       gap="medium"
     >

--- a/aries-site/src/examples/components/button/ButtonStatesExample.js
+++ b/aries-site/src/examples/components/button/ButtonStatesExample.js
@@ -6,15 +6,21 @@ export const ButtonStatesExample = () => {
 
   return (
     <Box
-      direction={size !== 'small' ? 'column' : 'row'}
-      gap={size !== 'small' ? 'small' : 'medium'}
+      direction={!['xsmall', 'small'].includes(size) ? 'column' : 'row'}
+      gap={!['xsmall', 'small'].includes(size) ? 'small' : 'medium'}
     >
-      <Box direction={size !== 'small' ? 'row' : 'column'} gap="medium">
+      <Box
+        direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+        gap="medium"
+      >
         <Button label="Default" onClick={() => {}} />
         <Button label="Active" active onClick={() => {}} />
         <Button label="Disabled" disabled onClick={() => {}} />
       </Box>
-      <Box direction={size !== 'small' ? 'row' : 'column'} gap="medium">
+      <Box
+        direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+        gap="medium"
+      >
         <Button label="Primary" primary onClick={() => {}} />
         <Button label="Primary Active" primary active onClick={() => {}} />
         <Button label="Primary Disabled" primary disabled onClick={() => {}} />

--- a/aries-site/src/examples/components/datatable/DataTableEmptyCellExample.js
+++ b/aries-site/src/examples/components/datatable/DataTableEmptyCellExample.js
@@ -322,7 +322,7 @@ export const DataTableEmptyCellExample = ({ designSystemDemo }) => {
               header: 'Id',
               primary: true,
               render: datum => datum.id.slice(datum.id.length - 5),
-              pin: size === 'small',
+              pin: ['xsmall', 'small'].includes(size),
             },
             ...columns,
           ]}

--- a/aries-site/src/examples/components/datatable/DataTableExample.js
+++ b/aries-site/src/examples/components/datatable/DataTableExample.js
@@ -317,7 +317,7 @@ export const DataTableExample = ({ designSystemDemo }) => {
               header: 'Id',
               primary: true,
               render: datum => datum.id.slice(datum.id.length - 5),
-              pin: size === 'small',
+              pin: ['xsmall', 'small'].includes(size),
             },
             ...columns,
           ]}

--- a/aries-site/src/examples/components/datatable/DataTableMultiSelectExample.js
+++ b/aries-site/src/examples/components/datatable/DataTableMultiSelectExample.js
@@ -246,11 +246,11 @@ export const DataTableMultiSelectExample = () => {
               primary: true,
               property: 'id',
               header: 'Id',
-              pin: size === 'small',
+              pin: ['xsmall', 'small'].includes(size),
             },
             ...columns,
           ]}
-          pin={size === 'small'}
+          pin={['xsmall', 'small'].includes(size)}
           select={selected}
           onSelect={setSelected}
         />

--- a/aries-site/src/examples/components/datatable/DataTableSingleSelectExample.js
+++ b/aries-site/src/examples/components/datatable/DataTableSingleSelectExample.js
@@ -210,11 +210,15 @@ export const DataTableSingleSelectExample = () => {
           aria-describedby="orders-heading"
           data={data}
           columns={[
-            { property: 'id', header: 'Id', pin: size === 'small' },
+            {
+              property: 'id',
+              header: 'Id',
+              pin: ['xsmall', 'small'].includes(size),
+            },
             ...columns,
           ]}
           onClickRow={({ datum }) => setPageDetails(datum)}
-          pin={size === 'small'}
+          pin={['xsmall', 'small'].includes(size)}
         />
       </Box>
     </>

--- a/aries-site/src/examples/components/datatable/DataTableSortable.js
+++ b/aries-site/src/examples/components/datatable/DataTableSortable.js
@@ -173,11 +173,11 @@ export const DataTableSortable = () => {
               property: 'id',
               header: 'Id',
               primary: true,
-              pin: size === 'small',
+              pin: ['xsmall', 'small'].includes(size),
             },
             ...columns,
           ]}
-          pin={size === 'small'}
+          pin={['xsmall', 'small'].includes(size)}
           sort={{ property: 'numeric', direction: 'desc' }}
           sortable
         />

--- a/aries-site/src/examples/components/datatable/DataTableSummaryExample.js
+++ b/aries-site/src/examples/components/datatable/DataTableSummaryExample.js
@@ -146,7 +146,7 @@ export const DataTableSummaryExample = ({ designSystemDemo }) => {
               primary: true,
               property: 'application',
               header: 'Service',
-              pin: size === 'small',
+              pin: ['xsmall', 'small'].includes(size),
             },
             ...columns,
           ]}

--- a/aries-site/src/examples/components/footer/FooterComboExample.js
+++ b/aries-site/src/examples/components/footer/FooterComboExample.js
@@ -20,12 +20,12 @@ export const FooterComboExample = () => {
       </Footer>
       <Footer
         background="background-front"
-        direction={size !== 'small' ? 'row' : 'column'}
-        align={size !== 'small' ? 'center' : undefined}
+        direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+        align={!['xsmall', 'small'].includes(size) ? 'center' : undefined}
       >
         <Box
-          direction={size !== 'small' ? 'row' : 'column'}
-          align={size !== 'small' ? 'center' : undefined}
+          direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+          align={!['xsmall', 'small'].includes(size) ? 'center' : undefined}
           gap="xsmall"
         >
           <Text size="small">
@@ -34,7 +34,7 @@ export const FooterComboExample = () => {
         </Box>
         <Box
           direction="row"
-          align={size !== 'small' ? 'center' : undefined}
+          align={!['xsmall', 'small'].includes(size) ? 'center' : undefined}
           gap="xsmall"
           wrap
         >

--- a/aries-site/src/examples/components/footer/FooterExample.js
+++ b/aries-site/src/examples/components/footer/FooterExample.js
@@ -14,14 +14,14 @@ export const FooterExample = () => {
   return (
     <Footer
       background="background-front"
-      direction={size !== 'small' ? 'row' : 'column'}
-      align={size !== 'small' ? 'center' : undefined}
+      direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+      align={!['xsmall', 'small'].includes(size) ? 'center' : undefined}
       pad={{ horizontal: 'medium', vertical: 'small' }}
       fill="horizontal"
     >
       <Box
-        direction={size !== 'small' ? 'row' : 'column'}
-        align={size !== 'small' ? 'center' : undefined}
+        direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+        align={!['xsmall', 'small'].includes(size) ? 'center' : undefined}
         gap="xsmall"
       >
         <Text size="small">
@@ -30,7 +30,7 @@ export const FooterExample = () => {
       </Box>
       <Box
         direction="row"
-        align={size !== 'small' ? 'center' : undefined}
+        align={!['xsmall', 'small'].includes(size) ? 'center' : undefined}
         gap="xsmall"
         wrap
       >

--- a/aries-site/src/examples/components/header/HeaderExample.js
+++ b/aries-site/src/examples/components/header/HeaderExample.js
@@ -43,7 +43,8 @@ export const HeaderExample = () => {
           responsive={false}
         >
           <Hpe color="brand" />
-          {(size !== 'small' || (size === 'small' && !focused)) && (
+          {(!['xsmall', 'small'].includes(size) ||
+            (['xsmall', 'small'].includes(size) && !focused)) && (
             <Box direction="row" gap="xsmall" wrap>
               <Text color="text-strong" weight="bold">
                 HPE
@@ -54,14 +55,14 @@ export const HeaderExample = () => {
         </Box>
       </Button>
       <>
-        {!focused && size === 'small' && (
+        {!focused && ['xsmall', 'small'].includes(size) && (
           <Button
             icon={<SearchIcon />}
             hoverIndicator
             onClick={() => setFocused(true)}
           />
         )}
-        {(focused || size !== 'small') && (
+        {(focused || !['xsmall', 'small'].includes(size)) && (
           <Box background="background-contrast" round="xsmall" width="medium">
             <Keyboard onEsc={() => setFocused(false)}>
               <StyledTextInput

--- a/aries-site/src/examples/components/header/HeaderNavigationExample.js
+++ b/aries-site/src/examples/components/header/HeaderNavigationExample.js
@@ -39,7 +39,7 @@ export const HeaderNavigationExample = () => {
           </Box>
         </Box>
       </Button>
-      {size !== 'small' ? (
+      {!['xsmall', 'small'].includes(size) ? (
         <Nav direction="row">
           {items.map(item => (
             <Button label={item.label} key={item.label} />

--- a/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
+++ b/aries-site/src/examples/components/header/HeaderSearchActionsExample.js
@@ -32,7 +32,7 @@ const Search = () => {
     }
   }, [focused, setFocused]);
 
-  return !focused && size === 'small' ? (
+  return !focused && ['xsmall', 'small'].includes(size) ? (
     <Button
       icon={<SearchIcon />}
       hoverIndicator
@@ -56,31 +56,31 @@ const Search = () => {
 };
 
 export const HeaderSearchActionsExample = () => (
-    <Header fill="horizontal">
-      <Button>
-        <Box
-          direction="row"
-          align="start"
-          gap="medium"
-          // pad maintains accessible hit target
-          // non-responsive maintains same dimensions for mobile
-          pad={{ vertical: 'small' }}
-          responsive={false}
-        >
-          <Hpe color="brand" />
-          <Box direction="row" gap="xsmall" wrap>
-            <Text color="text-strong" weight="bold">
-              HPE
-            </Text>
-            <Text color="text-strong">App Name</Text>
-          </Box>
+  <Header fill="horizontal">
+    <Button>
+      <Box
+        direction="row"
+        align="start"
+        gap="medium"
+        // pad maintains accessible hit target
+        // non-responsive maintains same dimensions for mobile
+        pad={{ vertical: 'small' }}
+        responsive={false}
+      >
+        <Hpe color="brand" />
+        <Box direction="row" gap="xsmall" wrap>
+          <Text color="text-strong" weight="bold">
+            HPE
+          </Text>
+          <Text color="text-strong">App Name</Text>
         </Box>
-      </Button>
-      <Search />
-      <Box direction="row">
-        <Button icon={<Notification />} />
-        <Button icon={<Chat />} />
-        <Button icon={<User />} />
       </Box>
-    </Header>
-  );
+    </Button>
+    <Search />
+    <Box direction="row">
+      <Button icon={<Notification />} />
+      <Button icon={<Chat />} />
+      <Button icon={<User />} />
+    </Box>
+  </Header>
+);

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -17,7 +17,7 @@ export const LayerCenterExample = () => {
           <Box
             fill="vertical"
             overflow="auto"
-            width={size !== 'small' ? 'medium' : undefined}
+            width={!['xsmall', 'small'].includes(size) ? 'medium' : undefined}
             pad="medium"
           >
             <Box justify="between" direction="row">
@@ -43,7 +43,7 @@ export const LayerCenterExample = () => {
           <Box
             fill="vertical"
             overflow="auto"
-            width={size !== 'small' ? 'medium' : undefined}
+            width={!['xsmall', 'small'].includes(size) ? 'medium' : undefined}
           >
             <Box
               direction="row"

--- a/aries-site/src/examples/components/layer/LayerExample.js
+++ b/aries-site/src/examples/components/layer/LayerExample.js
@@ -23,7 +23,7 @@ export const LayerExample = () => {
       {open && (
         <Layer
           position="right"
-          full={size !== 'small' ? 'vertical' : true}
+          full={!['xsmall', 'small'].includes(size) ? 'vertical' : true}
           modal
           onClickOutside={onClose}
           onEsc={onClose}
@@ -31,7 +31,7 @@ export const LayerExample = () => {
           <Box
             fill="vertical"
             overflow="auto"
-            width={size !== 'small' ? 'medium' : undefined}
+            width={!['xsmall', 'small'].includes(size) ? 'medium' : undefined}
             pad="medium"
           >
             <Header>

--- a/aries-site/src/examples/components/layer/LayerSideDrawerExample.js
+++ b/aries-site/src/examples/components/layer/LayerSideDrawerExample.js
@@ -125,14 +125,14 @@ export const LayerSideDrawerExample = () => {
       {open && (
         <Layer
           position="right"
-          full={size !== 'small' ? 'vertical' : true}
+          full={!['xsmall', 'small'].includes(size) ? 'vertical' : true}
           onEsc={onClose}
           modal={false}
         >
           <Box
             fill="vertical"
             overflow="auto"
-            width={size !== 'small' ? 'medium' : undefined}
+            width={!['xsmall', 'small'].includes(size) ? 'medium' : undefined}
             pad="medium"
           >
             <LayerForm setOpen={value => setOpen(value)} />

--- a/aries-site/src/examples/components/menu/MenuHeaderExample.js
+++ b/aries-site/src/examples/components/menu/MenuHeaderExample.js
@@ -24,7 +24,7 @@ export const MenuHeaderExample = () => {
           responsive={false}
         >
           <Hpe color="brand" />
-          {size !== 'small' && (
+          {!['xsmall', 'small'].includes(size) && (
             <Box direction="row" gap="xsmall" wrap>
               <Text color="text-strong" weight="bold">
                 HPE

--- a/aries-site/src/examples/components/namevaluelist/Examples/NameValueListEditHorizontalExample.js
+++ b/aries-site/src/examples/components/namevaluelist/Examples/NameValueListEditHorizontalExample.js
@@ -64,7 +64,7 @@ export const NameValueListEditHorizontalExample = () => {
             secondary
             label="Edit"
             onClick={() => setEdit(true)}
-            fill={size === 'small' ? 'horizontal' : undefined}
+            fill={['xsmall', 'small'].includes(size) ? 'horizontal' : undefined}
           />
         )}
       </Box>
@@ -121,7 +121,9 @@ export const NameValueListEditHorizontalExample = () => {
               label="Save Changes"
               primary
               type="submit"
-              fill={size === 'small' ? 'horizontal' : undefined}
+              fill={
+                ['xsmall', 'small'].includes(size) ? 'horizontal' : undefined
+              }
             />
             <Button
               label="Cancel"
@@ -129,7 +131,9 @@ export const NameValueListEditHorizontalExample = () => {
                 setEdit(false);
                 setTempData(currentData);
               }}
-              fill={size === 'small' ? 'horizontal' : undefined}
+              fill={
+                ['xsmall', 'small'].includes(size) ? 'horizontal' : undefined
+              }
             />
           </Box>
         ) : (

--- a/aries-site/src/examples/components/namevaluelist/Previews/NameValueListAnatomyPreview.js
+++ b/aries-site/src/examples/components/namevaluelist/Previews/NameValueListAnatomyPreview.js
@@ -14,7 +14,10 @@ export const NameValueListAnatomyPreview = () => {
     <Box pad="small">
       <NameValueList
         pairProps={{
-          direction: size === 'medium' || size === 'small' ? 'column' : 'row',
+          direction:
+            size === 'medium' || ['xsmall', 'small'].includes(size)
+              ? 'column'
+              : 'row',
         }}
       >
         {Object.entries(anatomyData).map(([name, value]) => (

--- a/aries-site/src/examples/components/pagination/PaginationCardsExample.js
+++ b/aries-site/src/examples/components/pagination/PaginationCardsExample.js
@@ -53,7 +53,9 @@ export const PaginationCardsExample = () => {
         align="center"
         border="top"
         pad={{ vertical: 'xsmall' }}
-        direction={size !== 'small' ? 'row' : 'column-reverse'}
+        direction={
+          !['xsmall', 'small'].includes(size) ? 'row' : 'column-reverse'
+        }
         justify="between"
         flex={false}
       >

--- a/aries-site/src/examples/components/pagination/PaginationListExample.js
+++ b/aries-site/src/examples/components/pagination/PaginationListExample.js
@@ -30,7 +30,7 @@ export const PaginationListExample = () => {
           border: 'top',
           direction: 'row',
           fill: 'horizontal',
-          justify: size !== 'small' ? 'end' : 'center',
+          justify: !['xsmall', 'small'].includes(size) ? 'end' : 'center',
           pad: { top: 'xsmall' },
         }}
       />

--- a/aries-site/src/examples/components/pagination/PaginationTableExample.js
+++ b/aries-site/src/examples/components/pagination/PaginationTableExample.js
@@ -558,7 +558,7 @@ export const PaginationTableExample = () => {
               header: 'Id',
               primary: true,
               render: datum => datum.id.slice(datum.id.length - 5),
-              pin: size === 'small',
+              pin: ['xsmall', 'small'].includes(size),
             },
             ...columns,
           ]}
@@ -569,7 +569,7 @@ export const PaginationTableExample = () => {
             direction: 'row',
             fill: 'horizontal',
             flex: false,
-            justify: size !== 'small' ? 'end' : 'center',
+            justify: !['xsmall', 'small'].includes(size) ? 'end' : 'center',
             pad: { top: 'xsmall' },
           }}
           step={10}

--- a/aries-site/src/examples/components/spinner/ContentSpinnerExample.js
+++ b/aries-site/src/examples/components/spinner/ContentSpinnerExample.js
@@ -46,7 +46,7 @@ export const ContentSpinnerExample = () => {
           </Box>
         </Button>
 
-        {size !== 'small' ? (
+        {!['xsmall', 'small'].includes(size) ? (
           <Box gap="xsmall" direction="row">
             <Button icon={<HelpOption />} />
             <Button icon={<Notification />} />

--- a/aries-site/src/examples/components/tag/CreateTag/CreateTag.js
+++ b/aries-site/src/examples/components/tag/CreateTag/CreateTag.js
@@ -85,7 +85,7 @@ export const CreateTag = () => {
       >
         <Grid
           columns={
-            size !== 'small'
+            !['xsmall', 'small'].includes(size)
               ? [['auto', 'medium'], ['auto', 'medium'], 'auto']
               : '100%'
           }
@@ -172,7 +172,7 @@ export const CreateTag = () => {
             justify="start"
             // use theme style values to align Button with FormField input
             pad={
-              size !== 'small'
+              !['xsmall', 'small'].includes(size)
                 ? {
                     top: `${parseInt(theme.text.xsmall.height, 10) +
                       parseInt(
@@ -193,7 +193,9 @@ export const CreateTag = () => {
               alignSelf="start"
               label="Assign"
               type="submit"
-              fill={size === 'small' ? 'horizontal' : undefined}
+              fill={
+                ['xsmall', 'small'].includes(size) ? 'horizontal' : undefined
+              }
               secondary
             />
           </Box>

--- a/aries-site/src/examples/components/tag/CreateTag/TagPageHeader.js
+++ b/aries-site/src/examples/components/tag/CreateTag/TagPageHeader.js
@@ -1,27 +1,22 @@
-import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Text } from 'grommet';
-import { PageContainerContext } from '../../..';
 
-export const TagPageHeader = ({ description }) => {
-  const { ...pageContainer } = useContext(PageContainerContext);
-  return (
-    <Box {...pageContainer} gap="medium" flex={false}>
-      <Box gap="xsmall" flex={false}>
-        <Heading level={2} margin="none">
-          Create and Assign Tags
-        </Heading>
-        <Text size="large">
-          {description ||
-            'Tags are name-value pairs that can be assigned to resources.'}
-        </Text>
-      </Box>
+export const TagPageHeader = ({ description }) => (
+  <Box gap="medium" flex={false}>
+    <Box gap="xsmall" flex={false}>
+      <Heading level={2} margin="none">
+        Create and Assign Tags
+      </Heading>
       <Text size="large">
-        Tags will be assigned to <Text weight="bold">1</Text> selected device.
+        {description ||
+          'Tags are name-value pairs that can be assigned to resources.'}
       </Text>
     </Box>
-  );
-};
+    <Text size="large">
+      Tags will be assigned to <Text weight="bold">1</Text> selected device.
+    </Text>
+  </Box>
+);
 
 TagPageHeader.propTypes = {
   description: PropTypes.string,

--- a/aries-site/src/examples/components/tag/CreateTag/TagPageHeader.js
+++ b/aries-site/src/examples/components/tag/CreateTag/TagPageHeader.js
@@ -1,22 +1,27 @@
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Text } from 'grommet';
+import { PageContainerContext } from '../../..';
 
-export const TagPageHeader = ({ description }) => (
-  <Box gap="medium" flex={false}>
-    <Box gap="xsmall" flex={false}>
-      <Heading level={2} margin="none">
-        Create and Assign Tags
-      </Heading>
+export const TagPageHeader = ({ description }) => {
+  const { ...pageContainer } = useContext(PageContainerContext);
+  return (
+    <Box {...pageContainer} gap="medium" flex={false}>
+      <Box gap="xsmall" flex={false}>
+        <Heading level={2} margin="none">
+          Create and Assign Tags
+        </Heading>
+        <Text size="large">
+          {description ||
+            'Tags are name-value pairs that can be assigned to resources.'}
+        </Text>
+      </Box>
       <Text size="large">
-        {description ||
-          'Tags are name-value pairs that can be assigned to resources.'}
+        Tags will be assigned to <Text weight="bold">1</Text> selected device.
       </Text>
     </Box>
-    <Text size="large">
-      Tags will be assigned to <Text weight="bold">1</Text> selected device.
-    </Text>
-  </Box>
-);
+  );
+};
 
 TagPageHeader.propTypes = {
   description: PropTypes.string,

--- a/aries-site/src/examples/components/tag/CreateTagSimple.js
+++ b/aries-site/src/examples/components/tag/CreateTagSimple.js
@@ -60,7 +60,7 @@ export const CreateTagSimple = () => {
       >
         <Grid
           columns={
-            size !== 'small'
+            !['xsmall', 'small'].includes(size)
               ? [['auto', 'medium'], 'auto']
               : '100%'
           }
@@ -104,7 +104,7 @@ export const CreateTagSimple = () => {
             justify="start"
             // use theme style values to align Button with FormField input
             pad={
-              size !== 'small'
+              !['xsmall', 'small'].includes(size)
                 ? {
                     top: `${parseInt(theme.text.xsmall.height, 10) +
                       parseInt(
@@ -125,7 +125,9 @@ export const CreateTagSimple = () => {
               alignSelf="start"
               label="Assign"
               type="submit"
-              fill={size === 'small' ? 'horizontal' : undefined}
+              fill={
+                ['xsmall', 'small'].includes(size) ? 'horizontal' : undefined
+              }
               secondary
             />
           </Box>

--- a/aries-site/src/examples/foundation/background-colors/BasicLayoutCardsExample.js
+++ b/aries-site/src/examples/foundation/background-colors/BasicLayoutCardsExample.js
@@ -43,7 +43,7 @@ export const BasicLayoutCardsExample = () => {
             />
             <Grid
               columns="small"
-              gap={size !== 'small' ? 'medium' : 'small'}
+              gap={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
               fill
             >
               {data.map((datum, index) => (
@@ -76,7 +76,7 @@ const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/foundation/background-colors/BasicLayoutExample.js
+++ b/aries-site/src/examples/foundation/background-colors/BasicLayoutExample.js
@@ -25,7 +25,7 @@ export const BasicLayoutExample = () => {
           </Header>
           <Main background="background" flex={false} pad="medium">
             <Box
-              direction={size !== 'small' ? 'row' : 'column'}
+              direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
               gap="medium"
               wrap
             >
@@ -65,7 +65,7 @@ const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/foundation/background-colors/LayeredLayoutExample.js
+++ b/aries-site/src/examples/foundation/background-colors/LayeredLayoutExample.js
@@ -36,8 +36,12 @@ export const LayeredLayoutExample = () => {
               content, such as these Cards.
             </Paragraph>
             <Grid
-              columns={size !== 'small' ? 'small' : { count: 2, size: 'auto' }}
-              gap={size !== 'small' ? 'medium' : 'small'}
+              columns={
+                !['xsmall', 'small'].includes(size)
+                  ? 'small'
+                  : { count: 2, size: 'auto' }
+              }
+              gap={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
             >
               {data.map((datum, index) => (
                 <Card
@@ -65,7 +69,7 @@ const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js
+++ b/aries-site/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js
@@ -37,8 +37,12 @@ export const LayeredLayoutFixedExample = () => {
               content, such as these Cards.
             </Paragraph>
             <Grid
-              columns={size !== 'small' ? 'small' : { count: 2, size: 'auto' }}
-              gap={size !== 'small' ? 'medium' : 'small'}
+              columns={
+                !['xsmall', 'small'].includes(size)
+                  ? 'small'
+                  : { count: 2, size: 'auto' }
+              }
+              gap={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
             >
               {data.map((datum, index) => (
                 <Card
@@ -66,7 +70,7 @@ const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/foundation/color/ColorPalettes.js
+++ b/aries-site/src/examples/foundation/color/ColorPalettes.js
@@ -174,7 +174,7 @@ export const ElevationLight = () => {
       label="Light Background"
       justify="between"
       direction="row-responsive"
-      gap={size === 'small' ? 'medium' : undefined}
+      gap={['xsmall', 'small'].includes(size) ? 'medium' : undefined}
       pad={{
         horizontal: 'large',
         vertical: 'large',
@@ -202,7 +202,7 @@ export const ElevationDark = () => {
       label="Dark Background"
       justify="between"
       direction="row-responsive"
-      gap={size === 'small' ? 'medium' : undefined}
+      gap={['xsmall', 'small'].includes(size) ? 'medium' : undefined}
       pad={{
         horizontal: 'large',
         vertical: 'large',

--- a/aries-site/src/examples/foundation/color/TextExample.js
+++ b/aries-site/src/examples/foundation/color/TextExample.js
@@ -5,7 +5,7 @@ import { Box, Text, ResponsiveContext } from 'grommet';
 export const TextExample = ({ color, hex }) => {
   const size = React.useContext(ResponsiveContext);
   const textSize = 'small';
-  const exampleTextSize = size === 'small' ? '60px' : '84px';
+  const exampleTextSize = ['xsmall', 'small'].includes(size) ? '60px' : '84px';
 
   return (
     <Box align="center" margin={{ horizontal: 'small' }}>

--- a/aries-site/src/examples/templates/FilterControls/FilterControls.js
+++ b/aries-site/src/examples/templates/FilterControls/FilterControls.js
@@ -49,7 +49,8 @@ export const FilterControls = ({
         align="start"
         justify="between"
         gap="small"
-        wrap={size === 'small'} // so search input has room to grow on mobile
+        // so search input has room to grow on mobile
+        wrap={['xsmall', 'small'].includes(size)}
       >
         <Box direction="row" gap="small" margin={{ bottom: 'xsmall' }}>
           {searchFilter && (

--- a/aries-site/src/examples/templates/FilterControls/FiltersLayer.js
+++ b/aries-site/src/examples/templates/FilterControls/FiltersLayer.js
@@ -37,8 +37,8 @@ export const FiltersLayer = () => {
   return (
     <Layer
       as="section"
-      position={size !== 'small' ? 'right' : undefined}
-      full={size === 'small' ? true : 'vertical'}
+      position={!['xsmall', 'small'].includes(size) ? 'right' : undefined}
+      full={['xsmall', 'small'].includes(size) ? true : 'vertical'}
       onClickOutside={() => closeLayer()}
       onEsc={() => closeLayer()}
       {...layerProps}
@@ -47,7 +47,9 @@ export const FiltersLayer = () => {
         fill="vertical"
         gap="medium"
         pad={{ vertical: 'medium' }}
-        width={{ min: size !== 'small' ? 'medium' : undefined }}
+        width={{
+          min: !['xsmall', 'small'].includes(size) ? 'medium' : undefined,
+        }}
         {...containerProps}
       >
         <Header pad={{ horizontal: 'medium' }}>

--- a/aries-site/src/examples/templates/FilterControls/SearchFilter.js
+++ b/aries-site/src/examples/templates/FilterControls/SearchFilter.js
@@ -31,7 +31,7 @@ export const SearchFilter = ({ placeholder }) => {
 
   return (
     <>
-      {size !== 'small' || searchFocused ? (
+      {!['xsmall', 'small'].includes(size) || searchFocused ? (
         <Box width="medium" flex="shrink">
           <StyledTextInput
             ref={inputRef}

--- a/aries-site/src/examples/templates/ascending-navigation/AscendingNavigationAnatomy.js
+++ b/aries-site/src/examples/templates/ascending-navigation/AscendingNavigationAnatomy.js
@@ -38,7 +38,11 @@ const AnatomyGrid = ({ ...rest }) => {
   const size = useContext(ResponsiveContext);
   return (
     <Grid
-      columns={size !== 'small' ? ['medium', 'medium'] : ['small', 'small']}
+      columns={
+        !['xsmall', 'small'].includes(size)
+          ? ['medium', 'medium']
+          : ['small', 'small']
+      }
       rows={['xxsmall', 'auto']}
       gap="none"
       justify="center"

--- a/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
+++ b/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
@@ -79,7 +79,7 @@ const PageContent = () => {
       <Grid gap={parentGrid.gap[size]} columns={parentGrid.columns[size]}>
         {/* Content Block 1 is top priority content. At narrow breakpoints, 
         place as first content element. Otherwise, place in second column. */}
-        {(['xsmall', 'small'].includes(size) || size === 'xsmall') && (
+        {['xsmall', 'small'].includes(size) && (
           <ContentBlock title="1" />
         )}
         <Grid gap={firstChildGrid.gap}>

--- a/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
+++ b/aries-site/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
@@ -79,7 +79,9 @@ const PageContent = () => {
       <Grid gap={parentGrid.gap[size]} columns={parentGrid.columns[size]}>
         {/* Content Block 1 is top priority content. At narrow breakpoints, 
         place as first content element. Otherwise, place in second column. */}
-        {(size === 'small' || size === 'xsmall') && <ContentBlock title="1" />}
+        {(['xsmall', 'small'].includes(size) || size === 'xsmall') && (
+          <ContentBlock title="1" />
+        )}
         <Grid gap={firstChildGrid.gap}>
           <Grid columns={firstChildGrid.columns[size]} gap={firstChildGrid.gap}>
             <ContentBlock title="2" />
@@ -96,7 +98,7 @@ const PageContent = () => {
             <ContentBlock title="6" fill="vertical" />
           </Grid>
         </Grid>
-        {size !== 'small' && size !== 'xsmall' && (
+        {!['xsmall', 'small'].includes(size) && size !== 'xsmall' && (
           <ContentBlock title="1" fill="vertical" />
         )}
       </Grid>

--- a/aries-site/src/examples/templates/dashboards/DashboardExample.js
+++ b/aries-site/src/examples/templates/dashboards/DashboardExample.js
@@ -15,7 +15,9 @@ export const DashboardExample = () => {
             background="background"
             justify="center"
             pad={{
-              horizontal: size !== 'small' ? 'xlarge' : 'medium',
+              horizontal: !['xsmall', 'small'].includes(size)
+                ? 'xlarge'
+                : 'medium',
               vertical: 'large',
             }}
             flex={false}

--- a/aries-site/src/examples/templates/dashboards/TwoColumnDashboard.js
+++ b/aries-site/src/examples/templates/dashboards/TwoColumnDashboard.js
@@ -124,7 +124,7 @@ const PageContent = () => {
             </Grid>
           </Box>
         </Box>
-        {!['xsmall', 'small'].includes(size) && size !== 'xsmall' && (
+        {!['xsmall', 'small'].includes(size) && (
           <Box gap="large">
             {/* fragment is used to create a gap spacing element 
             for alignment to column 1 */}

--- a/aries-site/src/examples/templates/dashboards/TwoColumnDashboard.js
+++ b/aries-site/src/examples/templates/dashboards/TwoColumnDashboard.js
@@ -92,7 +92,7 @@ const PageContent = () => {
       <Grid columns={parentGrid.columns[size]} gap={parentGrid.gap[size]}>
         {/* RecentActivity is top priority content. At narrow breakpoints, 
         place as first content element. Otherwise, place in second column. */}
-        {(['xsmall', 'small'].includes(size) || size === 'xsmall') && (
+        {['xsmall', 'small'].includes(size) && (
           <RecentActivity />
         )}
         <Box gap="large">

--- a/aries-site/src/examples/templates/dashboards/TwoColumnDashboard.js
+++ b/aries-site/src/examples/templates/dashboards/TwoColumnDashboard.js
@@ -92,7 +92,9 @@ const PageContent = () => {
       <Grid columns={parentGrid.columns[size]} gap={parentGrid.gap[size]}>
         {/* RecentActivity is top priority content. At narrow breakpoints, 
         place as first content element. Otherwise, place in second column. */}
-        {(size === 'small' || size === 'xsmall') && <RecentActivity />}
+        {(['xsmall', 'small'].includes(size) || size === 'xsmall') && (
+          <RecentActivity />
+        )}
         <Box gap="large">
           <Box gap="small">
             <Heading level={2} size="small" margin="none">
@@ -122,7 +124,7 @@ const PageContent = () => {
             </Grid>
           </Box>
         </Box>
-        {size !== 'small' && size !== 'xsmall' && (
+        {!['xsmall', 'small'].includes(size) && size !== 'xsmall' && (
           <Box gap="large">
             {/* fragment is used to create a gap spacing element 
             for alignment to column 1 */}

--- a/aries-site/src/examples/templates/dashboards/components/DashboardGrid.js
+++ b/aries-site/src/examples/templates/dashboards/components/DashboardGrid.js
@@ -6,7 +6,7 @@ export const DashboardGrid = ({ ...rest }) => {
   const size = useContext(ResponsiveContext);
   return (
     <Grid
-      columns={size !== 'small' ? 'medium' : '100%'}
+      columns={!['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
       rows={[['auto', 'full']]}
       gap="medium"
       fill

--- a/aries-site/src/examples/templates/filtering/FilteringCards/FilteringCards.js
+++ b/aries-site/src/examples/templates/filtering/FilteringCards/FilteringCards.js
@@ -57,7 +57,7 @@ export const FilteringCards = ({ containerRef }) => {
   return (
     <Box
       background="background"
-      pad={size !== 'small' ? 'large' : 'medium'}
+      pad={!['xsmall', 'small'].includes(size) ? 'large' : 'medium'}
       gap="medium"
     >
       <Heading level={2} margin="none">
@@ -85,8 +85,12 @@ const Users = () => {
   return (
     <Box overflow="auto" fill>
       <Grid
-        columns={size !== 'small' ? 'small' : { count: 2, size: 'auto' }}
-        gap={size !== 'small' ? 'medium' : 'small'}
+        columns={
+          !['xsmall', 'small'].includes(size)
+            ? 'small'
+            : { count: 2, size: 'auto' }
+        }
+        gap={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
       >
         {filteredResults.map(datum => (
           <Card

--- a/aries-site/src/examples/templates/filtering/FilteringLists/FilteringLists.js
+++ b/aries-site/src/examples/templates/filtering/FilteringLists/FilteringLists.js
@@ -23,7 +23,7 @@ export const FilteringLists = ({ containerRef }) => {
 
   const size = useContext(ResponsiveContext);
   const formFieldProps = {
-    width: size !== 'small' ? 'small' : undefined,
+    width: !['xsmall', 'small'].includes(size) ? 'small' : undefined,
   };
   // Define which attributes should be made available for the user
   // to filter upon
@@ -58,7 +58,7 @@ export const FilteringLists = ({ containerRef }) => {
     containerProps: {
       fill: false,
       pad: {
-        horizontal: size === 'small' ? undefined : 'medium',
+        horizontal: ['xsmall', 'small'].includes(size) ? undefined : 'medium',
         vertical: 'small',
       },
       width: { max: 'large' },
@@ -66,21 +66,21 @@ export const FilteringLists = ({ containerRef }) => {
     // contentProps accept any Grommet Box props to customize the Box
     // containing the FormField filters.
     contentProps: {
-      direction: size === 'small' ? 'column' : 'row',
-      gap: size === 'small' ? 'xsmall' : 'medium',
+      direction: ['xsmall', 'small'].includes(size) ? 'column' : 'row',
+      gap: ['xsmall', 'small'].includes(size) ? 'xsmall' : 'medium',
       pad: { horizontal: 'medium', bottom: 'small' },
     },
-    full: size === 'small',
+    full: ['xsmall', 'small'].includes(size),
     // containerRef is for demonstration purposes on this site. Most
     // implementations should likely remove.
     target: containerRef && containerRef.current,
-    position: size === 'small' ? undefined : 'center',
+    position: ['xsmall', 'small'].includes(size) ? undefined : 'center',
   };
 
   return (
     <Box
       background="background"
-      pad={size !== 'small' ? 'large' : 'medium'}
+      pad={!['xsmall', 'small'].includes(size) ? 'large' : 'medium'}
       gap="medium"
     >
       <Header gap="small">
@@ -121,7 +121,9 @@ const Orders = () => {
       <List
         action={(item, index) => (
           <Box key={index} align="center" direction="row" gap="small">
-            {size !== 'small' && <Text color="text-strong">{item.status}</Text>}
+            {!['xsmall', 'small'].includes(size) && (
+              <Text color="text-strong">{item.status}</Text>
+            )}
             {statusIcons[item.status]}
           </Box>
         )}

--- a/aries-site/src/examples/templates/filtering/FilteringTable/FilteringTable.js
+++ b/aries-site/src/examples/templates/filtering/FilteringTable/FilteringTable.js
@@ -119,7 +119,7 @@ const ServerResults = () => {
           {
             property: 'id',
             header: 'Name',
-            pin: size === 'small',
+            pin: ['xsmall', 'small'].includes(size),
             primary: true,
             render: datum => datum.displayName,
           },

--- a/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithDropButton.js
@@ -112,7 +112,7 @@ export const FilteringWithDropButton = () => {
             Machines
           </Heading>
           <Box align="center" direction="row" gap="small">
-            {size !== 'small' || searchFocused ? (
+            {!['xsmall', 'small'].includes(size) || searchFocused ? (
               <Box width="medium">
                 <StyledTextInput
                   ref={inputRef}
@@ -140,7 +140,7 @@ export const FilteringWithDropButton = () => {
                 onClick={() => setSearchFocused(true)}
               />
             )}
-            {(size !== 'small' || !searchFocused) && (
+            {(!['xsmall', 'small'].includes(size) || !searchFocused) && (
               <Filters
                 data={data}
                 filtering={filtering}
@@ -360,8 +360,12 @@ const Results = ({ data }) => {
   return (
     <Box overflow="auto" pad={{ bottom: 'medium' }} fill>
       <Grid
-        columns={size !== 'small' ? 'small' : { count: 2, size: 'auto' }}
-        gap={size !== 'small' ? 'medium' : 'small'}
+        columns={
+          !['xsmall', 'small'].includes(size)
+            ? 'small'
+            : { count: 2, size: 'auto' }
+        }
+        gap={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
       >
         {data.map((datum, index) => (
           <Card

--- a/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithRangeSelector.js
@@ -122,7 +122,7 @@ export const FilteringWithRangeSelector = ({ containerRef }) => {
             Storage
           </Heading>
           <Box align="center" direction="row" gap="small">
-            {size !== 'small' || searchFocused ? (
+            {!['xsmall', 'small'].includes(size) || searchFocused ? (
               <Box width="medium">
                 <StyledTextInput
                   ref={inputRef}
@@ -150,7 +150,7 @@ export const FilteringWithRangeSelector = ({ containerRef }) => {
                 onClick={() => setSearchFocused(true)}
               />
             )}
-            {(size !== 'small' || !searchFocused) && (
+            {(!['xsmall', 'small'].includes(size) || !searchFocused) && (
               <Filters
                 data={data}
                 filtering={filtering}
@@ -222,7 +222,7 @@ const Filters = ({
     );
   };
 
-  if (size === 'small') {
+  if (['xsmall', 'small'].includes(size)) {
     return (
       <>
         <Box align="center" direction="row" gap="xsmall">
@@ -490,7 +490,7 @@ const AvailabilityFilter = ({
           // on mobile, we want to filter the data immediately but
           // on desktop, we wait until the user clicks
           // "Apply Filter" to filter the data
-          if (size === 'small') {
+          if (['xsmall', 'small'].includes(size)) {
             const nextFilters = {
               ...filters,
               availability: nextAvailability =>

--- a/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
+++ b/aries-site/src/examples/templates/filtering/FilteringWithSelect.js
@@ -108,7 +108,7 @@ export const FilteringWithSelect = ({ containerRef }) => {
             Hosts
           </Heading>
           <Box align="center" direction="row" gap="small">
-            {size !== 'small' || searchFocused ? (
+            {!['xsmall', 'small'].includes(size) || searchFocused ? (
               <Box width="medium">
                 <StyledTextInput
                   ref={inputRef}
@@ -136,7 +136,7 @@ export const FilteringWithSelect = ({ containerRef }) => {
                 onClick={() => setSearchFocused(true)}
               />
             )}
-            {(size !== 'small' || !searchFocused) && (
+            {(!['xsmall', 'small'].includes(size) || !searchFocused) && (
               <Filters
                 data={data}
                 filtering={filtering}
@@ -221,7 +221,7 @@ const Filters = ({
   return (
     <>
       <Box align="center" direction="row" gap="small">
-        {size !== 'small' ? (
+        {!['xsmall', 'small'].includes(size) ? (
           content
         ) : (
           <Button
@@ -237,8 +237,8 @@ const Filters = ({
       </Box>
       {showLayer && (
         <Layer
-          position={size !== 'small' ? 'right' : undefined}
-          full={size !== 'small' ? 'vertical' : true}
+          position={!['xsmall', 'small'].includes(size) ? 'right' : undefined}
+          full={!['xsmall', 'small'].includes(size) ? 'vertical' : true}
           modal
           onClickOutside={() => {
             filterData(allData, previousFilters);
@@ -359,7 +359,9 @@ const Results = ({ data }) => {
             flex={false}
           >
             <Box direction="row" gap="small" align="center">
-              {size !== 'small' && <Text>{item.status}</Text>}
+              {!['xsmall', 'small'].includes(size) && (
+                <Text>{item.status}</Text>
+              )}
               {item.status === 'Ready' ? (
                 <StatusGoodSmall color="status-ok" size="small" />
               ) : (

--- a/aries-site/src/examples/templates/filtering/PersistentFiltering.js
+++ b/aries-site/src/examples/templates/filtering/PersistentFiltering.js
@@ -216,7 +216,7 @@ export const PersistentFiltering = ({ containerRef }) => {
             Sites
           </Heading>
           <Box align="center" direction="row" gap="small">
-            {size !== 'small' || searchFocused ? (
+            {!['xsmall', 'small'].includes(size) || searchFocused ? (
               <Box width="medium">
                 <StyledTextInput
                   ref={inputRef}
@@ -244,15 +244,17 @@ export const PersistentFiltering = ({ containerRef }) => {
                 onClick={() => setSearchFocused(true)}
               />
             )}
-            {size === 'small' && !searchFocused && <Filters {...filterProps} />}
+            {['xsmall', 'small'].includes(size) && !searchFocused && (
+              <Filters {...filterProps} />
+            )}
           </Box>
           <RecordSummary data={data} filtering={filtering} />
         </Box>
       </Header>
       <Box direction="row" fill>
-        {size !== 'small' && <Filters {...filterProps} />}
+        {!['xsmall', 'small'].includes(size) && <Filters {...filterProps} />}
         <Box fill>
-          {size !== 'small' && (
+          {!['xsmall', 'small'].includes(size) && (
             <ActiveFilters
               filters={filters}
               filterData={filterData}
@@ -467,7 +469,7 @@ const Filters = ({
     </Box>
   );
 
-  return size === 'small' ? (
+  return ['xsmall', 'small'].includes(size) ? (
     <>
       <Box align="center" direction="row" gap="small">
         <Button
@@ -482,8 +484,8 @@ const Filters = ({
       </Box>
       {showLayer && (
         <Layer
-          position={size !== 'small' ? 'right' : undefined}
-          full={size !== 'small' ? 'vertical' : true}
+          position={!['xsmall', 'small'].includes(size) ? 'right' : undefined}
+          full={!['xsmall', 'small'].includes(size) ? 'vertical' : true}
           modal
           onClickOutside={() => {
             filterData(allData, previousFilters);
@@ -806,9 +808,9 @@ const Results = ({ data }) => {
   return (
     <Box overflow="auto" fill>
       <Grid
-        columns={size !== 'small' ? 'medium' : '100%'}
+        columns={!['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
         gap="medium"
-        pad={size !== 'small' ? 'medium' : 'small'}
+        pad={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
       >
         {data.map((datum, index) => (
           <Card

--- a/aries-site/src/examples/templates/forms/ChangePasswordExample.js
+++ b/aries-site/src/examples/templates/forms/ChangePasswordExample.js
@@ -112,7 +112,7 @@ export const ChangePasswordExample = () => {
             />
           </FormField>
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'medium', bottom: 'small' }}
           >
             <Button label="Update Password" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/CustomizeExample.js
+++ b/aries-site/src/examples/templates/forms/CustomizeExample.js
@@ -98,7 +98,7 @@ export const CustomizeExample = () => {
             />
           </FormField>
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'medium', bottom: 'small' }}
           >
             <Button label="Continue" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/PayExample.js
+++ b/aries-site/src/examples/templates/forms/PayExample.js
@@ -193,7 +193,7 @@ export const PayExample = () => {
             </Box>
           </Box>
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'small', bottom: 'small' }}
           >
             <Button label="Checkout" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
+++ b/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
@@ -158,7 +158,7 @@ export const RequiredFieldsExample = () => {
             </Box>
           )}
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'medium', bottom: 'small' }}
           >
             <Button label="Create" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/SettingsExample.js
+++ b/aries-site/src/examples/templates/forms/SettingsExample.js
@@ -103,7 +103,7 @@ export const SettingsExample = () => {
               />
             </FormField>
             <Box
-              align={size !== 'small' ? 'start' : undefined}
+              align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
               margin={{ top: 'small', bottom: 'small' }}
             >
               <Button label="Apply Settings" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/ShippingExample.js
+++ b/aries-site/src/examples/templates/forms/ShippingExample.js
@@ -308,7 +308,7 @@ export const ShippingExample = () => {
             </FormField>
           </Box>
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'small', bottom: 'small' }}
           >
             <Button label="Continue" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -206,7 +206,7 @@ export const SignInExample = () => {
             </Box>
           )}
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'medium', bottom: 'small' }}
           >
             <Button

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -230,7 +230,7 @@ export const SignUpExample = () => {
             />
           </FormField>
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'medium', bottom: 'small' }}
           >
             <Button label="Sign Up" primary type="submit" />

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -230,7 +230,7 @@ export const SimpleSignUpExample = () => {
             />
           </FormField>
           <Box
-            align={size !== 'small' ? 'start' : undefined}
+            align={!['xsmall', 'small'].includes(size) ? 'start' : undefined}
             margin={{ top: 'medium', bottom: 'small' }}
           >
             <Button label="Sign Up" primary type="submit" />

--- a/aries-site/src/examples/templates/global-header/components/AppIdentity.js
+++ b/aries-site/src/examples/templates/global-header/components/AppIdentity.js
@@ -24,7 +24,7 @@ export const AppIdentity = forwardRef(
       <Box
         align="center"
         direction="row"
-        gap={size !== 'small' ? 'medium' : 'small'}
+        gap={!['xsmall', 'small'].includes(size) ? 'medium' : 'small'}
       >
         {/* menu is only available when user is logged in */}
         {user && <MenuLayer />}

--- a/aries-site/src/examples/templates/global-header/components/GlobalHeader.js
+++ b/aries-site/src/examples/templates/global-header/components/GlobalHeader.js
@@ -14,7 +14,7 @@ export const GlobalHeader = () => {
         justify="between"
         fill="horizontal"
         pad={{
-          horizontal: size !== 'small' ? 'medium' : 'small',
+          horizontal: !['xsmall', 'small'].includes(size) ? 'medium' : 'small',
           vertical: 'small',
         }}
       >

--- a/aries-site/src/examples/templates/global-header/components/HeaderNav.js
+++ b/aries-site/src/examples/templates/global-header/components/HeaderNav.js
@@ -18,7 +18,7 @@ export const HeaderNav = () => {
 
   return user ? (
     <Nav align="center" direction="row" gap="small">
-      {size !== 'small' && (
+      {!['xsmall', 'small'].includes(size) && (
         <>
           <Button icon={<HelpOption />} a11yTitle="Help" title="Help" />
           <Button icon={<HomeRounded />} a11yTitle="Home" title="Home" />

--- a/aries-site/src/examples/templates/global-header/components/MenuLayer.js
+++ b/aries-site/src/examples/templates/global-header/components/MenuLayer.js
@@ -26,15 +26,15 @@ export const MenuLayer = () => {
       <Button icon={<Menu />} onClick={() => setShowLayer(true)} />
       {showLayer && (
         <Layer
-          full={size !== 'small' ? 'vertical' : true}
+          full={!['xsmall', 'small'].includes(size) ? 'vertical' : true}
           modal={false}
           onClickOutside={() => setShowLayer(false)}
           onEsc={() => setShowLayer(false)}
-          position={size !== 'small' ? 'left' : undefined}
+          position={!['xsmall', 'small'].includes(size) ? 'left' : undefined}
         >
           <Box
             fill="vertical"
-            width={size !== 'small' ? 'medium' : undefined}
+            width={!['xsmall', 'small'].includes(size) ? 'medium' : undefined}
             elevation="large"
           >
             <Header pad={pad}>

--- a/aries-site/src/examples/templates/global-header/components/MockGlobalHeader.js
+++ b/aries-site/src/examples/templates/global-header/components/MockGlobalHeader.js
@@ -5,16 +5,16 @@ import { useContext } from 'react';
 export const MockGlobalHeader = ({ children }) => {
   const size = useContext(ResponsiveContext);
 
-  return size === 'small' ? (
+  return ['xsmall', 'small'].includes(size) ? (
     <Box fill>
       <Image src="/templateImages/globalheader-small.png" />
-      { children }
+      {children}
       <Image src="/templateImages/globalheader-footer-small.png" />
     </Box>
   ) : (
     <Box fill>
       <Image src="/templateImages/globalheader.png" />
-      { children }
+      {children}
       <Image src="/templateImages/globalheader-footer.png" />
     </Box>
   );

--- a/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
+++ b/aries-site/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
@@ -212,11 +212,11 @@ const AppContainer = ({ ...rest }) => {
   return (
     <Box
       background="background-back"
-      height={size === 'small' ? { max: 'large' } : '100%'}
-      width={size === 'small' ? 'medium' : '100%'}
+      height={['xsmall', 'small'].includes(size) ? { max: 'large' } : '100%'}
+      width={['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
       overflow="auto"
       pad={{
-        horizontal: size !== 'small' ? 'large' : 'medium',
+        horizontal: !['xsmall', 'small'].includes(size) ? 'large' : 'medium',
         bottom: 'large',
       }}
       {...rest}

--- a/aries-site/src/examples/templates/list-views/ListScreenExample.js
+++ b/aries-site/src/examples/templates/list-views/ListScreenExample.js
@@ -66,7 +66,7 @@ const StyledList = () => {
       pad="small"
       action={(item, index) => (
         <Box key={index} direction="row" align="center" gap="medium">
-          {size !== 'small' && (
+          {!['xsmall', 'small'].includes(size) && (
             <Text
               weight="bold"
               size="xsmall"
@@ -82,7 +82,9 @@ const StyledList = () => {
           />
         </Box>
       )}
-      margin={size === 'small' ? { bottom: 'large' } : undefined}
+      margin={
+        ['xsmall', 'small'].includes(size) ? { bottom: 'large' } : undefined
+      }
     >
       {(datum, index) => (
         <Box
@@ -157,8 +159,8 @@ const ScreenContainer = ({ mobile, ...rest }) => {
   return (
     <Box
       background="background"
-      width={size === 'small' ? 'medium' : '100%'}
-      height={size === 'small' ? { max: 'large' } : undefined}
+      width={['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
+      height={['xsmall', 'small'].includes(size) ? { max: 'large' } : undefined}
       style={{ position: 'relative' }}
       fill
     >

--- a/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js
+++ b/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js
@@ -2,58 +2,58 @@ import React from 'react';
 import { Header, Box, Footer, Main, ResponsiveContext, Text } from 'grommet';
 
 export const HeaderFooterExample = () => (
-    <AppContainer>
-      <Box flex overflow="auto">
-        <Box height={{ min: '100%' }}>
-          <Header
-            background="background-front"
-            fill="horizontal"
-            pad="small"
-            // remove height="xxsmall" in prod, for demo purposes only
-            height="xxsmall"
-            // remove dashed border in prod, for demo purposes only
-            border={{ color: 'border', style: 'dashed' }}
-          >
-            <Text weight="bold" color="text-strong">
-              Header
-            </Text>
-          </Header>
-          <Main
-            fill={undefined}
-            flex={false}
-            pad="small"
-            // remove height="xlarge" in prod, for demo purposes only
-            height="xlarge"
-            // remove dashed border in prod, for demo purposes only
-            border={{ color: 'border', style: 'dashed' }}
-          >
-            <Text weight="bold" color="text-strong">
-              Main
-            </Text>
-          </Main>
-          <Footer
-            background="background-front"
-            fill="horizontal"
-            pad="small"
-            // remove dashed border in prod, for demo purposes only
-            border={{ color: 'border', style: 'dashed' }}
-            // remove height="xxsmall" in prod, for demo purposes only
-            height="xxsmall"
-          >
-            <Text weight="bold" color="text-strong">
-              Footer
-            </Text>
-          </Footer>
-        </Box>
+  <AppContainer>
+    <Box flex overflow="auto">
+      <Box height={{ min: '100%' }}>
+        <Header
+          background="background-front"
+          fill="horizontal"
+          pad="small"
+          // remove height="xxsmall" in prod, for demo purposes only
+          height="xxsmall"
+          // remove dashed border in prod, for demo purposes only
+          border={{ color: 'border', style: 'dashed' }}
+        >
+          <Text weight="bold" color="text-strong">
+            Header
+          </Text>
+        </Header>
+        <Main
+          fill={undefined}
+          flex={false}
+          pad="small"
+          // remove height="xlarge" in prod, for demo purposes only
+          height="xlarge"
+          // remove dashed border in prod, for demo purposes only
+          border={{ color: 'border', style: 'dashed' }}
+        >
+          <Text weight="bold" color="text-strong">
+            Main
+          </Text>
+        </Main>
+        <Footer
+          background="background-front"
+          fill="horizontal"
+          pad="small"
+          // remove dashed border in prod, for demo purposes only
+          border={{ color: 'border', style: 'dashed' }}
+          // remove height="xxsmall" in prod, for demo purposes only
+          height="xxsmall"
+        >
+          <Text weight="bold" color="text-strong">
+            Footer
+          </Text>
+        </Footer>
       </Box>
-    </AppContainer>
-  );
+    </Box>
+  </AppContainer>
+);
 
 const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/templates/page-layouts/HeaderOnlyExample.js
+++ b/aries-site/src/examples/templates/page-layouts/HeaderOnlyExample.js
@@ -2,45 +2,45 @@ import React from 'react';
 import { Header, Box, Main, ResponsiveContext, Text } from 'grommet';
 
 export const HeaderOnlyExample = () => (
-    <AppContainer>
-      <Box flex overflow="auto">
-        <Box height={{ min: '100%' }}>
-          <Header
-            background="background-front"
-            fill="horizontal"
-            pad="small"
-            // remove dashed border in prod, for demo purposes only
-            border={{ color: 'border', style: 'dashed' }}
-            // remove height="xxsmall" in prod, for demo purposes only
-            height="xxsmall"
-          >
-            <Text weight="bold" color="text-strong">
-              Header
-            </Text>
-          </Header>
-          <Main
-            fill={undefined}
-            flex={false}
-            pad="small"
-            // remove dashed border in prod, for demo purposes only
-            border={{ color: 'border', style: 'dashed' }}
-            // remove height="xlarge" in prod, for demo purposes only
-            height="xlarge"
-          >
-            <Text weight="bold" color="text-strong">
-              Main
-            </Text>
-          </Main>
-        </Box>
+  <AppContainer>
+    <Box flex overflow="auto">
+      <Box height={{ min: '100%' }}>
+        <Header
+          background="background-front"
+          fill="horizontal"
+          pad="small"
+          // remove dashed border in prod, for demo purposes only
+          border={{ color: 'border', style: 'dashed' }}
+          // remove height="xxsmall" in prod, for demo purposes only
+          height="xxsmall"
+        >
+          <Text weight="bold" color="text-strong">
+            Header
+          </Text>
+        </Header>
+        <Main
+          fill={undefined}
+          flex={false}
+          pad="small"
+          // remove dashed border in prod, for demo purposes only
+          border={{ color: 'border', style: 'dashed' }}
+          // remove height="xlarge" in prod, for demo purposes only
+          height="xlarge"
+        >
+          <Text weight="bold" color="text-strong">
+            Main
+          </Text>
+        </Main>
       </Box>
-    </AppContainer>
-  );
+    </Box>
+  </AppContainer>
+);
 
 const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/templates/page-layouts/StickyHeaderExample.js
+++ b/aries-site/src/examples/templates/page-layouts/StickyHeaderExample.js
@@ -53,7 +53,7 @@ const AppContainer = ({ ...rest }) => {
   const size = React.useContext(ResponsiveContext);
   return (
     <Box
-      direction={size === 'small' ? 'column-reverse' : 'row'}
+      direction={['xsmall', 'small'].includes(size) ? 'column-reverse' : 'row'}
       fill
       margin="auto"
       width={{ max: 'xxlarge' }}

--- a/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/aries-site/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -37,14 +37,14 @@ const StepOne = () => {
   const size = useContext(ResponsiveContext);
   return (
     <Box
-      direction={size !== 'small' ? 'row' : 'column-reverse'}
+      direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column-reverse'}
       margin={{ bottom: 'medium' }}
-      gap={size === 'small' ? 'small' : undefined}
+      gap={['xsmall', 'small'].includes(size) ? 'small' : undefined}
       justify="between"
       wrap
     >
       <Box
-        width={size !== 'small' ? 'medium' : '100%'}
+        width={!['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
         margin={{ bottom: 'medium' }}
         gap="medium"
         flex={false}
@@ -262,7 +262,11 @@ const Guidance = () => {
       pad="medium"
       round="small"
       flex
-      width={size !== 'small' ? { min: 'small', max: 'medium' } : '100%'}
+      width={
+        !['xsmall', 'small'].includes(size)
+          ? { min: 'small', max: 'medium' }
+          : '100%'
+      }
     >
       <Text color="text-strong" size="large">
         When guidance is required for the form or content of the wizard, you

--- a/aries-site/src/examples/templates/wizard/WizardValidationExample.js
+++ b/aries-site/src/examples/templates/wizard/WizardValidationExample.js
@@ -105,8 +105,12 @@ const StepOne = () => {
   return (
     <>
       <Grid
-        columns={size !== 'small' ? { count: 'fit', size: 'medium' } : '100%'}
-        gap={size !== 'small' ? 'large' : undefined}
+        columns={
+          !['xsmall', 'small'].includes(size)
+            ? { count: 'fit', size: 'medium' }
+            : '100%'
+        }
+        gap={!['xsmall', 'small'].includes(size) ? 'large' : undefined}
         margin={{ bottom: 'medium' }}
       >
         {stepOneInputs.map((input, index) => (

--- a/aries-site/src/examples/templates/wizard/components/CancellationLayer.js
+++ b/aries-site/src/examples/templates/wizard/components/CancellationLayer.js
@@ -9,7 +9,7 @@ export const CancellationLayer = ({ onSetOpen, ...rest }) => {
   return (
     <Layer
       position="center"
-      full={size === 'small'}
+      full={['xsmall', 'small'].includes(size)}
       onClickOutside={() => onSetOpen(false)}
       onEsc={() => onSetOpen(false)}
       {...rest}
@@ -28,7 +28,7 @@ export const CancellationLayer = ({ onSetOpen, ...rest }) => {
         <Box
           as="footer"
           gap="small"
-          direction={size !== 'small' ? 'row' : 'column'}
+          direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
           align="center"
           justify="end"
         >
@@ -36,11 +36,11 @@ export const CancellationLayer = ({ onSetOpen, ...rest }) => {
             label="No, Stay"
             onClick={() => onSetOpen(false)}
             secondary
-            fill={size !== 'small' ? false : 'horizontal'}
+            fill={!['xsmall', 'small'].includes(size) ? false : 'horizontal'}
           />
           <Button
             label="Yes, Exit"
-            fill={size !== 'small' ? false : 'horizontal'}
+            fill={!['xsmall', 'small'].includes(size) ? false : 'horizontal'}
             onClick={() => {
               onSetOpen(false);
               setFormValues(defaultFormValues);

--- a/aries-site/src/examples/templates/wizard/components/StepContent.js
+++ b/aries-site/src/examples/templates/wizard/components/StepContent.js
@@ -17,12 +17,11 @@ export const StepContent = ({ onSubmit }) => {
     width,
   } = useContext(WizardContext);
 
-  const handleSubmit = (event) => {
+  const handleSubmit = event => {
     setValid(true);
     if (activeIndex < steps.length - 1) {
       setActiveIndex(activeIndex + 1);
-    }
-    else if (onSubmit) {
+    } else if (onSubmit) {
       onSubmit(event);
     }
   };
@@ -31,8 +30,10 @@ export const StepContent = ({ onSubmit }) => {
   // return an error or info message. This removes the need for the
   // user to scroll to find which field blocked form submission.
   const onValidate = validationResults => {
-    const names  = [ ...Object.keys(validationResults.errors),
-      ...Object.keys(validationResults.infos) ];
+    const names = [
+      ...Object.keys(validationResults.errors),
+      ...Object.keys(validationResults.infos),
+    ];
     if (names.length > 0) {
       const selector = names.map(name => `[name=${name}]`).join(',');
       const firstInvalid = document.querySelectorAll(selector)[0];
@@ -46,16 +47,28 @@ export const StepContent = ({ onSubmit }) => {
   return (
     <Box
       align="center"
-      pad={size !== 'small' ? { vertical: 'large' } : { vertical: 'medium' }}
+      pad={
+        !['xsmall', 'small'].includes(size)
+          ? { vertical: 'large' }
+          : { vertical: 'medium' }
+      }
       overflow="auto"
       ref={ref}
-      flex={size === 'small' ? true : undefined}
-      margin={size !== 'small' ? { horizontal: 'medium' } : undefined}
+      flex={['xsmall', 'small'].includes(size) ? true : undefined}
+      margin={
+        !['xsmall', 'small'].includes(size)
+          ? { horizontal: 'medium' }
+          : undefined
+      }
     >
       <Box
         width={width}
         gap="medium"
-        pad={size === 'small' ? { horizontal: 'medium' } : 'xxsmall'}
+        pad={
+          ['xsmall', 'small'].includes(size)
+            ? { horizontal: 'medium' }
+            : 'xxsmall'
+        }
       >
         <StepHeader />
         <Box margin={{ top: 'small' }}>

--- a/aries-site/src/examples/templates/wizard/components/StepFooter.js
+++ b/aries-site/src/examples/templates/wizard/components/StepFooter.js
@@ -9,14 +9,18 @@ export const StepFooter = () => {
 
   return (
     <Box
-      margin={size !== 'small' ? { horizontal: 'medium' } : undefined}
+      margin={
+        !['xsmall', 'small'].includes(size)
+          ? { horizontal: 'medium' }
+          : undefined
+      }
       flex={false}
     >
       <Footer
         border={{ side: 'top', color: 'border' }}
         justify="end"
         pad={
-          size !== 'small'
+          !['xsmall', 'small'].includes(size)
             ? { vertical: 'medium' }
             : { vertical: 'small', horizontal: 'medium' }
         }

--- a/aries-site/src/examples/templates/wizard/components/WizardHeader.js
+++ b/aries-site/src/examples/templates/wizard/components/WizardHeader.js
@@ -27,7 +27,7 @@ export const WizardHeader = ({ setOpen }) => {
           {activeStep > 1 && (
             <Button
               label={
-                size !== 'small'
+                !['xsmall', 'small'].includes(size)
                   ? (steps[activeIndex - 1] && steps[activeIndex - 1].title) ||
                     `Step ${activeStep - 1} Title`
                   : undefined
@@ -44,7 +44,7 @@ export const WizardHeader = ({ setOpen }) => {
         </Box>
         <Box direction="row" flex justify="end">
           <Button
-            label={size !== 'small' ? 'Cancel' : undefined}
+            label={!['xsmall', 'small'].includes(size) ? 'Cancel' : undefined}
             icon={<FormClose />}
             reverse
             onClick={() => setOpen(true)}

--- a/aries-site/src/examples/templates/wizard/utils.js
+++ b/aries-site/src/examples/templates/wizard/utils.js
@@ -5,14 +5,13 @@
 export const getWidth = (numberColumns, theme, size) => {
   const inputWidth =
     parseInt(theme.global.size.medium.replace('px', ''), 10) * numberColumns;
-  const gapWidth =
-    size !== 'small'
-      ? parseInt(theme.global.edgeSize.large.replace('px', ''), 10) *
-        (numberColumns - 1)
-      : 0;
+  const gapWidth = !['xsmall', 'small'].includes(size)
+    ? parseInt(theme.global.edgeSize.large.replace('px', ''), 10) *
+      (numberColumns - 1)
+    : 0;
   const focusPad =
     2 *
-    (size === 'small'
+    (['xsmall', 'small'].includes(size)
       ? parseInt(theme.global.edgeSize.small.replace('px', ''), 10)
       : parseInt(theme.global.edgeSize.xxsmall.replace('px', ''), 10));
   return `${inputWidth + gapWidth + focusPad}px`;

--- a/aries-site/src/layouts/content/Example/BestPracticeGroup.js
+++ b/aries-site/src/layouts/content/Example/BestPracticeGroup.js
@@ -5,14 +5,14 @@ export const BestPracticeGroup = ({ ...rest }) => {
   const size = useContext(ResponsiveContext);
   let column;
   // on small and medium layout we want to use auto
-  if (size !== 'medium' && size !== 'small') {
+  if (size !== 'medium' && !['xsmall', 'small'].includes(size)) {
     column = ['1/2', '1/2'];
   } else column = 'auto';
 
   return (
     <Grid
       columns={column}
-      gap={size !== 'small' ? 'large' : 'none'}
+      gap={!['xsmall', 'small'].includes(size) ? 'large' : 'none'}
       {...rest}
     />
   );

--- a/aries-site/src/layouts/content/Example/DoDontContainer.js
+++ b/aries-site/src/layouts/content/Example/DoDontContainer.js
@@ -44,7 +44,10 @@ export const DoDontContainer = ({
 
   return (
     <>
-      <Container height={size !== 'small' ? height : undefined} {...rest} />
+      <Container
+        height={!['xsmall', 'small'].includes(size) ? height : undefined}
+        {...rest}
+      />
       {bestPractice}
     </>
   );

--- a/aries-site/src/layouts/content/Example/ExampleControls.js
+++ b/aries-site/src/layouts/content/Example/ExampleControls.js
@@ -22,7 +22,7 @@ export const ExampleControls = ({
   showResponsiveControls,
 }) => {
   const size = useContext(ResponsiveContext);
-  const isSmall = size === 'small';
+  const isSmall = ['xsmall', 'small'].includes(size);
   const buttonSize = isSmall ? 'small' : undefined;
   const fullscreenControl = !(horizontalLayout || showResponsiveControls);
 

--- a/aries-site/src/layouts/content/Example/HorizontalExample.js
+++ b/aries-site/src/layouts/content/Example/HorizontalExample.js
@@ -21,9 +21,18 @@ export const HorizontalExample = ({
         // responsiveControls to align with code block to its right
         margin={
           plain && showResponsiveControls
-            ? { top: 'xsmall', bottom: size !== 'small' ? 'medium' : undefined }
+            ? {
+                top: 'xsmall',
+                bottom: !['xsmall', 'small'].includes(size)
+                  ? 'medium'
+                  : undefined,
+              }
             : // on small screens, gap from outer box handles spacing
-              { bottom: size !== 'small' ? 'medium' : undefined }
+              {
+                bottom: !['xsmall', 'small'].includes(size)
+                  ? 'medium'
+                  : undefined,
+              }
         }
         width={width}
       >

--- a/aries-site/src/layouts/content/Example/ResponsiveContainer.js
+++ b/aries-site/src/layouts/content/Example/ResponsiveContainer.js
@@ -16,10 +16,10 @@ export const ResponsiveContainer = forwardRef(
         fill
       >
         <Box
-          height={size === 'small' ? 'large' : '100%'}
+          height={['xsmall', 'small'].includes(size) ? 'large' : '100%'}
           {...rest}
           ref={ref}
-          width={size === 'small' ? 'medium' : '100%'}
+          width={['xsmall', 'small'].includes(size) ? 'medium' : '100%'}
         />
       </Box>
     );

--- a/aries-site/src/layouts/content/PageIntro.js
+++ b/aries-site/src/layouts/content/PageIntro.js
@@ -7,8 +7,11 @@ export const PageIntro = ({ children, ...rest }) => {
   return (
     <Box height={{ min: 'medium' }} justify="center">
       <Grid
-        gap={size !== 'small' ? 'large' : 'medium'}
-        columns={{ count: 'fit', size: size !== 'small' ? 'medium' : 'fill' }}
+        gap={!['xsmall', 'small'].includes(size) ? 'large' : 'medium'}
+        columns={{
+          count: 'fit',
+          size: !['xsmall', 'small'].includes(size) ? 'medium' : 'fill',
+        }}
         {...rest}
       >
         {/* Empty card allows vertical space for background image to 

--- a/aries-site/src/layouts/content/UsageExample.js
+++ b/aries-site/src/layouts/content/UsageExample.js
@@ -19,7 +19,7 @@ export const UsageExample = ({ children, label, themeMode, pad, ...rest }) => {
         <Box
           direction="row"
           background={colors['background-front']}
-          pad={size === 'small' ? pad.small : pad}
+          pad={['xsmall', 'small'].includes(size) ? pad.small : pad}
           {...rest}
         >
           {children}

--- a/aries-site/src/layouts/main/Header.js
+++ b/aries-site/src/layouts/main/Header.js
@@ -19,7 +19,7 @@ const StyledHeader = ({ ...rest }) => {
     <Header
       pad={{
         vertical: 'medium',
-        horizontal: size !== 'small' ? 'xlarge' : 'large',
+        horizontal: !['xsmall', 'small'].includes(size) ? 'xlarge' : 'large',
       }}
       {...rest}
     >
@@ -27,7 +27,7 @@ const StyledHeader = ({ ...rest }) => {
         <AppIdentity brand="hpe" logo={false} title="Design System" />
       </Link>
       <Box direction="row" align="center" gap="xsmall">
-        {size !== 'small' &&
+        {!['xsmall', 'small'].includes(size) &&
           navItems.map(item => (
             <Link key={item.name} href={nameToPath(item.name)} passHref>
               <Button

--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -24,7 +24,7 @@ import { Config } from '../../../config';
 import { getRelatedContent, getPageDetails } from '../../utils';
 
 const calcPad = size => {
-  const val = size !== 'small' ? 'xlarge' : 'large';
+  const val = !['xsmall', 'small'].includes(size) ? 'xlarge' : 'large';
   return val;
 };
 

--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -225,7 +225,7 @@ export const Search = ({ setOpen }) => {
 
   return (
     <Layer
-      margin={size !== 'small' ? { top: 'medium' } : 'none'}
+      margin={!['xsmall', 'small'].includes(size) ? { top: 'medium' } : 'none'}
       onEsc={onClose}
       onClickOutside={onClose}
       position="top"

--- a/aries-site/src/layouts/navigation/SearchResults.js
+++ b/aries-site/src/layouts/navigation/SearchResults.js
@@ -103,7 +103,7 @@ export const SearchResults = ({
             placeholder="Search the HPE Design System"
             value={query}
             onChange={onChange}
-            size={size !== 'small' ? 'xlarge' : 'medium'}
+            size={!['xsmall', 'small'].includes(size) ? 'xlarge' : 'medium'}
           />
         </Keyboard>
       </Box>
@@ -125,12 +125,14 @@ export const SearchResults = ({
             >
               <Text
                 color="text-strong"
-                size={size !== 'small' ? 'xlarge' : 'large'}
+                size={!['xsmall', 'small'].includes(size) ? 'xlarge' : 'large'}
                 weight="bold"
               >
                 Similar to '{query}'
               </Text>
-              <Text size={size !== 'small' ? 'large' : 'medium'}>
+              <Text
+                size={!['xsmall', 'small'].includes(size) ? 'large' : 'medium'}
+              >
                 You may also be interested in this related content:
               </Text>
             </Box>
@@ -158,7 +160,7 @@ export const SearchResults = ({
         )}
       </Box>
       <Pagination
-        alignSelf={size === 'small' ? 'center' : 'end'}
+        alignSelf={['xsmall', 'small'].includes(size) ? 'center' : 'end'}
         numberItems={results.length}
         page={Math.floor(page.end / step)}
         onChange={({ startIndex, endIndex }) => {

--- a/aries-site/src/pages/404.js
+++ b/aries-site/src/pages/404.js
@@ -46,14 +46,16 @@ const Message = () => (
 const Custom404 = () => {
   const size = useContext(ResponsiveContext);
 
-  const first = size !== 'small' ? <Message /> : <Visual />;
-  const second = size !== 'small' ? <Visual /> : <Message />;
+  const first = !['xsmall', 'small'].includes(size) ? <Message /> : <Visual />;
+  const second = !['xsmall', 'small'].includes(size) ? <Visual /> : <Message />;
 
   return (
     <Layout title={title} isLanding>
       <Meta title={title} />
       <Grid
-        columns={size !== 'small' ? ['medium', 'auto'] : '100%'}
+        columns={
+          !['xsmall', 'small'].includes(size) ? ['medium', 'auto'] : '100%'
+        }
         gap="large"
         pad={{ top: 'large' }}
         fill

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -28,7 +28,7 @@ const title = 'Home';
 const pageDetails = getPageDetails(title);
 
 const calcPad = size => {
-  const val = size !== 'small' ? 'xlarge' : 'large';
+  const val = !['xsmall', 'small'].includes(size) ? 'xlarge' : 'large';
   return val;
 };
 
@@ -37,7 +37,7 @@ const widthProps = { width: { max: 'xxlarge' }, margin: 'auto' };
 
 const Intro = ({ children }) => {
   const size = useContext(ResponsiveContext);
-  return size === 'small' ? (
+  return ['xsmall', 'small'].includes(size) ? (
     <Box>
       <Hero height={{ max: '292px' }} margin={{ bottom: '-24px' }} />
       <Card background="none" elevation="none">
@@ -60,12 +60,14 @@ const Intro = ({ children }) => {
       <Box height={{ min: 'medium' }} justify="center" {...widthProps}>
         <Grid
           gap="large"
-          columns={size === 'small' ? ['auto'] : ['3/4', 'auto']}
+          columns={
+            ['xsmall', 'small'].includes(size) ? ['auto'] : ['3/4', 'auto']
+          }
         >
           <Card background="none" elevation="none">
             {children}
           </Card>
-          {size !== 'small' && (
+          {!['xsmall', 'small'].includes(size) && (
             <Card background="none" elevation="none" height="small" />
           )}
         </Grid>
@@ -94,8 +96,8 @@ const Index = () => {
               Design, develop and deliver
             </Heading>
             <Paragraph size="xlarge">
-              Empower designers and developers to quickly create
-              accessible enterprise app experiences
+              Empower designers and developers to quickly create accessible
+              enterprise app experiences
             </Paragraph>
           </Box>
         </Intro>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2371--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

We are moving towards supporting an `xsmall` breakpoint. This is a breaking change in the theme and requires instances where people are using `small` as a breakpoint to shift to mobile designs to change to check for `xsmall` and `small`. This PR contains the changes needed for the DS site.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1794
Related to https://hpe.slack.com/archives/C04LMJWQT/p1645007683789829

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes.