### PR TITLE
Fix mobile width for example presentation

### DIFF
--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -176,7 +176,7 @@ export const Example = ({
             : undefined
         }
         screen={screen}
-        width={width}
+        width={screen === screens.mobile ? 'medium' : width}
         ref={inlineRef}
       >
         {/* prevent theme from overriding the desired background color */}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2447--keen-mayer-a86c8b.netlify.app/templates/dashboards)

#### What does this PR do?

When clicking "Mobile" on example presentations, the width was not being restricted to "medium" -- this fixes that.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
