### PR TITLE
Fix icons to be inline with v5 brand direction

### DIFF
--- a/aries-site/src/examples/components/button/ButtonIconExample.js
+++ b/aries-site/src/examples/components/button/ButtonIconExample.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Button, ResponsiveContext } from 'grommet';
-import { FormPrevious, FormNext } from 'grommet-icons';
+import { Previous, Next } from 'grommet-icons';
 
 export const ButtonIconExample = () => {
   const size = React.useContext(ResponsiveContext);
@@ -15,29 +15,24 @@ export const ButtonIconExample = () => {
         gap="medium"
         align="center"
       >
-        <Button label="Button" icon={<FormPrevious />} onClick={() => {}} />
-        <Button label="Button" icon={<FormNext />} reverse onClick={() => {}} />
-        <Button icon={<FormNext />} onClick={() => {}} />
+        <Button label="Button" icon={<Previous />} onClick={() => {}} />
+        <Button label="Button" icon={<Next />} reverse onClick={() => {}} />
+        <Button icon={<Next />} onClick={() => {}} />
       </Box>
       <Box
         direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
         gap="medium"
         align="center"
       >
+        <Button label="Button" icon={<Previous />} primary onClick={() => {}} />
         <Button
           label="Button"
-          icon={<FormPrevious />}
-          primary
-          onClick={() => {}}
-        />
-        <Button
-          label="Button"
-          icon={<FormNext />}
+          icon={<Next />}
           primary
           reverse
           onClick={() => {}}
         />
-        <Button icon={<FormNext />} primary onClick={() => {}} />
+        <Button icon={<Next />} primary onClick={() => {}} />
       </Box>
     </Box>
   );

--- a/aries-site/src/examples/components/footer/FooterComboExample.js
+++ b/aries-site/src/examples/components/footer/FooterComboExample.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { Box, Button, Footer, ResponsiveContext, Text } from 'grommet';
-import { FormPrevious, FormNext } from 'grommet-icons';
+import { Previous, Next } from 'grommet-icons';
 
 export const FooterComboExample = () => {
   const size = useContext(ResponsiveContext);
@@ -15,8 +15,8 @@ export const FooterComboExample = () => {
   return (
     <Box gap="medium">
       <Footer fill="horizontal">
-        <Button label="Go back" icon={<FormPrevious />} />
-        <Button label="Next" icon={<FormNext />} reverse />
+        <Button label="Go back" icon={<Previous />} />
+        <Button label="Next" icon={<Next />} reverse />
       </Footer>
       <Footer
         background="background-front"

--- a/aries-site/src/examples/components/footer/FooterPageExample.js
+++ b/aries-site/src/examples/components/footer/FooterPageExample.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Button, Footer } from 'grommet';
-import { FormPrevious, FormNext } from 'grommet-icons';
+import { Previous, Next } from 'grommet-icons';
 
 export const FooterPageExample = () => (
   <Footer fill="horizontal">
-    <Button label="Go back" icon={<FormPrevious />} />
-    <Button label="Next" icon={<FormNext />} reverse />
+    <Button label="Go back" icon={<Previous />} />
+    <Button label="Next" icon={<Next />} reverse />
   </Footer>
 );

--- a/aries-site/src/examples/components/menu/MenuHeaderExample.js
+++ b/aries-site/src/examples/components/menu/MenuHeaderExample.js
@@ -23,7 +23,7 @@ export const MenuHeaderExample = () => {
           pad={{ vertical: 'small' }}
           responsive={false}
         >
-          <Hpe color="brand" />
+          <Hpe color="brand" height="medium" />
           {!['xsmall', 'small'].includes(size) && (
             <Box direction="row" gap="xsmall" wrap>
               <Text color="text-strong" weight="bold">


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Addresses "Icons" section for https://github.com/grommet/hpe-design-system/issues/3274

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
