### PR TITLE
remove mention of using size = small

### DIFF
--- a/aries-site/src/pages/components/pageheader.mdx
+++ b/aries-site/src/pages/components/pageheader.mdx
@@ -80,7 +80,7 @@ Page-level actions should:
 
 A title is a required element of the page and should:
 
-- Always be an h1, and most often should be `size="small"`.
+- Always be an h1.
 - Uniquely and concisely identify the page. No two pages under the same parent should have the same name.
 - Follow sentence case capitalization (i.e., List of clusters, My account).
 - Wrap if too long for the available space. See [Responsive Behavior and Content Prioritization](#responsive-behavior-and-content-prioritization) for more guidance.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
remove mention of `size='small'`
#### Where should the reviewer start?
pageheader
#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
locally 
#### Any background context you want to provide?
We should remove the size="small" — With v5 of theme, we aren’t encouraging people to use size prop anymore
#### What are the relevant issues?
none
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
sure
#### Is this change backwards compatible or is it a breaking change?
backwards compatible