### PR TITLE
Update datatable-customization.mdx

### DIFF
--- a/aries-site/src/pages/templates/datatable-customization.mdx
+++ b/aries-site/src/pages/templates/datatable-customization.mdx
@@ -28,18 +28,17 @@ which columns should appear in the DataTable and another for ordering the column
 
 ## Anatomy of a customizable DataTable
 
-### An action to display column visibility and order controls
+### An action to manage column visibility and order controls
 
-Place a button with an `Edit` icon next to the `Actions` menu for the data table on the
-right side above the data table. The `Actions` menu is mainly for actions which modify
-items in the data table. Controls like the search and filter controls change what items
-are shown in the data table or how they are presented rather than changing the items
-themselves. Since we want to customize the data table itself, we have separate controls
-for changing which columns are shown in the data table and their order.
+Since we want to customize the data table itself, we have separate controls for changing
+which columns are shown in the data table and their order. Place a button with a `Manage Columns`
+icon next to the search and filter controls on the left. These view controls change what items
+are shown in the data table or how they are presented rather than changing the items themselves.
+The right aligned `Actions` menu is mainly for actions which modify items in the data table.
 
 ### Column visibility
 
-Clicking on the `Edit` button opens a dropdown which has two tabs. The first tab should
+Clicking on the `Manage Columns` button opens a dropdown which has two tabs. The first tab should
 be active and labeled "Select columns." The tab content should consist of a Search input
 and a CheckBoxGroup that lists all possible table columns.
 


### PR DESCRIPTION
DS Site: DataTable Customization Guidance Update

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

- Update the guidance to reflect the correct location of the column select/order control in the datatable toolbar.
- Update the datatable example to use tooltips in the toolbar

#### Where should the reviewer start?
https://github.com/grommet/hpe-design-system/issues/3260
#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
