### PR TITLE
Add text-xweak to color page

### DIFF
--- a/aries-site/src/data/color.js
+++ b/aries-site/src/data/color.js
@@ -308,6 +308,11 @@ const textColors = [
     value: 'text-weak',
     hex: colors['text-weak'],
   },
+  {
+    name: 'text-xweak',
+    value: 'text-xweak',
+    hex: colors['text-xweak'],
+  },
 ];
 
 const statusColorsLight = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4933,9 +4933,9 @@ can-use-dom@^0.1.0:
   integrity sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ==
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001400:
-  version "1.0.30001420"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz#f62f35f051e0b6d25532cf376776d41e45b47ef6"
-  integrity sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==
+  version "1.0.30001421"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001421.tgz#979993aaacff5ab72a8d0d58c28ddbcb7b4deba6"
+  integrity sha512-Sw4eLbgUJAEhjLs1Fa+mk45sidp1wRn5y6GtDpHGBaNJ9OCDJaVh2tIaWWUnGfuXfKf1JCBaIarak3FkVAvEeA==
 
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.4.0"
@@ -7999,7 +7999,7 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.27.0"
-  resolved "https://github.com/grommet/grommet/tarball/stable#0c0e2c31fae208a094d0b66d3a6c4f8ee7e5ac74"
+  resolved "https://github.com/grommet/grommet/tarball/stable#63938630a10a3437f5ba34d724fb95f2cde6de50"
   dependencies:
     grommet-icons "^4.8.0"
     hoist-non-react-statics "^3.2.0"
@@ -14237,9 +14237,9 @@ testcafe-hammerhead@24.7.2:
     webauth "^1.1.0"
 
 testcafe-hammerhead@>=19.4.0:
-  version "26.0.1"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-26.0.1.tgz#5863020188940a7c9b6a8a739f143c037cb93503"
-  integrity sha512-OUTUOxaupe5tA1A9k8w2T5hHnZ2T5jT727+jDJy9Udlmx12zmhYvwsDpXEQAGoaptzPDARd3rcW6uFeHs3vsUg==
+  version "26.0.2"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-26.0.2.tgz#2d9d0c0cb7410dca82fa393d64a74446f4833dd8"
+  integrity sha512-+iqgwl2bYPeVTjbH0o+tFcw3Qtob7n+Yc4aUNZUlzKbDWoP41U4eWuqOToPo6Pww0JTGUkaft4R02TRGofUHOg==
   dependencies:
     acorn-hammerhead "0.6.1"
     asar "^2.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-2978--keen-mayer-a86c8b.netlify.app/foundation/color#text-color-palette)

#### What does this PR do?

Add `text-xweak` to color page, was missing from this page even though it's been in the theme.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
