### PR TITLE
column selector move next to search

### DIFF
--- a/aries-site/src/examples/templates/FilterControls/FilterControls.js
+++ b/aries-site/src/examples/templates/FilterControls/FilterControls.js
@@ -1,11 +1,13 @@
 import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Box, ResponsiveContext } from 'grommet';
+import { Box, Button, ResponsiveContext } from 'grommet';
+import { Splits } from 'grommet-icons';
 
 import { Filters, ResultsSummary, SearchFilter, useFilters } from '.';
 
 export const FilterControls = ({
   actions,
+  configure,
   data,
   filters,
   layerProps,
@@ -62,6 +64,7 @@ export const FilterControls = ({
             <SearchFilter placeholder={searchFilter.placeholder} />
           )}
           <Filters />
+          {configure}
         </Box>
         {actions}
       </Box>
@@ -72,6 +75,7 @@ export const FilterControls = ({
 
 FilterControls.propTypes = {
   actions: PropTypes.element,
+  configure: PropTypes.element,
   data: PropTypes.array,
   filters: PropTypes.arrayOf(
     PropTypes.shape({

--- a/aries-site/src/examples/templates/FilterControls/FilterControls.js
+++ b/aries-site/src/examples/templates/FilterControls/FilterControls.js
@@ -1,7 +1,6 @@
 import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Button, ResponsiveContext } from 'grommet';
-import { Splits } from 'grommet-icons';
+import { Box, ResponsiveContext } from 'grommet';
 
 import { Filters, ResultsSummary, SearchFilter, useFilters } from '.';
 
@@ -63,8 +62,8 @@ export const FilterControls = ({
           {searchFilter && (
             <SearchFilter placeholder={searchFilter.placeholder} />
           )}
-          <Filters />
           {configure}
+          <Filters />
         </Box>
         {actions}
       </Box>

--- a/aries-site/src/examples/templates/filtering/FilteringTable/FilterServers.js
+++ b/aries-site/src/examples/templates/filtering/FilteringTable/FilterServers.js
@@ -2,11 +2,11 @@ import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, DataTable, ResponsiveContext, Text } from 'grommet';
 import {
-  Splits,
   StatusWarningSmall,
   StatusCriticalSmall,
   StatusGoodSmall,
   StatusUnknownSmall,
+  Splits,
 } from 'grommet-icons';
 
 import {
@@ -50,12 +50,8 @@ export const FilterServers = ({ bestPractice = true }) => (
         filters={filtersConfig}
         primaryKey="id"
         searchFilter={{ placeholder: 'Search' }}
-        actions={
-          <Box direction="row" gap="small">
-            <Button icon={<Splits />} kind="toolbar" tip="Configure columns" />
-            {bestPractice && <Button label="Add Server" secondary />}
-          </Box>
-        }
+        configure={<Button icon={<Splits />} kind="toolbar" tip="Configure columns" />}
+        actions={bestPractice && <Button label="Add Server" secondary />}
       />
       <ServerResults />
     </Box>

--- a/aries-site/src/examples/templates/table-customization/components/TableCustomizationExample.js
+++ b/aries-site/src/examples/templates/table-customization/components/TableCustomizationExample.js
@@ -117,13 +117,7 @@ export const TableCustomizationExample = () => {
                     // becomes confusing what the "Clear filters" button will
                     // do with regards to any column configurations that have
                     // been applied.
-                    actions={
-                      <Box
-                        direction="row"
-                        align="start"
-                        gap="small"
-                        flex={false}
-                      >
+                    configure={
                         <DropButton
                           a11yTitle="Configure columns button"
                           icon={<Splits />}
@@ -141,9 +135,8 @@ export const TableCustomizationExample = () => {
                           }
                           tip="Configure columns"
                         />
-                        <Menu kind="toolbar" label="Actions" items={[]} />
-                      </Box>
                     }
+                    actions={<Menu kind="toolbar" label="Actions" items={[]} />}
                     data={allData}
                     filters={filtersConfig}
                     searchFilter={{ placeholder: 'Search' }}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2729--keen-mayer-a86c8b.netlify.app/templates/filtering#filtering-with-selectable-results)

#### What does this PR do?
This PR  Updates the filtering / datatable examples so that the "column selector" control is placed alongside the search and filter as opposed to inline with the "action" buttons
#### Where should the reviewer start?
filterControls.js
#### What testing has been done on this PR?
site
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [x] Small, medium, and large screen sizes
- [x] Cross-browsers (FireFox, Chrome, and Safari)
- [x] Light & dark modes
- [x] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [x] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
site
#### Any background context you want to provide?
This is related to having a data collection toolbar composed with:

View/presentation controls (presentation only, does not manipulate underlying data)
Action controls (change data and/or apply actions against)
Results Summary
Results section

#### What are the relevant issues?
closes #2717 
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 