### PR TITLE
Feedback submit option

### DIFF
--- a/aries-site/src/components/feedback/Feedback.js
+++ b/aries-site/src/components/feedback/Feedback.js
@@ -19,8 +19,7 @@ export const Feedback = ({
   value,
 }) => {
   const theme = useContext(ThemeContext);
-
-  console.log(messages);
+  
   let content = (
     <Box {...theme?.feedback?.container}>
       <FeedbackHeader title={title}>

--- a/aries-site/src/components/feedback/Feedback.js
+++ b/aries-site/src/components/feedback/Feedback.js
@@ -6,8 +6,8 @@ import { FormClose } from 'grommet-icons';
 
 export const Feedback = ({
   children,
-  footerActions,
   layerProps,
+  messages,
   modal,
   onChange,
   onClose,
@@ -20,10 +20,9 @@ export const Feedback = ({
 }) => {
   const theme = useContext(ThemeContext);
 
+  console.log(messages);
   let content = (
-    <Box
-      {...theme?.feedback?.container}
-    >
+    <Box {...theme?.feedback?.container}>
       <FeedbackHeader title={title}>
         {modal && (
           <Button
@@ -45,7 +44,16 @@ export const Feedback = ({
       >
         <Box {...theme?.feedback?.body}>
           <>{children}</>
-          <Box {...theme?.feedback?.footer}>{footerActions}</Box>
+          <Box {...theme?.feedback?.footer}>
+            {/* how would we decide which order? offer reverse prop? */}
+            {/* what about passing in other button props? primary icon? */}
+            {messages && (
+              <>
+                <Button label={messages?.submit || 'Submit'} type="submit" />
+                <Button label={messages?.cancel || 'Cancel'} />
+              </>
+            )}
+          </Box>
         </Box>
       </Form>
     </Box>
@@ -53,11 +61,7 @@ export const Feedback = ({
 
   if (modal)
     content = show && (
-      <Layer
-        modal={false}
-        onEsc={onEsc}
-        {...layerProps}
-      >
+      <Layer modal={false} onEsc={onEsc} {...layerProps}>
         {content}
       </Layer>
     );

--- a/aries-site/src/components/feedback/Question.js
+++ b/aries-site/src/components/feedback/Question.js
@@ -28,7 +28,7 @@ export const Question = ({ label, inputProps, kind, name }) => {
   return (
     <FormField
       contentProps={{
-        border: kind === 'star' || kind === 'thumbs' ? falses : 'undefined',
+        border: kind === 'star' || kind === 'thumbs' ? false : 'undefined',
       }}
       label={
         kind === 'star' || kind === 'thumbs' ? <Text>{label}</Text> : label

--- a/aries-site/src/layouts/main/Layout.js
+++ b/aries-site/src/layouts/main/Layout.js
@@ -192,6 +192,14 @@ export const Layout = ({
               onEsc={onClose}
               onClose={onClose}
               show={open}
+              messages={
+                !isSucessful
+                  ? {
+                      submit: 'Submit feedback',
+                      cancel: 'No thanks',
+                    }
+                  : undefined
+              }
               modal
               title="We’d love your feedback"
               onChange={nextValue => setValue(nextValue)}
@@ -203,24 +211,6 @@ export const Layout = ({
                   : 'center',
                 margin: { vertical: 'xlarge', horizontal: 'medium' },
               }}
-              footerActions={
-                <>
-                  {!isSucessful ? (
-                    <Box direction="row" gap="small">
-                      <Button
-                        onClick={onClose}
-                        label="Cancel"
-                        a11yTitle="Cancel feedback submission"
-                      />
-                      <Button label="Submit" primary type="submit" />
-                    </Box>
-                  ) : (
-                    <Text alignSelf="end" weight="bold">
-                      Thank You!
-                    </Text>
-                  )}
-                </>
-              }
             >
               <Question
                 label={`What this ${title} guidance helpful to you?`}


### PR DESCRIPTION
This is another approach @taysea brought up to how we can handle the submit `buttons` for the user. In the other PR I have a prop `footerActions` in which the user can decide how the button for the submit are placed and how they want to use them.

This PR offers that we have a submit button in the component render by default. This way the user can pass if they want a `cancel` button or only a submit button. now the order not sure if they would be able to change that? someone may want `submit` on the right where someone else may want it on the left. This also brings up if `onSubmit` is required to send the data to an API then will the submit be required? 
