### PR TITLE
Layer sideformdrawer

### DIFF
--- a/aries-site/src/examples/components/layer/LayerSideDrawerExample.js
+++ b/aries-site/src/examples/components/layer/LayerSideDrawerExample.js
@@ -43,6 +43,10 @@ const LayerForm = ({ setOpen }) => {
           label="Text Area"
           htmlFor="text-area-input"
           name="textAreaInput"
+          tabIndex={-1}
+          a11yTitle={`You are on a Text Area in a layer containing
+          a form. To close the layer 
+          and return to the primary content, press Esc.`}
         >
           <TextArea
             id="text-area-input"

--- a/aries-site/src/examples/components/layer/LayerSideDrawerExample.js
+++ b/aries-site/src/examples/components/layer/LayerSideDrawerExample.js
@@ -46,7 +46,7 @@ const LayerForm = ({ setOpen }) => {
           tabIndex={-1}
           a11yTitle={`You are on a Text Area in a layer containing
           a form. To close the layer 
-          and return to the primary content, press Esc.`}
+          and return to the primary content, press Escape.`}
         >
           <TextArea
             id="text-area-input"

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -61,7 +61,7 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 - **Page Layouts**
   - Completed dashboard template for a [3 column dashboard layout](https://design-system.hpe.design/templates/dashboards#three-column-dashboard).
 - **Page Header** - Completed research and use case gathering for Page Header and began design ideation.
-- **Banner Notification** - Completed research and use case gathering for Banner Notification and began design ideation. Implementation on Banner Notification on the Design System site to come.
+- **Banner Notification** - Completed ideation on Banner Notifications. Guidance, theme updates, and implementation examples for Banner Notifications will be coming soon.
 
 ### Stay current with the latest changes 
 - **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -66,7 +66,7 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 ### Stay current with the latest changes 
 - **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 
 - **FileInput** - Updated [FileInput examples on Design System site](https://design-system.hpe.design/components/fileinput) to align with Figma assets that adjust the button label (e.g., "Select Files" to "Select More Files") when files have already been uploaded.
-- **Menu** - Added an example of when Menu is placed in row with other toolbar controls to the [Design System site](https://design-system.hpe.design/components/menu#within-a-toolbar).
+- **Menu** - Added an example of [Menu in a toolbar](https://design-system.hpe.design/components/menu#within-a-toolbar).
 
 ### Latest Releases
 - **Grommet v2.20.1** - Release includes enhancements including (but not limited to): Notification toast position, DataChart type additions, Tag size prop, DateInput icon customization.

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -52,27 +52,6 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 
 <!-- BEGIN: What's New Entries -->
 
-## February 14 - March 4, 2022
-
-### Communications
-- **Office Hours** - We have combined our two office hours into one which will be held every Thursday, 10:00 PM IST / 8:00 AM PST. This office hours is open to all. Contact Kamlesh Thakur, if you would like a calendar invite.
-
-### Roadmap Updates 
-- **Page Layouts**
-  - Completed dashboard template for a [3 column dashboard layout](https://design-system.hpe.design/templates/dashboards#three-column-dashboard).
-- **Page Header** - Completed research and use case gathering for Page Header and began design ideation.
-- **Banner Notification** - Completed ideation on Banner Notifications. Guidance, theme updates, and implementation examples for Banner Notifications will be coming soon.
-
-### Stay current with the latest changes 
-- **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 
-- **FileInput** - Updated [FileInput examples on Design System site](https://design-system.hpe.design/components/fileinput) to align with Figma assets that adjust the button label (e.g., "Select Files" to "Select More Files") when files have already been uploaded.
-- **Menu** - Added an example of [Menu in a toolbar](https://design-system.hpe.design/components/menu#within-a-toolbar).
-
-### Latest Releases
-- **Grommet v2.20.1** - Release includes enhancements including (but not limited to): Notification toast position, DataChart type additions, Tag size prop, DateInput icon customization.
-Full details about this release are available in the [Release Notes](https://github.com/grommet/grommet/releases/tag/v2.21.0).
-
-
 ## January 24 - February 11, 2022
 
 ### HPE theme breaking change

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -52,6 +52,28 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 
 <!-- BEGIN: What's New Entries -->
 
+## February 14 - March 4, 2022
+
+### Communications
+- **Office Hours** - We have combined our two office hours into one which will be held every Thursday, 10:00 PM IST / 8:00 AM PST. This office hours is open to all. Contact Kamlesh Thakur, if you would like a calendar invite.
+
+### Roadmap Updates 
+- **Page Layouts**
+  - Added support for `xsmall` breakpoint. This is a **breaking change** in the theme and requires instances where users are using small as a breakpoint to shift to mobile designs need to change their check to `xsmall`.
+  - Completed dashboard template for a [3 column dashboard layout](https://design-system.hpe.design/templates/dashboards#three-column-dashboard).
+  - 
+- **Page Header** - Completed research and gathering use cases for PageHeader; gave a share out on PageHeader to the team and commenced ideating designs for PageHeader based off of use cases and feedback gathered.
+- **Banner Notification** -
+
+### Stay current with the latest changes 
+- **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 
+- **FileInput** - Figma calls for FileInput button label to change when files have already been uploaded this example was added to the [Design System site](https://design-system.hpe.design/components/fileinput).
+- **Menu** - Added an example of when Menu is placed in row with other toolbar controls to the [Design System site](https://design-system.hpe.design/components/menu#within-a-toolbar).
+
+### Latest Releases
+- **Grommet v2.20.1** - Release includes enhancements including (but not limited to): Notification toast position, DataChart type additions, Tag size prop, DateInput icon customization.
+Full details about this release are available in the [Release Notes](https://github.com/grommet/grommet/releases/tag/v2.21.0).
+
 
 ## January 24 - February 11, 2022
 

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -65,7 +65,7 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 
 ### Stay current with the latest changes 
 - **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 
-- **FileInput** - Figma calls for FileInput button label to change when files have already been uploaded this example was added to the [Design System site](https://design-system.hpe.design/components/fileinput).
+- **FileInput** - Updated [FileInput examples on Design System site](https://design-system.hpe.design/components/fileinput) to align with Figma assets that adjust the button label (e.g., "Select Files" to "Select More Files") when files have already been uploaded.
 - **Menu** - Added an example of when Menu is placed in row with other toolbar controls to the [Design System site](https://design-system.hpe.design/components/menu#within-a-toolbar).
 
 ### Latest Releases

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -61,9 +61,8 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 - **Page Layouts**
   - Added support for `xsmall` breakpoint. This is a **breaking change** in the theme and requires instances where users are using small as a breakpoint to shift to mobile designs need to change their check to `xsmall`.
   - Completed dashboard template for a [3 column dashboard layout](https://design-system.hpe.design/templates/dashboards#three-column-dashboard).
-  - 
 - **Page Header** - Completed research and gathering use cases for PageHeader; gave a share out on PageHeader to the team and commenced ideating designs for PageHeader based off of use cases and feedback gathered.
-- **Banner Notification** -
+- **Banner Notification** - Completed ideation, gave a share out on Banner Notification to the Design System team. Ideation on Banner Notification on the Design System site to come.
 
 ### Stay current with the latest changes 
 - **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -59,10 +59,9 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 
 ### Roadmap Updates 
 - **Page Layouts**
-  - Added support for `xsmall` breakpoint. This is a **breaking change** in the theme and requires instances where users are using small as a breakpoint to shift to mobile designs need to change their check to `xsmall`.
   - Completed dashboard template for a [3 column dashboard layout](https://design-system.hpe.design/templates/dashboards#three-column-dashboard).
-- **Page Header** - Completed research and gathering use cases for PageHeader; gave a share out on PageHeader to the team and commenced ideating designs for PageHeader based off of use cases and feedback gathered.
-- **Banner Notification** - Completed ideation, gave a share out on Banner Notification to the Design System team. Ideation on Banner Notification on the Design System site to come.
+- **Page Header** - Completed research and use case gathering for Page Header and began design ideation.
+- **Banner Notification** - Completed research and use case gathering for Banner Notification and began design ideation. Implementation on Banner Notification on the Design System site to come.
 
 ### Stay current with the latest changes 
 - **Layer** - Updated our [Layer modal example](https://design-system.hpe.design/components/layer#center-modal) on the Design-System site. 

--- a/aries-site/src/pages/whats-new.mdx
+++ b/aries-site/src/pages/whats-new.mdx
@@ -52,6 +52,7 @@ regarding either via [Slack](https://hpe.slack.com/archives/C04LMJWQT).
 
 <!-- BEGIN: What's New Entries -->
 
+
 ## January 24 - February 11, 2022
 
 ### HPE theme breaking change


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2421--keen-mayer-a86c8b.netlify.app/components/layer#side-drawer-modal)

#### What does this PR do?
Adds an a11ytitle to the first `formfield` to let the user know they are in a layer and how to return to the previous screen
Since we took out the "X" close `button` that previously handled this `a11ytitle` adding it to the first interactive element was what I found to be best practice.
#### Where should the reviewer start?
LayerSideDrawerExample.js
#### What testing has been done on this PR?
screen reader on the site
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [x] Keyboard interactions
- [x] Screen reader experience
- [x] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [x] Console is free of warnings and errors
- [x] Passes E2E commit checks
- [x] Visual snapshots are reasonable

#### How should this be manually tested?
screen reader 
#### Any background context you want to provide?
Since the "X" close button was replaced with the `cancel` button at the bottom we do not want the focus to be on the `close` button anymore since it was moved after the form this would cause confusion for the user. I looked at 2 different approaches with adding a focus on the `header` to let the screen reader know they are on a header in a `layer` however it is not best practice to put a focus on a non-interactive element. I changed the focus to be on the first `formfield` in the `layer` however this is just a work around since this may get lost in other teams implementing I believe that Grommet should have the capabilities to let a user know when they are in a `layer` and how to exit using the `esc` button. I added a issue to Grommet to enhance the `layer` accessibility.
https://github.com/grommet/grommet/issues/5976
#### What are the relevant issues?
closes #2333 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
