### PR TITLE
Add link to Github issue forms from site

### DIFF
--- a/aries-site/src/layouts/main/Header.js
+++ b/aries-site/src/layouts/main/Header.js
@@ -2,7 +2,7 @@ import React, { useContext, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Box, Button, Header, ResponsiveContext } from 'grommet';
-import { Search as SearchIcon } from 'grommet-icons';
+import { Search as SearchIcon, CircleQuestion } from 'grommet-icons';
 import { ThemeModeToggle, AppIdentity } from '../../components';
 
 import { getPageDetails, nameToPath } from '../../utils';
@@ -48,6 +48,13 @@ const StyledHeader = ({ ...rest }) => {
           onClick={() => setShowSearch(true)}
         />
         {showSearch && <Search setOpen={setShowSearch} />}
+        <Button
+          tip="File an issue or request"
+          icon={<CircleQuestion />}
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://github.com/grommet/hpe-design-system/issues/new/choose"
+        />
         <ThemeModeToggle />
       </Box>
     </Header>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-3655--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Exploration of ability to link to Github issue form directly from site (until we have a more integrated solution). Is an icon-only button with tip sufficient? Do we need a label?

I went with our suggested "Help" icon, but another option could be Github icon?

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
