### PR TITLE
Fix background-screenOverlay, add text-anchor, nest disabled states

### DIFF
--- a/.changeset/bright-shirts-carry.md
+++ b/.changeset/bright-shirts-carry.md
@@ -1,0 +1,8 @@
+---
+"hpe-design-tokens": minor
+---
+
+- Fixed background-screenOverlay.
+- Added `color.text.anchor`, `color.text.anchor.hover`.
+- Fixed `anchor.disabled` tokens to be structured as `anchor.disabled.rest`
+- Fixed `dataCell.primary.disabled` tokens to be structured as `dataCell.primary.disabled.rest`

--- a/design-tokens/tokens/component/component.default.json
+++ b/design-tokens/tokens/component/component.default.json
@@ -9676,51 +9676,53 @@
         }
       },
       "disabled": {
-        "textColor": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.textColor}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["TEXT_FILL"],
-              "codeSyntax": {}
+        "rest": {
+          "textColor": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.textColor}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["TEXT_FILL"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "iconColor": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.iconColor}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR"],
-              "codeSyntax": {}
+          },
+          "iconColor": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.iconColor}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "borderColor": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.borderColor}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
-              "codeSyntax": {}
+          },
+          "borderColor": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.borderColor}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "background": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.background}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-              "codeSyntax": {}
+          },
+          "background": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.background}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
             }
           }
         }
@@ -10968,7 +10970,7 @@
       "rest": {
         "textColor": {
           "$type": "color",
-          "$value": "{color.text.strong.REST}",
+          "$value": "{color.text.anchor.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -11006,7 +11008,7 @@
       "hover": {
         "textColor": {
           "$type": "color",
-          "$value": "{color.text.strong.REST}",
+          "$value": "{color.text.anchor.DEFAULT.hover}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -11042,39 +11044,41 @@
         }
       },
       "disabled": {
-        "textColor": {
-          "$type": "color",
-          "$value": "{color.text.strong.REST}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["TEXT_FILL"],
-              "codeSyntax": {}
+        "rest": {
+          "textColor": {
+            "$type": "color",
+            "$value": "{color.text.disabled.DEFAULT.REST}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["TEXT_FILL"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "fontWeight": {
-          "$type": "number",
-          "$value": "{fontWeight.medium}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": [],
-              "codeSyntax": {}
+          },
+          "fontWeight": {
+            "$type": "number",
+            "$value": "{fontWeight.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "textDecoration": {
-          "$type": "string",
-          "$value": "underline",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
+          },
+          "textDecoration": {
+            "$type": "string",
+            "$value": "underline",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": true,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
           }
         }
@@ -13046,188 +13050,6 @@
         }
       }
     },
-    "badge": {
-      "value": {
-        "default": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.background.neutral.xstrong.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "textColor": {
-              "$type": "color",
-              "$value": "{color.text.onStrong.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "border": {
-              "$type": "color",
-              "$value": "{color.transparent}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        },
-        "small": {
-          "paddingX": {
-            "$type": "number",
-            "$value": "{static.spacing.5xsmall}",
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          },
-          "paddingY": {
-            "$type": "number",
-            "$value": 0,
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          },
-          "borderRadius": {
-            "$type": "number",
-            "$value": "{static.radius.full}",
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        },
-        "critical": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.icon.critical.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "textColor": {
-              "$type": "color",
-              "$value": "{color.text.onStrong.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "border": {
-              "$type": "color",
-              "$value": "{color.transparent}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        }
-      },
-      "dot": {
-        "default": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.background.neutral.xstrong.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        },
-        "small": {
-          "width": {
-            "$type": "number",
-            "$value": 9,
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          },
-          "height": {
-            "$type": "number",
-            "$value": 9,
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        },
-        "critical": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.icon.critical.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "spinner": {
       "track": {
         "background": {
@@ -13448,26 +13270,6 @@
         }
       }
     },
-    "switch": {
-      "default": {
-        "medium": {
-          "track": {
-            "paddingX": {
-              "$type": "number",
-              "$value": "{static.spacing.none}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "globalHeader": {
       "default": {
         "background": {
@@ -13479,6 +13281,188 @@
               "hiddenFromPublishing": false,
               "scopes": ["ALL_SCOPES"],
               "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "badge": {
+      "value": {
+        "default": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.background.neutral.xstrong.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "textColor": {
+              "$type": "color",
+              "$value": "{color.text.onStrong.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "border": {
+              "$type": "color",
+              "$value": "{color.transparent}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "small": {
+          "paddingX": {
+            "$type": "number",
+            "$value": "{static.spacing.5xsmall}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "paddingY": {
+            "$type": "number",
+            "$value": 0,
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "borderRadius": {
+            "$type": "number",
+            "$value": "{static.radius.full}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "critical": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.icon.critical.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "textColor": {
+              "$type": "color",
+              "$value": "{color.text.onStrong.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "border": {
+              "$type": "color",
+              "$value": "{color.transparent}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "dot": {
+        "default": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.background.neutral.xstrong.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "small": {
+          "width": {
+            "$type": "number",
+            "$value": 9,
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "height": {
+            "$type": "number",
+            "$value": 9,
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "critical": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.icon.critical.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
             }
           }
         }
@@ -13694,6 +13678,26 @@
                 "hiddenFromPublishing": false,
                 "scopes": ["ALL_SCOPES"],
                 "codeSyntax": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "switch": {
+      "default": {
+        "medium": {
+          "track": {
+            "paddingX": {
+              "$type": "number",
+              "$value": "{static.spacing.none}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
               }
             }
           }

--- a/design-tokens/tokens/component/component.v1.json
+++ b/design-tokens/tokens/component/component.v1.json
@@ -9676,51 +9676,53 @@
         }
       },
       "disabled": {
-        "textColor": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.textColor}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["TEXT_FILL"],
-              "codeSyntax": {}
+        "rest": {
+          "textColor": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.textColor}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["TEXT_FILL"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "iconColor": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.iconColor}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR"],
-              "codeSyntax": {}
+          },
+          "iconColor": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.iconColor}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "borderColor": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.borderColor}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
-              "codeSyntax": {}
+          },
+          "borderColor": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.borderColor}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "background": {
-          "$type": "color",
-          "$value": "{dataCell.default.disabled.rest.background}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-              "codeSyntax": {}
+          },
+          "background": {
+            "$type": "color",
+            "$value": "{dataCell.default.disabled.rest.background}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
             }
           }
         }
@@ -10968,7 +10970,7 @@
       "rest": {
         "textColor": {
           "$type": "color",
-          "$value": "{color.text.primary.DEFAULT.REST}",
+          "$value": "{color.text.anchor.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -11006,7 +11008,7 @@
       "hover": {
         "textColor": {
           "$type": "color",
-          "$value": "{color.text.primary.DEFAULT.hover}",
+          "$value": "{color.text.anchor.DEFAULT.hover}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -11042,39 +11044,41 @@
         }
       },
       "disabled": {
-        "textColor": {
-          "$type": "color",
-          "$value": "{color.text.disabled.DEFAULT.REST}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["TEXT_FILL"],
-              "codeSyntax": {}
+        "rest": {
+          "textColor": {
+            "$type": "color",
+            "$value": "{color.text.disabled.DEFAULT.REST}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["TEXT_FILL"],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "fontWeight": {
-          "$type": "number",
-          "$value": "{fontWeight.medium}",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": [],
-              "codeSyntax": {}
+          },
+          "fontWeight": {
+            "$type": "number",
+            "$value": "{fontWeight.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-          }
-        },
-        "textDecoration": {
-          "$type": "string",
-          "$value": "underline",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
+          },
+          "textDecoration": {
+            "$type": "string",
+            "$value": "underline",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": true,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
           }
         }
@@ -13046,188 +13050,6 @@
         }
       }
     },
-    "badge": {
-      "value": {
-        "default": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.background.neutral.xstrong.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "textColor": {
-              "$type": "color",
-              "$value": "{color.text.onStrong.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "border": {
-              "$type": "color",
-              "$value": "{color.transparent}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        },
-        "small": {
-          "paddingX": {
-            "$type": "number",
-            "$value": "{static.spacing.5xsmall}",
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          },
-          "paddingY": {
-            "$type": "number",
-            "$value": 0,
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          },
-          "borderRadius": {
-            "$type": "number",
-            "$value": "{static.radius.full}",
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        },
-        "critical": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.icon.critical.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "textColor": {
-              "$type": "color",
-              "$value": "{color.text.onStrong.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            },
-            "border": {
-              "$type": "color",
-              "$value": "{color.transparent}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        }
-      },
-      "dot": {
-        "default": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.background.neutral.xstrong.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        },
-        "small": {
-          "width": {
-            "$type": "number",
-            "$value": 9,
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          },
-          "height": {
-            "$type": "number",
-            "$value": 9,
-            "$description": "",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["ALL_SCOPES"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        },
-        "critical": {
-          "rest": {
-            "background": {
-              "$type": "color",
-              "$value": "{color.icon.critical.DEFAULT.REST}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "spinner": {
       "track": {
         "background": {
@@ -13448,26 +13270,6 @@
         }
       }
     },
-    "switch": {
-      "default": {
-        "medium": {
-          "track": {
-            "paddingX": {
-              "$type": "number",
-              "$value": "{static.spacing.hair}",
-              "$description": "",
-              "$extensions": {
-                "com.figma": {
-                  "hiddenFromPublishing": false,
-                  "scopes": ["ALL_SCOPES"],
-                  "codeSyntax": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "globalHeader": {
       "default": {
         "background": {
@@ -13479,6 +13281,188 @@
               "hiddenFromPublishing": false,
               "scopes": ["ALL_SCOPES"],
               "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "badge": {
+      "value": {
+        "default": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.background.neutral.xstrong.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "textColor": {
+              "$type": "color",
+              "$value": "{color.text.onStrong.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "border": {
+              "$type": "color",
+              "$value": "{color.transparent}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "small": {
+          "paddingX": {
+            "$type": "number",
+            "$value": "{static.spacing.5xsmall}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "paddingY": {
+            "$type": "number",
+            "$value": 0,
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "borderRadius": {
+            "$type": "number",
+            "$value": "{static.radius.full}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "critical": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.icon.critical.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "textColor": {
+              "$type": "color",
+              "$value": "{color.text.onStrong.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "border": {
+              "$type": "color",
+              "$value": "{color.transparent}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "dot": {
+        "default": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.background.neutral.xstrong.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "small": {
+          "width": {
+            "$type": "number",
+            "$value": 9,
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "height": {
+            "$type": "number",
+            "$value": 9,
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "critical": {
+          "rest": {
+            "background": {
+              "$type": "color",
+              "$value": "{color.icon.critical.DEFAULT.REST}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
+              }
             }
           }
         }
@@ -13694,6 +13678,26 @@
                 "hiddenFromPublishing": false,
                 "scopes": ["ALL_SCOPES"],
                 "codeSyntax": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "switch": {
+      "default": {
+        "medium": {
+          "track": {
+            "paddingX": {
+              "$type": "number",
+              "$value": "{static.spacing.hair}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"],
+                  "codeSyntax": {}
+                }
               }
             }
           }

--- a/design-tokens/tokens/primitive/primitives.default.json
+++ b/design-tokens/tokens/primitive/primitives.default.json
@@ -978,6 +978,18 @@
             }
           }
         },
+        "opacity50": {
+          "$type": "color",
+          "$value": "#00000080",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"],
+              "codeSyntax": {}
+            }
+          }
+        },
         "opacity72": {
           "$type": "color",
           "$value": "#000000b8",

--- a/design-tokens/tokens/semantic/color.dark.json
+++ b/design-tokens/tokens/semantic/color.dark.json
@@ -137,8 +137,24 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity12}",
+            "$value": "{base.color.black.opacity50}",
             "$description": "The background color for the overlay that sits behind modal layers.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "unknown": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.white.opacity6}",
+            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -203,22 +219,6 @@
             "$type": "color",
             "$value": "{base.color.red.800-Opacity30}",
             "$description": "Use for backgrounds communicating errors or danger.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "unknown": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.white.opacity6}",
-            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -702,6 +702,34 @@
       "heading": {
         "DEFAULT": {
           "REST": {
+            "$type": "color",
+            "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "anchor": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "hover": {
             "$type": "color",
             "$value": "{color.text.strong.REST}",
             "$description": "Text color for headings.",

--- a/design-tokens/tokens/semantic/color.light.json
+++ b/design-tokens/tokens/semantic/color.light.json
@@ -137,8 +137,24 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity12}",
+            "$value": "{base.color.black.opacity50}",
             "$description": "The background color for the overlay that sits behind modal layers.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "unknown": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.black.opacity4}",
+            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -203,22 +219,6 @@
             "$type": "color",
             "$value": "{base.color.red.500-Opacity24}",
             "$description": "Use for backgrounds communicating errors or danger.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "unknown": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.black.opacity4}",
-            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -702,6 +702,34 @@
       "heading": {
         "DEFAULT": {
           "REST": {
+            "$type": "color",
+            "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "anchor": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "hover": {
             "$type": "color",
             "$value": "{color.text.strong.REST}",
             "$description": "Text color for headings.",

--- a/design-tokens/tokens/semantic/color.v1-dark.json
+++ b/design-tokens/tokens/semantic/color.v1-dark.json
@@ -149,6 +149,22 @@
           }
         }
       },
+      "unknown": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.white.opacity6}",
+            "$description": "Use for backgrounds communicating an unknown status.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
       "warning": {
         "DEFAULT": {
           "REST": {
@@ -203,22 +219,6 @@
             "$type": "color",
             "$value": "{base.color.red.800-Opacity30}",
             "$description": "Use for backgrounds communicating errors or danger.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "unknown": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.white.opacity6}",
-            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -704,6 +704,34 @@
           "REST": {
             "$type": "color",
             "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "anchor": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{color.text.primary.DEFAULT.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "hover": {
+            "$type": "color",
+            "$value": "{color.text.primary.DEFAULT.hover}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {

--- a/design-tokens/tokens/semantic/color.v1-light.json
+++ b/design-tokens/tokens/semantic/color.v1-light.json
@@ -149,6 +149,22 @@
           }
         }
       },
+      "unknown": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{base.color.black.opacity4}",
+            "$description": "Use for backgrounds communicating an unknown status.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
       "warning": {
         "DEFAULT": {
           "REST": {
@@ -203,22 +219,6 @@
             "$type": "color",
             "$value": "{base.color.red.500-Opacity12}",
             "$description": "Use for backgrounds communicating errors or danger.",
-            "$extensions": {
-              "com.figma": {
-                "hiddenFromPublishing": false,
-                "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                "codeSyntax": {}
-              }
-            }
-          }
-        }
-      },
-      "unknown": {
-        "DEFAULT": {
-          "REST": {
-            "$type": "color",
-            "$value": "{base.color.black.opacity4}",
-            "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
                 "hiddenFromPublishing": false,
@@ -704,6 +704,34 @@
           "REST": {
             "$type": "color",
             "$value": "{color.text.strong.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "anchor": {
+        "DEFAULT": {
+          "REST": {
+            "$type": "color",
+            "$value": "{color.text.primary.DEFAULT.REST}",
+            "$description": "Text color for headings.",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "hover": {
+            "$type": "color",
+            "$value": "{color.text.primary.DEFAULT.hover}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7829,13 +7829,13 @@ graphlib@^2.1.5:
     lodash "^4.17.15"
 
 grommet-icons@^4.12.3:
-  version "4.12.3"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.12.3.tgz#75f3e1ef68f25dee8dbeaa433de70db4f624fd2a"
-  integrity sha512-4v4KG7OE66oOWnGgjZYrnNd9jORwgWpvRKCS0GqOEswqtlXcArEGgUrEgM/nVyvL/tKxac9MTXHzMnjy0/E9ZQ==
+  version "4.12.4"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.12.4.tgz#23d2d994ca666197f3132e4b02edc11b39a1cc84"
+  integrity sha512-LB2u1X7B22wq6ib0DUPhdXmiYXvkg+Xx3eP1tVrKGqhfk+tTkX0nDyK7wFhH+7fvj2ebWjJMYia6G0zH1voGOw==
 
 "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
-  version "4.12.3"
-  resolved "https://github.com/grommet/grommet-icons/tarball/stable#67f55c85c94e4ca4ca06898f4074b401f0585fdc"
+  version "4.12.4"
+  resolved "https://github.com/grommet/grommet-icons/tarball/stable#67839aebf5b804c9a4a82db82ebec86d40d04680"
 
 grommet-theme-hpe@5.7.0:
   version "5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,7 +7828,7 @@ graphlib@^2.1.5:
   dependencies:
     lodash "^4.17.15"
 
-grommet-icons@^4.12.3:
+grommet-icons@^4.12.4:
   version "4.12.4"
   resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.12.4.tgz#23d2d994ca666197f3132e4b02edc11b39a1cc84"
   integrity sha512-LB2u1X7B22wq6ib0DUPhdXmiYXvkg+Xx3eP1tVrKGqhfk+tTkX0nDyK7wFhH+7fvj2ebWjJMYia6G0zH1voGOw==
@@ -7844,10 +7844,10 @@ grommet-theme-hpe@5.7.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.45.0"
-  resolved "https://github.com/grommet/grommet/tarball/stable#609276966a06c506ab1a54754a288839e4630539"
+  resolved "https://github.com/grommet/grommet/tarball/stable#52b33e24612aa7bbbc6deb3a7abbc5cd787e0299"
   dependencies:
     "@emotion/is-prop-valid" "^1.3.1"
-    grommet-icons "^4.12.3"
+    grommet-icons "^4.12.4"
     hoist-non-react-statics "^3.3.2"
     markdown-to-jsx "7.4.4"
     prop-types "^15.8.1"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- Fixes background-screenOverlay to align to current v5 grommet-theme-hpe
- Adds `color-text-anchor`, `color-text-anchor-hover` to semantic set and references them by component tokens
- Found a couple instance where "disabled" state was not structure as `disabled.rest`. Updated and audited all components for consistency.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
