### PR TITLE
Convert horizontal example to use Grid

### DIFF
--- a/aries-site/src/layouts/content/Example/ExampleResources.js
+++ b/aries-site/src/layouts/content/Example/ExampleResources.js
@@ -57,7 +57,7 @@ export const ExampleResources = ({
 
   if (horizontalLayout && code) {
     return (
-      <Box margin="0px" height={{ max: 'medium' }} round="small" {...rest}>
+      <Box height={{ max: 'medium' }} {...rest}>
         <SyntaxHighlighter
           tabIndex="0"
           style={theme.dark ? prism.dark : prism.light}

--- a/aries-site/src/layouts/content/Example/HorizontalExample.js
+++ b/aries-site/src/layouts/content/Example/HorizontalExample.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Box, ResponsiveContext } from 'grommet';
+import { Box, Grid, ResponsiveContext } from 'grommet';
 
 export const HorizontalExample = ({
   content,
@@ -12,8 +12,19 @@ export const HorizontalExample = ({
 }) => {
   const size = useContext(ResponsiveContext);
 
+  const grid = {
+    columns: {
+      xsmall: 'auto',
+      small: 'auto',
+      medium: 'auto',
+      large: ['auto', 'flex'],
+      xlarge: ['auto', 'flex'],
+    },
+    gap: ['large', 'xlarge'].includes(size) ? 'large' : 'small',
+  };
+
   return (
-    <Box align="start" direction="row-responsive" gap="large" wrap>
+    <Grid columns={grid.columns[size]} gap={grid.gap}>
       <Box
         // let content maintain its defined width
         flex={false}
@@ -38,11 +49,11 @@ export const HorizontalExample = ({
       >
         {content}
       </Box>
-      <Box flex={false} width="large">
+      <Box width={{ min: 'medium' }}>
         {resources}
         {controls}
       </Box>
-    </Box>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2418--keen-mayer-a86c8b.netlify.app/components/card)

#### What does this PR do?

Convert HorizontalExample to use Grid.
- I'm finding that Grid gives us a bit more control over responsive behaviors than `row-responsive`. This will also allow the example to be a bit wider, but still have the code exposed.

#### Where should the reviewer start?

[Card](https://deploy-preview-2418--keen-mayer-a86c8b.netlify.app/components/card)

HorizontalExample.js

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [ ] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [x] Passes E2E commit checks
- [x] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
