### PR TITLE
fix layer modal to match figma

### DIFF
--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -1,5 +1,13 @@
 import React, { useContext, useState } from 'react';
-import { Button, Box, Layer, Heading, ResponsiveContext, Text } from 'grommet';
+import {
+  Button,
+  Box,
+  Layer,
+  Heading,
+  ResponsiveContext,
+  Text,
+  Paragraph,
+} from 'grommet';
 import { Alert, MailOption, FormClose } from 'grommet-icons';
 
 export const LayerCenterExample = () => {
@@ -25,7 +33,7 @@ export const LayerCenterExample = () => {
                 <Box justify="center">
                   <MailOption />
                 </Box>
-                <Heading margin="none" level={2}>
+                <Heading margin="none" level={4}>
                   Modal Dialog
                 </Heading>
               </Box>
@@ -33,10 +41,13 @@ export const LayerCenterExample = () => {
                 <Button icon={<FormClose />} onClick={onClose} />
               </Box>
             </Box>
+            <Paragraph margin="none">A subtitle if needed</Paragraph>
             <Box overflow="auto" pad={{ vertical: 'medium' }}>
               <Text>
-                For modal dialogs, the use case will determine the design and
-                size of the box for your content
+                The width of this modal dialog is 384px with 12px corner radius.
+                The box component has 24px padding. For modal dialogs, the use
+                case will determine the design and size of the box for your
+                content.
               </Text>
             </Box>
           </Box>

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -33,7 +33,7 @@ export const LayerCenterExample = () => {
                 <Box justify="center">
                   <MailOption />
                 </Box>
-                <Heading margin="none" level={4}>
+                <Heading margin="none" size="small" level={2}>
                   Modal Dialog
                 </Heading>
               </Box>
@@ -44,10 +44,10 @@ export const LayerCenterExample = () => {
             <Paragraph margin="none">A subtitle if needed</Paragraph>
             <Box overflow="auto" pad={{ vertical: 'medium' }}>
               <Text>
-                The width of this modal dialog is 'medium' (384px) with 'small' (12px) corner radius.
-                The Box component has 'medium' (24px) padding. For modal dialogs, the use
-                case will determine the design and size of the box for your
-                content.
+                The width of this modal dialog is 'medium' (384px) with 'small'
+                (12px) corner radius. The Box component has 'medium' (24px)
+                padding. For modal dialogs, the use case will determine the
+                design and size of the box for your content.
               </Text>
             </Box>
           </Box>

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -45,7 +45,7 @@ export const LayerCenterExample = () => {
             <Box overflow="auto" pad={{ vertical: 'medium' }}>
               <Text>
                 The width of this modal dialog is 'medium' (384px) with 'small' (12px) corner radius.
-                The box component has 24px padding. For modal dialogs, the use
+                The Box component has 'medium' (24px) padding. For modal dialogs, the use
                 case will determine the design and size of the box for your
                 content.
               </Text>

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -44,7 +44,7 @@ export const LayerCenterExample = () => {
             <Paragraph margin="none">A subtitle if needed</Paragraph>
             <Box overflow="auto" pad={{ vertical: 'medium' }}>
               <Text>
-                The width of this modal dialog is 384px with 12px corner radius.
+                The width of this modal dialog is 'medium' (384px) with 'small' (12px) corner radius.
                 The box component has 24px padding. For modal dialogs, the use
                 case will determine the design and size of the box for your
                 content.

--- a/aries-site/src/examples/components/layer/LayerCenterExample.js
+++ b/aries-site/src/examples/components/layer/LayerCenterExample.js
@@ -41,14 +41,14 @@ export const LayerCenterExample = () => {
                 <Button icon={<FormClose />} onClick={onClose} />
               </Box>
             </Box>
-            <Paragraph margin="none">A subtitle if needed</Paragraph>
+            <Text>A subtitle if needed</Text>
             <Box overflow="auto" pad={{ vertical: 'medium' }}>
-              <Text>
+              <Paragraph margin="none">
                 The width of this modal dialog is 'medium' (384px) with 'small'
                 (12px) corner radius. The Box component has 'medium' (24px)
                 padding. For modal dialogs, the use case will determine the
                 design and size of the box for your content.
-              </Text>
+              </Paragraph>
             </Box>
           </Box>
           <Box


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2391--keen-mayer-a86c8b.netlify.app/components/layer?q=layer#center-modal)

#### What does this PR do?
This PR aligns the `layer` modal with Figma
#### Where should the reviewer start?
LayerCenterExample.js
#### What testing has been done on this PR?
site
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [x] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
site
#### Any background context you want to provide?
A subtitle was added as an option to the layer modal as well as the correct heading size 
#### What are the relevant issues?
closes #2332 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible