### PR TITLE
Align tabs to the left in the Inline notifications guidance page

### DIFF
--- a/aries-site/src/examples/templates/inline-notifications/PageBannerExample.js
+++ b/aries-site/src/examples/templates/inline-notifications/PageBannerExample.js
@@ -43,7 +43,7 @@ export const PageBannerExample = () => {
             // changes the route and sets the active tab.
             actions={[{ label: 'View details', onClick: () => setActive(2) }]}
           />
-          <Tabs activeIndex={active}>
+          <Tabs justify="start" activeIndex={active}>
             <Tab title="Projects" onClick={() => setActive(0)}>
               <Box pad={{ vertical: 'medium' }}>
                 <Grid columns="medium" rows="small" gap="medium">


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-4165--keen-mayer-a86c8b.netlify.app/templates/inline-notifications?q=inli#additional-detail)

#### What does this PR do?
Changing tabs alignment in the Inline notifications example



### Expected Behavior
According to [tabs guidance](https://design-system.hpe.design/components/tabs?q=tabs#alignment), tabs should always be left aligned.

Left align the tabs in the [Additional detail](https://design-system.hpe.design/templates/inline-notifications?q=inline#additional-detail) example 



#### Screenshots
![Screenshot 2024-09-10 at 11 50 36 AM](https://github.com/user-attachments/assets/9f5bb123-d58d-4ab2-9cc3-83fd06e7894d)



