### PR TITLE
Add onEnter tags

### DIFF
--- a/aries-site/src/examples/components/tag/CreateTag/CreateTag.js
+++ b/aries-site/src/examples/components/tag/CreateTag/CreateTag.js
@@ -22,7 +22,6 @@ import {
   TagResults,
   updateCreateOption,
 } from '.';
-import { zipObjectDeep } from 'lodash';
 
 const defaultNameOptions = [];
 const defaultValueOptions = [];

--- a/aries-site/src/examples/components/tag/CreateTagSimple.js
+++ b/aries-site/src/examples/components/tag/CreateTagSimple.js
@@ -56,8 +56,6 @@ export const CreateTagSimple = () => {
     }
   };
 
-  console.log(open, valueSearch);
-
   return (
     <TagAppContainer>
       <TagPageHeader

--- a/aries-site/src/examples/components/tag/CreateTagSimple.js
+++ b/aries-site/src/examples/components/tag/CreateTagSimple.js
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Grid,
+  Keyboard,
   Form,
   FormField,
   Select,
@@ -40,9 +41,22 @@ export const CreateTagSimple = () => {
   );
   const [value, setValue] = useState(defaultValue);
   const [valueSearch, setValueSearch] = useState('');
+  const [open, setOpen] = useState('');
 
   // tags
   const [currentTags, setCurrentTags] = useState(defaultTags);
+  const onEnter = () => {
+    if (valueSearch.length) {
+      defaultValueOptions.pop(); // remove create options
+      defaultValueOptions.push(valueSearch);
+      setValueOptions(alphabetize(defaultValueOptions));
+      setValue(valueSearch);
+      setOpen(false);
+      setValueSearch('');
+    }
+  };
+
+  console.log(open, valueSearch);
 
   return (
     <TagAppContainer>
@@ -72,33 +86,36 @@ export const CreateTagSimple = () => {
             label="Tags"
             required={{ indicator: false }}
           >
-            <Select
-              name="tag-value-simple"
-              id="tag-value-simple"
-              placeholder="Select or create a tag"
-              value={value}
-              options={valueOptions}
-              onChange={({ option }) => {
-                if (option.includes(prefix)) {
-                  defaultValueOptions.pop(); // remove Create option
-                  defaultValueOptions.push(valueSearch);
-                  setValueOptions(alphabetize(defaultValueOptions));
-                  setValue(valueSearch);
-                } else {
-                  setValue(option);
-                }
-              }}
-              onSearch={text => {
-                const nextValueOptions = defaultValueOptions;
-                updateCreateOption(text, nextValueOptions);
-                const exp = getRegExp(text);
-                setValueOptions(
-                  alphabetize(nextValueOptions.filter(o => exp.test(o))),
-                );
-                setValueSearch(text);
-              }}
-              searchPlaceholder="Search tags"
-            />
+            <Keyboard onEnter={onEnter}>
+              <Select
+                name="tag-value-simple"
+                id="tag-value-simple"
+                placeholder="Select or create a tag"
+                value={value}
+                open={open}
+                options={valueOptions}
+                onChange={({ option }) => {
+                  if (option.includes(prefix)) {
+                    defaultValueOptions.pop(); // remove Create option
+                    defaultValueOptions.push(valueSearch);
+                    setValueOptions(alphabetize(defaultValueOptions));
+                    setValue(valueSearch);
+                  } else {
+                    setValue(option);
+                  }
+                }}
+                onSearch={text => {
+                  const nextValueOptions = defaultValueOptions;
+                  updateCreateOption(text, nextValueOptions);
+                  const exp = getRegExp(text);
+                  setValueOptions(
+                    alphabetize(nextValueOptions.filter(o => exp.test(o))),
+                  );
+                  setValueSearch(text);
+                }}
+                searchPlaceholder="Search tags"
+              />
+            </Keyboard>
           </FormField>
           <Box
             justify="start"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR uses `Keyboard` to wrap `select` to allow the user to press enter to create a Tag
#### Where should the reviewer start?
CreateTag.js
#### What testing has been done on this PR?
site
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
keyboard creating a tag on both examples 
#### Any background context you want to provide?

#### What are the relevant issues?
closes #2268 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible