### PR TITLE
scale checkbox label in examples

### DIFF
--- a/aries-site/src/themes/scaled.js
+++ b/aries-site/src/themes/scaled.js
@@ -19,6 +19,9 @@ const undefinedThemeProperties = {
   button: {
     extend: '',
   },
+  checkBox: {
+    extend: '',
+  },
 };
 
 export const scaled = (scale = 1, baseSpacing = 24) => {
@@ -111,6 +114,15 @@ export const scaled = (scale = 1, baseSpacing = 24) => {
   // and scale accordingly.
   scaledTheme.anchor.extend = `
     ${source.anchor.extend} 
+    font-size: ${Math.ceil(18 * scale)}px;
+    line-height: ${Math.ceil(24 * scale)}px;
+  `;
+
+  // CheckBox typically inherits its font-size from its parent and does not have
+  // a theme property to adjust. Therefore use checkBox.extend, assume 'medium'
+  // and scale accordingly.
+  scaledTheme.checkBox.extend = `
+    ${source.checkBox.extend} 
     font-size: ${Math.ceil(18 * scale)}px;
     line-height: ${Math.ceil(24 * scale)}px;
   `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-3304--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Scales the labels for CheckBoxes when examples are presented in screen mode.

#### Where should the reviewer start?

scaled.js

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
