### PR TITLE
Fix breakpoint names in docs

### DIFF
--- a/aries-site/src/pages/templates/content-layouts.mdx
+++ b/aries-site/src/pages/templates/content-layouts.mdx
@@ -37,11 +37,11 @@ See the table below for breakpoints defined by the HPE Design System. Keep in mi
 
 | T-shirt Size   | Range         |  Margin (pixels) |
 | -------------- | ----------    | -----------------:
-| **xxsmall**    | 576 and below |      12
-| **xsmall**     | 577 - 768     |      24
-| **small**      | 769 - 1080    |      24
-| **medium**     | 1081 - 1439   |      48
-| **large**      | 1440 and above|      48
+| **xsmall**    | 576 and below |      12
+| **small**     | 577 - 768     |      24
+| **medium**      | 769 - 1080    |      24
+| **large**     | 1081 - 1439   |      48
+| **xlarge**      | 1440 and above|      48
 
 #### Page Margin
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Our breakpoints are xsmall - xlarge -- adjusting docs to match.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
Yes.