### PR TITLE
Pull in flattened Figma names

### DIFF
--- a/design-tokens/tokens/semantic/color.dark.json
+++ b/design-tokens/tokens/semantic/color.dark.json
@@ -137,12 +137,44 @@
           }
         }
       },
-      "warning": {
+      "ok": {
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.yellow.400-Opacity12}",
-            "$description": "Use for borders communicating warning or caution.",
+            "$value": "{base.color.green.500-Opacity30}",
+            "$description": "Use for backgrounds communicating success.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "critical": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.red.800-Opacity30}",
+            "$description": "Use for backgrounds communicating errors or danger.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "unknown": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.white.opacity6}",
+            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -169,12 +201,12 @@
           }
         }
       },
-      "critical": {
+      "warning": {
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.800-Opacity30}",
-            "$description": "Use for backgrounds communicating errors or danger.",
+            "$value": "{base.color.yellow.400-Opacity12}",
+            "$description": "Use for borders communicating warning or caution.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -205,38 +237,6 @@
             "$type": "color",
             "$value": "{base.color.green.600}",
             "$description": "Hover variant of background-primary.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "unknown": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.white.opacity6}",
-            "$description": "Use for backgrounds communicating an unknown status.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "ok": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.green.500-Opacity30}",
-            "$description": "Use for backgrounds communicating success.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -573,38 +573,6 @@
           }
         }
       },
-      "onStrong": {
-        "default": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.grey.1200}",
-            "$description": "Text color to be used on strong backgrounds. For example, background-neutral-xstrong.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["TEXT_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "heading": {
-        "default": {
-          "REST": {
-            "$type": "color",
-            "$value": "{color.text.strong.REST}",
-            "$description": "Text color for headings.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
       "primary": {
         "DEFAULT": {
           "REST": {
@@ -701,6 +669,22 @@
           }
         }
       },
+      "heading": {
+        "default": {
+          "REST": {
+            "$type": "color",
+            "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
       "onSelectedStrong": {
         "DEFAULT": {
           "REST": {
@@ -723,6 +707,22 @@
             "$type": "color",
             "$value": "{color.text.strong.REST}",
             "$description": "Text color to be used for text sitting on non-strong variants of background-selected.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["TEXT_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "onStrong": {
+        "default": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.grey.1200}",
+            "$description": "Text color to be used on strong backgrounds. For example, background-neutral-xstrong.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,

--- a/design-tokens/tokens/semantic/color.light.json
+++ b/design-tokens/tokens/semantic/color.light.json
@@ -137,12 +137,44 @@
           }
         }
       },
-      "warning": {
+      "ok": {
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.orange.400-Opacity24}",
-            "$description": "Use for borders communicating warning or caution.",
+            "$value": "{base.color.green.400-Opacity24}",
+            "$description": "Use for backgrounds communicating success.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "critical": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.red.500-Opacity24}",
+            "$description": "Use for backgrounds communicating errors or danger.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "unknown": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.black.opacity4}",
+            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -169,12 +201,12 @@
           }
         }
       },
-      "critical": {
+      "warning": {
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.500-Opacity24}",
-            "$description": "Use for backgrounds communicating errors or danger.",
+            "$value": "{base.color.orange.400-Opacity24}",
+            "$description": "Use for borders communicating warning or caution.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -205,38 +237,6 @@
             "$type": "color",
             "$value": "{base.color.green.600}",
             "$description": "Hover variant of background-primary.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "unknown": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.black.opacity4}",
-            "$description": "Use for backgrounds communicating an unknown status.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "ok": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.green.400-Opacity24}",
-            "$description": "Use for backgrounds communicating success.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -573,38 +573,6 @@
           }
         }
       },
-      "onStrong": {
-        "default": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.white.100}",
-            "$description": "Text color to be used on strong backgrounds. For example, background-neutral-xstrong.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["TEXT_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "heading": {
-        "default": {
-          "REST": {
-            "$type": "color",
-            "$value": "{color.text.strong.REST}",
-            "$description": "Text color for headings.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
       "primary": {
         "DEFAULT": {
           "REST": {
@@ -701,6 +669,22 @@
           }
         }
       },
+      "heading": {
+        "default": {
+          "REST": {
+            "$type": "color",
+            "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
       "onSelectedStrong": {
         "DEFAULT": {
           "REST": {
@@ -723,6 +707,22 @@
             "$type": "color",
             "$value": "{color.text.strong.REST}",
             "$description": "Text color to be used for text sitting on non-strong variants of background-selected.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["TEXT_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "onStrong": {
+        "default": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.white.100}",
+            "$description": "Text color to be used on strong backgrounds. For example, background-neutral-xstrong.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

After flattening the Figma color names, have pulled in the updates. No adjustments to values/token nesting structure, just some reordering that occurred as a result of flattening out in Figma.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
