### PR TITLE
Update the misuses section with Selector examples

### DIFF
--- a/aries-site/src/pages/components/card/index.mdx
+++ b/aries-site/src/pages/components/card/index.mdx
@@ -133,7 +133,7 @@ When cards are presenting as a group, they should function as a list.
 ## Misuses
 
 - When data attributes across items needs to be analyzed, sorted, compared, and filtered, a card may not be the best tool. Instead, [DataTable](/components/datatable) may be more appropriate tool to meet these needs.
-- Cards should not be used as a control to filter data on the same screen. A button is the appropriate control to apply a filter. Alternatively, cards may be used to present summarized information and allow a user to navigate to a pre-filtered view of that information.
+- Cards should not be used as controls to filter data directly on the same screen. Instead, the [Selector](templates/selector) component is the appropriate tool for filtering data sets.
 
 <BestPracticeGroup>
   <Example

--- a/aries-site/src/pages/components/card/index.mdx
+++ b/aries-site/src/pages/components/card/index.mdx
@@ -134,33 +134,6 @@ When cards are presenting as a group, they should function as a list.
 
 - When data attributes across items needs to be analyzed, sorted, compared, and filtered, a card may not be the best tool. Instead, [DataTable](/components/datatable) may be more appropriate tool to meet these needs.
 - Cards should not be used as controls to filter data directly on the same screen. Instead, the [Selector](templates/selector) component is the appropriate tool for filtering data sets.
-
-<BestPracticeGroup>
-  <Example
-    height={{ min: 'small' }}
-    bestPractice={{
-      type: 'do',
-      message:
-        'Style status filter buttons as default buttons when the buttons are placed on the same page as the data they will be filtering.',
-    }}
-    scale={0.4}
-    width="100%"
-  >
-    <CardFilteringBestPractice />
-  </Example>
-  <Example
-    height={{ min: 'small' }}
-    bestPractice={{
-      type: 'dont',
-      message: `Don’t use a card to wrap a set of status filter buttons if clicking on one of those buttons will filter data that exists on the same page as that card. Cards should act as independent regions that do not affect surrounding content. However, placing these buttons in a card would be appropriate on a dashboard, where clicking on one of the status buttons would navigate to a different page that is filtered by the selected status.`,
-    }}
-    scale={0.4}
-    width="100%"
-  >
-    <CardFilteringBestPractice bestPractice={false} />
-  </Example>
-</BestPracticeGroup>
-
 - A card should not be used to group complex content into a single container. A card is meant to be individual, presenting a single, summarized topic which cannot be divided.
 
 <BestPracticeGroup>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
### [GitHub issue](https://github.com/grommet/hpe-design-system/issues/4141)

<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-4204--keen-mayer-a86c8b.netlify.app/components/card#misuses)

#### What does this PR do?
Update the Misuses part of the Card guidance
- Updated text with link to Selector component
- Removed Do-Don't visual example since it is no longer relevant.
(_Default buttons are no longer used for quick filtering and Selectors have borders thus eliminating the need to group them inside a card._)

