### PR TITLE
Update datatable-customization.mdx

### DIFF
--- a/aries-site/src/pages/templates/datatable-customization.mdx
+++ b/aries-site/src/pages/templates/datatable-customization.mdx
@@ -32,7 +32,7 @@ which columns should appear in the DataTable and another for ordering the column
 
 Since we want to customize the data table itself, we have separate controls for changing
 which columns are shown in the data table and their order. Place a button with a `Manage Columns`
-icon next to the search and filter controls on the left. These view controls change what items
+icon between the search and filter controls on the left. These view controls change what items
 are shown in the data table or how they are presented rather than changing the items themselves.
 The right aligned `Actions` menu is mainly for actions which modify items in the data table.
 


### PR DESCRIPTION
Slight change, missed adding the right word describing the location of the button, it should be 'between' the search and filter control on the left.  The previous makes it seem like it goes to the left of the search bar.

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
