### PR TITLE
Improve CSS output to make token parts clearer, align to docs

### DIFF
--- a/.changeset/fair-suns-joke.md
+++ b/.changeset/fair-suns-joke.md
@@ -1,0 +1,5 @@
+---
+"hpe-design-tokens": minor
+---
+
+- Update CSS variable output to maintain camelCase (eg., --hpe-data-cell-padding-x is now --hpe-dataCell-paddingX). This maintains clarity on design token parts.

--- a/design-tokens/src/HPEStyleDictionary.ts
+++ b/design-tokens/src/HPEStyleDictionary.ts
@@ -12,6 +12,7 @@ import {
   cssW3c,
   javascriptW3c,
   linearGradientCss,
+  nameCSS,
   numberToDimension,
   shadowCSS,
 } from './transforms/index.js';
@@ -49,6 +50,9 @@ HPEStyleDictionary.registerFormat({
 HPEStyleDictionary.registerFormat({
   name: `jsonFlat`,
   format: jsonFlat,
+});
+HPEStyleDictionary.registerTransform({
+  ...nameCSS,
 });
 HPEStyleDictionary.registerTransform({
   ...numberToDimension,

--- a/design-tokens/src/transforms/cssW3c.ts
+++ b/design-tokens/src/transforms/cssW3c.ts
@@ -1,6 +1,6 @@
 export const cssW3c: string[] = [
   'attribute/cti',
-  'name/kebab',
+  'name/css',
   'time/seconds',
   'html/icon',
   'size/rem',

--- a/design-tokens/src/transforms/index.ts
+++ b/design-tokens/src/transforms/index.ts
@@ -1,5 +1,6 @@
 export { javascriptW3c } from './javascriptW3c.js';
 export { cssW3c } from './cssW3c.js';
 export { linearGradientCss } from './linearGradientCss.js';
+export { nameCSS } from './nameCss.js';
 export { numberToDimension } from './numberToDimension.js';
 export { shadowCSS } from './shadowCss.js';

--- a/design-tokens/src/transforms/nameCss.ts
+++ b/design-tokens/src/transforms/nameCss.ts
@@ -1,0 +1,14 @@
+import {
+  PlatformConfig,
+  Transform,
+  TransformedToken,
+} from 'style-dictionary/types';
+
+export const nameCSS: Transform = {
+  name: 'name/css',
+  type: 'name',
+  transform: (token: TransformedToken, config: PlatformConfig) => {
+    const { prefix } = config;
+    return `${prefix}-${token.path.join('-')}`;
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This updates our style-dictionary output for CSS to align the CSS variable format with our docs: https://design-system.hpe.design/design-tokens/how-to-read-design-tokens#token-delimiters

Now, instead of relying on the built-in name/kebab transform (which auto hyphenated at camelCased words, eg. hpe.dataCell.paddingY --> hpe-data-cell-padding-y), we manage our own to maintain clarity on token parts (NEW output of hpe-dataCell-paddingY).

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

Some example changes to CSS output:

<img width="1415" alt="Screenshot 2025-01-07 at 11 17 37 AM" src="https://github.com/user-attachments/assets/0ddd2d9e-6e46-4648-a0a1-0cb9d90ff94d" />
<img width="1389" alt="Screenshot 2025-01-07 at 11 18 51 AM" src="https://github.com/user-attachments/assets/92d65b54-95f4-4122-aee5-f469cadb4ef4" />


#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
