### PR TITLE
Fix semantic heading level link in cards guidance page

### DIFF
--- a/aries-site/src/pages/components/card/index.mdx
+++ b/aries-site/src/pages/components/card/index.mdx
@@ -119,7 +119,7 @@ For cards within the same layout section, place a minimum gap of "medium" betwee
 
 ### Card titles
 
-Card titles should use a Heading of the correct [semantic heading level](foundation/typography#semantic-usage-of-heading-levels) based on where the card is in the document. For example, a card nested under a Heading level 2 should use a Heading level 3 for its title.
+Card titles should use a Heading of the correct [semantic heading level](/foundation/typography#semantic-usage-of-heading-levels) based on where the card is in the document. For example, a card nested under a Heading level 2 should use a Heading level 3 for its title.
 
 Don't use Text for the card title as this will hurt the experience for users of assisstive technologies.
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

Fixed link in cards guidance page

<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-3862--keen-mayer-a86c8b.netlify.app/components/card?q=card#card-titles)

![Screenshot 2024-05-02 at 5 13 14 PM](https://github.com/grommet/hpe-design-system/assets/5853565/1cf8c7df-79db-4dc2-8aff-c4146c9847ac)


#### What does this PR do?

Fixed bad link

`https://design-system.hpe.design/components/foundation/typography#semantic-usage-of-heading-levels`
to
`https://design-system.hpe.design/foundation/typography#semantic-usage-of-heading-levels`

