### PR TITLE
Improve keyboard autoclose behavior for managing child objects

### DIFF
--- a/aries-site/src/examples/templates/FormChildObject/FormChildObjects.js
+++ b/aries-site/src/examples/templates/FormChildObject/FormChildObjects.js
@@ -1,7 +1,10 @@
+import { createContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button } from 'grommet';
 import { ButtonGroup } from '../ButtonGroup';
 import { FormChildObject } from './FormChildObject';
+
+export const FormChildObjectsContext = createContext({});
 
 export const FormChildObjects = ({
   collection,
@@ -10,57 +13,73 @@ export const FormChildObjects = ({
   onAdd,
   onRemove,
   onRemoveAll,
-  primaryKey,
   required,
   summarize,
   values,
-}) => (
-  <Box>
-    {values?.length
-      ? values.map((obj, index) => (
-          <FormChildObject
-            key={index}
-            collectionName={collection.itemName}
-            index={index}
-            headingLevel={headingLevel}
-            name={obj.name}
-            // keep at least one child when child objects are required by parent
-            onRemove={required && values.length <= 1 ? null : onRemove}
-            open={obj[primaryKey] === ''}
-            summarize={summarize}
-            values={obj}
-          >
-            {Object.entries(obj).map(([key, value]) =>
-              fields[key]({ key, value, index }),
-            )}
-          </FormChildObject>
-        ))
-      : null}
-    <ButtonGroup
-      justify="end"
-      border={{ side: 'top', color: 'border-weak' }}
-      pad={{ top: 'small' }}
-    >
-      {/* keep at least one child when child objects are required by parent */}
-      {values?.length >= 2 && !required && (
-        <Button
-          label="Remove all"
-          // Move into messages map
-          aria-label={`Remove all ${collection.name}`}
-          onClick={onRemoveAll}
-        />
-      )}
-      <Button
-        // Move into messages map
-        label={`Add ${collection.itemName}`}
-        // Move into messages map
-        a11yTitle={`Add ${collection.itemName} to ${collection.parentName}`}
-        secondary
-        onClick={onAdd}
-      />
-    </ButtonGroup>
-  </Box>
-);
+}) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(Math.max(values.length - 1, 0));
+  }, [values.length]);
+
+  const contextValue = useMemo(
+    () => ({ activeIndex, setActiveIndex }),
+    [activeIndex],
+  );
+
+  return (
+    <FormChildObjectsContext.Provider value={contextValue}>
+      <Box>
+        {values?.length
+          ? values.map((obj, index) => (
+              <FormChildObject
+                key={index}
+                collectionName={collection.itemName}
+                index={index}
+                headingLevel={headingLevel}
+                name={obj.name}
+                // keep at least one child when child objects are
+                // required by parent
+                onRemove={required && values.length <= 1 ? null : onRemove}
+                open={activeIndex === index}
+                summarize={summarize}
+                values={obj}
+              >
+                {Object.entries(obj).map(([key, value]) =>
+                  fields[key]({ key, value, index }),
+                )}
+              </FormChildObject>
+            ))
+          : null}
+        <ButtonGroup
+          justify="end"
+          border={{ side: 'top', color: 'border-weak' }}
+          pad={{ top: 'small' }}
+        >
+          {/* keep at least one child when child 
+        objects are required by parent */}
+          {values?.length >= 2 && !required && (
+            <Button
+              label="Remove all"
+              // Move into messages map
+              aria-label={`Remove all ${collection.name}`}
+              onClick={onRemoveAll}
+            />
+          )}
+          <Button
+            // Move into messages map
+            label={`Add ${collection.itemName}`}
+            // Move into messages map
+            a11yTitle={`Add ${collection.itemName} to ${collection.parentName}`}
+            secondary
+            onClick={onAdd}
+          />
+        </ButtonGroup>
+      </Box>
+    </FormChildObjectsContext.Provider>
+  );
+};
 
 FormChildObjects.propTypes = {
   collection: PropTypes.shape({
@@ -76,7 +95,6 @@ FormChildObjects.propTypes = {
   onAdd: PropTypes.func,
   onRemove: PropTypes.func,
   onRemoveAll: PropTypes.func,
-  primaryKey: PropTypes.string,
   required: PropTypes.bool,
   summarize: PropTypes.arrayOf(PropTypes.string),
   values: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8008,7 +8008,7 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.28.0"
-  resolved "https://github.com/grommet/grommet/tarball/stable#1018684eee8ff55e0c7f3cf2c89f4995badf604f"
+  resolved "https://github.com/grommet/grommet/tarball/stable#78925a7813e35b3eedb080c1618be8b0a52a5d4a"
   dependencies:
     grommet-icons "^4.8.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-3060--keen-mayer-a86c8b.netlify.app/templates/forms/mangaging-child-objects)

#### What does this PR do?

This PR improves the collapsible behavior for mouse and keyboard of child objects. The desired behavior is:
- one child should be open at a time
- clicking on another child object should close the current one
- tabbing outside of the current child object should close the current one

The functionality for sensing if tab focus has moved to a drop component like Select departs a little from our general patterns, but I couldn't think of another way to achieve it at the moment. Suggestions welcome.

#### Where should the reviewer start?
aries-site/src/examples/templates/FormChildObject/FormChildObjects.js

#### What testing has been done on this PR?

Keyboard tab behavior (notice how child object stays open when tab moves into select):
https://user-images.githubusercontent.com/12522275/208748130-3fb5e799-8128-4746-b1b6-c134330c0cb9.mov

Mouse behavior:
https://user-images.githubusercontent.com/12522275/208748391-625f14ae-9712-4f28-b3e4-b8365eba179f.mov

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
