### PR TITLE
Add Select clear selection example

### DIFF
--- a/aries-site/src/examples/components/select/SelectClearExample.js
+++ b/aries-site/src/examples/components/select/SelectClearExample.js
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Box, Form, FormField, Select } from 'grommet';
+
+const options = [
+  'Item One',
+  'Item Two',
+  'Item Three',
+  'Item Four',
+  'Item Five',
+  'Item Six',
+];
+
+export const SelectClearExample = () => {
+  const [selected, setSelected] = useState('Item Four');
+
+  return (
+    <Box width="medium">
+      <Form>
+        {/* https://github.com/grommet/eslint-plugin-grommet/issues/46 */}
+        {/* eslint-disable-next-line grommet/formfield-htmlfor-id */}
+        <FormField
+          htmlFor="clear-example__input"
+          name="clear-example"
+          label="Label"
+        >
+          <Select
+            id="clear-example"
+            name="clear-example"
+            placeholder="Select item"
+            options={options}
+            value={selected}
+            onChange={({ option }) => setSelected(option)}
+            clear={{ label: 'Clear selection' }}
+          />
+        </FormField>
+      </Form>
+    </Box>
+  );
+};

--- a/aries-site/src/examples/components/select/index.js
+++ b/aries-site/src/examples/components/select/index.js
@@ -1,3 +1,4 @@
+export * from './SelectClearExample';
 export * from './SelectDisabledExample';
 export * from './SelectExample';
 export * from './SelectPreview';

--- a/aries-site/src/pages/components/select.mdx
+++ b/aries-site/src/pages/components/select.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../layouts';
 import {
+  SelectClearExample,
   SelectDisabledExample,
   SelectExample,
   SelectSearchExample,
@@ -80,4 +81,16 @@ Indicates that the Select input exists but cannot be interacted with until a pre
   height={{ min: 'small' }}
 >
   <SelectDisabledExample />
+</Example>
+
+### Clear selection
+
+Allow users to clear their selection if the select is not required. This prevents users from being locked into an option.
+
+<Example
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/select/SelectClearExample.js"
+  docs="https://v2.grommet.io/select?theme=hpe#props"
+  height={{ min: 'small' }}
+>
+  <SelectClearExample />
 </Example>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Adds example to the site with "Clear selection". This requires https://github.com/grommet/grommet-theme-hpe/pull/412 to be released before merging.

NOTE: Right now in Grommet if a `name` is passed to Select, that's used to in place of the word "selection" in "Clear selection" button. This just felt a little odd because name is usually more "dev centric" wording than user facing. For now, I've implemented by passing an object to define my own label like `clear={{ label: 'Clear selection' }}` -- in terms of being able to standardize wording though it does feel a bit off.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

Closes [#4225](https://github.com/grommet/hpe-design-system/issues/4225)

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
