### PR TITLE
Fix ESM build format

### DIFF
--- a/design-tokens/src/scripts/build-style-dictionary.js
+++ b/design-tokens/src/scripts/build-style-dictionary.js
@@ -117,7 +117,7 @@ try {
         files: [
           {
             destination: 'global.js',
-            format: 'esmGrommetRefs',
+            format: 'javascript/esm',
             filter: token =>
               token.filePath === `${TOKENS_DIR}/semantic/global.default.json`,
           },
@@ -414,7 +414,7 @@ try {
             filter: token =>
               token.filePath.includes(`${TOKENS_DIR}/component/`) &&
               !token.path.includes(FIGMA_PREFIX),
-            format: 'esmGrommetRefs',
+            format: 'javascript/esm',
           },
         ],
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Resolves incorrect place where esmGrommetRefs format was being used for ESM.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
