### PR TITLE
Rename formField tokens from `valueText` to `value`, etc.

### DIFF
--- a/design-tokens/tokens/component/component.default.json
+++ b/design-tokens/tokens/component/component.default.json
@@ -8102,7 +8102,7 @@
           }
         }
       },
-      "labelText": {
+      "label": {
         "fontSize": {
           "$type": "number",
           "$value": "{text.xsmall.fontSize}",
@@ -8140,7 +8140,7 @@
           }
         }
       },
-      "placeholderText": {
+      "placeholder": {
         "fontSize": {
           "$type": "number",
           "$value": "{element.medium.fontSize}",
@@ -8178,7 +8178,7 @@
           }
         }
       },
-      "helpText": {
+      "help": {
         "fontSize": {
           "$type": "number",
           "$value": "{text.xsmall.fontSize}",
@@ -8216,7 +8216,7 @@
           }
         }
       },
-      "infoText": {
+      "info": {
         "fontSize": {
           "$type": "number",
           "$value": "{text.xsmall.fontSize}",
@@ -8254,7 +8254,7 @@
           }
         }
       },
-      "errorText": {
+      "error": {
         "fontSize": {
           "$type": "number",
           "$value": "{text.xsmall.fontSize}",
@@ -8292,7 +8292,7 @@
           }
         }
       },
-      "valueText": {
+      "value": {
         "fontSize": {
           "$type": "number",
           "$value": "{element.medium.fontSize}",
@@ -8735,7 +8735,7 @@
         }
       }
     },
-    "labelText": {
+    "label": {
       "enabled": {
         "textColor": {
           "$type": "color",
@@ -8823,7 +8823,7 @@
         }
       }
     },
-    "placeholderText": {
+    "placeholder": {
       "disabled": {
         "$type": "color",
         "$value": "{color.text.disabled}",
@@ -8921,7 +8921,7 @@
         }
       }
     },
-    "helpText": {
+    "help": {
       "enabled": {
         "textColor": {
           "$type": "color",
@@ -9009,7 +9009,7 @@
         }
       }
     },
-    "infoText": {
+    "info": {
       "enabled": {
         "textColor": {
           "$type": "color",
@@ -9097,7 +9097,7 @@
         }
       }
     },
-    "errorText": {
+    "error": {
       "enabled": {
         "textColor": {
           "$type": "color",
@@ -9257,7 +9257,7 @@
         }
       }
     },
-    "valueText": {
+    "value": {
       "enabled": {
         "textColor": {
           "$type": "color",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Renames all the formfield text related tokens from `valueText`, `placeholderText`, etc. to `value`, `placeholder`, etc. since these might contain more than just "text" tokens.

The use of term `Text` in v0 was to avoid a style-dictionary build nuance which has been resolved by style-dictionary v4.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4356 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
