### PR TITLE
Fix/token to figma alias

### DIFF
--- a/design-tokens/src/token_import.ts
+++ b/design-tokens/src/token_import.ts
@@ -258,6 +258,25 @@ function isAlias(value: string) {
   return value.toString().trim().charAt(0) === '{';
 }
 
+/**
+ * When pushing to Figma, we should strip off "DEFAULT" and "REST" to match simplified token outputs.
+ * Also, format nested roles, prominence, or interaction to hyphenated ("-") approach
+ * e.g. color/background/critical/weak/DEFAULT/REST --> color/background/critical-weak
+ * @param alias
+ */
+const tokenAliasToFigmaAlias = (alias: string): string => {
+  const isColor = /^color/.test(alias);
+  let adjustedName = alias;
+  if (isColor) {
+    let parts = adjustedName.split('/');
+    parts = parts.filter(part => !excludedNameParts.includes(part));
+    const section = parts.slice(0, 2).join('/');
+    const name = parts.slice(2).join('-');
+    adjustedName = `${section}${name ? `/${name}` : ''}`;
+  }
+  return adjustedName;
+};
+
 function variableValueFromToken(
   token: Token,
   localVariablesByCollectionAndName: {
@@ -267,14 +286,12 @@ function variableValueFromToken(
   if (typeof token.$value === 'string' && isAlias(token.$value)) {
     // Assume aliases are in the format {group.subgroup.token} with any number of optional groups/subgroups
     // The Figma syntax for variable names is: group/subgroup/token
-    const value = token.$value
+    let value = token.$value
       .trim()
       .replace(/\./g, '/')
-      .replace(/[\{\}]/g, '')
-      .split('/')
-      .filter(part => !excludedNameParts.includes(part))
-      .join('/');
+      .replace(/[\{\}]/g, '');
 
+    value = tokenAliasToFigmaAlias(value);
     // When mapping aliases to existing local variables, we assume that variable names
     // are unique *across all collections* in the Figma file
     // TO DO how will this work with our density token concept is there are repeated
@@ -502,19 +519,7 @@ export function generatePostVariablesPayload(
       localVariablesByCollectionAndName[variableCollection?.id] || {};
 
     Object.entries(tokens).forEach(([tokenName, token]) => {
-      const isColor = /^color/.test(tokenName);
-      // When pushing to Figma, we should strip off "DEFAULT" and "REST"
-      // to match simplified token outputs
-      // we should also format nested roles, prominence, or interaction to hyphenated ("-") approach
-      // e.g. color/background/critical/weak/DEFAULT/REST --> color/background/critical-weak
-      let adjustedName = tokenName;
-      if (isColor) {
-        let parts = tokenName.split('/');
-        parts = parts.filter(part => !excludedNameParts.includes(part));
-        const section = parts.slice(0, 2).join('/');
-        const name = parts.slice(2).join('-');
-        adjustedName = `${section}${name ? `/${name}` : ''}`;
-      }
+      const adjustedName = tokenAliasToFigmaAlias(tokenName);
 
       const variable = localVariablesByName[adjustedName];
       const variableId = variable ? variable.id : adjustedName;

--- a/design-tokens/src/token_import.ts
+++ b/design-tokens/src/token_import.ts
@@ -270,7 +270,10 @@ function variableValueFromToken(
     const value = token.$value
       .trim()
       .replace(/\./g, '/')
-      .replace(/[\{\}]/g, '');
+      .replace(/[\{\}]/g, '')
+      .split('/')
+      .filter(part => !excludedNameParts.includes(part))
+      .join('/');
 
     // When mapping aliases to existing local variables, we assume that variable names
     // are unique *across all collections* in the Figma file


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Refinement to Github --> figma translation to resolve [failing Github action](https://github.com/grommet/hpe-design-system/actions/runs/12797599743/job/35679840114) where alias still included "REST", "DEFAULT". Removing these special terms before Figma tries to point to the flattened color.

I tested this locally by creating "test" Figma variable files. Confirmed that pushing and pulling retained desired token structure and properly handled aliasing.

<img width="681" alt="Screenshot 2025-01-15 at 2 40 52 PM" src="https://github.com/user-attachments/assets/fff42299-981b-45e9-ace6-59f662ff6f3d" />

<img width="669" alt="Screenshot 2025-01-15 at 2 41 04 PM" src="https://github.com/user-attachments/assets/b06e88ce-d982-4830-bb3e-33389aa11397" />

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
