### PR TITLE
Add element icon size tokens

### DIFF
--- a/design-tokens/tokens/component/element.default.json
+++ b/design-tokens/tokens/component/element.default.json
@@ -146,6 +146,20 @@
             "codeSyntax": {}
           }
         }
+      },
+      "icon": {
+        "size": {
+          "$type": "number",
+          "$value": "{size.icon.xsmall}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": ["WIDTH_HEIGHT"],
+              "codeSyntax": {}
+            }
+          }
+        }
       }
     },
     "small": {
@@ -290,6 +304,20 @@
             "com.figma": {
               "hiddenFromPublishing": false,
               "scopes": ["GAP"],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "icon": {
+        "size": {
+          "$type": "number",
+          "$value": "{size.icon.small}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": ["WIDTH_HEIGHT"],
               "codeSyntax": {}
             }
           }
@@ -442,6 +470,20 @@
             }
           }
         }
+      },
+      "icon": {
+        "size": {
+          "$type": "number",
+          "$value": "{size.icon.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": ["WIDTH_HEIGHT"],
+              "codeSyntax": {}
+            }
+          }
+        }
       }
     },
     "large": {
@@ -590,6 +632,20 @@
             }
           }
         }
+      },
+      "icon": {
+        "size": {
+          "$type": "number",
+          "$value": "{size.icon.large}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": ["WIDTH_HEIGHT"],
+              "codeSyntax": {}
+            }
+          }
+        }
       }
     },
     "xlarge": {
@@ -734,6 +790,20 @@
             "com.figma": {
               "hiddenFromPublishing": false,
               "scopes": ["GAP"],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "icon": {
+        "size": {
+          "$type": "number",
+          "$value": "{size.icon.xlarge}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": ["WIDTH_HEIGHT"],
               "codeSyntax": {}
             }
           }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Adding `element[t-shirt size].icon.size` tokens.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Related https://github.com/grommet/hpe-design-system/issues/4294

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
