### PR TITLE
Fix child object heading and icon style

### DIFF
--- a/aries-site/src/examples/templates/FormChildObject/ChildHeader.js
+++ b/aries-site/src/examples/templates/FormChildObject/ChildHeader.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Header, Heading, Text } from 'grommet';
-import { FormUp, FormDown } from 'grommet-icons';
+import { Up, Down } from 'grommet-icons';
 
 export const ChildHeader = ({
   // annotationIds are for documentation demo purposes only.
@@ -30,15 +30,8 @@ export const ChildHeader = ({
       {...rest}
     >
       <Box>
-        <Heading
-          id={annotationIds?.label}
-          level={headingLevel}
-          size="small"
-          margin="none"
-          color="text"
-          weight={500}
-        >
-          {name || `${collectionName} ${index}`}
+        <Heading id={annotationIds?.label} level={headingLevel} margin="none">
+          {name || `New ${collectionName} name 'undefined'`}
         </Heading>
         {summary && (
           <Text id={annotationIds?.valuesSummary} truncate>
@@ -47,9 +40,9 @@ export const ChildHeader = ({
         )}
       </Box>
       {open ? (
-        <FormUp id={annotationIds?.icon} a11yTitle="Hide detail" />
+        <Up id={annotationIds?.icon} a11yTitle="Hide detail" />
       ) : (
-        <FormDown id={annotationIds?.icon} a11yTitle="Show detail and edit" />
+        <Down id={annotationIds?.icon} a11yTitle="Show detail and edit" />
       )}
     </Header>
   );

--- a/aries-site/src/examples/templates/FormChildObject/ChildHeader.js
+++ b/aries-site/src/examples/templates/FormChildObject/ChildHeader.js
@@ -31,7 +31,7 @@ export const ChildHeader = ({
     >
       <Box>
         <Heading id={annotationIds?.label} level={headingLevel} margin="none">
-          {name || `New ${collectionName} name 'undefined'`}
+          {name || `New ${collectionName} (undefined)`}
         </Heading>
         {summary && (
           <Text id={annotationIds?.valuesSummary} truncate>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-3324--keen-mayer-a86c8b.netlify.app/templates/forms/managing-child-objects#required-children)

#### What does this PR do?

Closes https://github.com/grommet/hpe-design-system/issues/3178 and closes the typography portion of https://github.com/grommet/hpe-design-system/issues/3274 by adjusting the object heading style and the default object name.


