### PR TITLE
Add backdrop-filter to layer overlay and align DataTable pinned

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -240,6 +240,8 @@ export const aries = deepMerge(hpe, {
     overlay: {
       background: '#0000001F',
     },
+    // temp CSS selector to target Layer overlay
+    extend: '> div { backdrop-filter: blur(12px); }',
   },
   calendar: {
     // using level as a means of styling doesn't seem like the best...

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -205,6 +205,17 @@ export const aries = deepMerge(hpe, {
       weight: 400,
       color: 'text-strong',
     },
+    pinned: {
+      header: {
+        extend: 'backdrop-filter: blur(12px);',
+      },
+      body: {
+        extend: 'backdrop-filter: blur(12px);',
+      },
+      footer: {
+        extend: 'backdrop-filter: blur(12px);',
+      },
+    },
   },
   heading: {
     color: 'text-strong',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Adds blur to layer overlay for "modal" layers.

modal={true}
<img width="1577" alt="Screen Shot 2023-01-27 at 12 59 25 PM" src="https://user-images.githubusercontent.com/12522275/215196804-098115e7-e5a9-4e41-8793-611b46f3a55d.png">

modal={false)
<img width="1596" alt="Screen Shot 2023-01-27 at 12 59 14 PM" src="https://user-images.githubusercontent.com/12522275/215196820-2297c068-7a5b-4cbc-a217-35fab01d1d34.png">



#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
