### PR TITLE
Remove padding on form error icon

### DIFF
--- a/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
+++ b/aries-site/src/examples/templates/forms/RequiredFieldsExample.js
@@ -153,13 +153,7 @@ export const RequiredFieldsExample = () => {
               direction="row"
               gap="xsmall"
             >
-              <Box
-                flex={false}
-                margin={{ top: 'hair' }}
-                pad={{ top: 'xxsmall' }}
-              >
-                <CircleAlert size="small" />
-              </Box>
+              <CircleAlert size="small" />
               <Text size="xsmall">
                 The name of the superhero is already being used. Provide a
                 unique name.

--- a/aries-site/src/examples/templates/wizard/components/Error.js
+++ b/aries-site/src/examples/templates/wizard/components/Error.js
@@ -13,9 +13,7 @@ export const Error = ({ children, ...rest }) => (
     width="medium"
   >
     <Box direction="row" gap="xsmall" {...rest}>
-      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
-        <CircleAlert size="small" />
-      </Box>
+      <CircleAlert size="small" />
       <Text size="xsmall">{children}</Text>
     </Box>
   </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Removing the margin and pad from around CircleAlert in implementations of form level error.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="488" alt="Screen Shot 2023-07-28 at 3 33 29 PM" src="https://github.com/grommet/hpe-design-system/assets/12522275/0b8b3d15-ccc3-4d76-bedf-4cccb7374b67">

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
