### PR TITLE
Added aria-label to character counter examples

### DIFF
--- a/aries-site/src/examples/templates/forms/CharacterCounterExample.js
+++ b/aries-site/src/examples/templates/forms/CharacterCounterExample.js
@@ -26,7 +26,11 @@ export const CharacterCounterExample = () => {
         name="issue-description"
         htmlFor="issue-description"
       >
-        <TextArea id="issue-description" name="issue-description" />
+        <TextArea
+          aria-label="Text area with 40 character limit"
+          id="issue-description"
+          name="issue-description"
+        />
       </FormField>
     </Form>
   );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-4484--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Adds aria-label to the character counter example so screenreader users are aware of the character limit before they start typing

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/3787

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible