### PR TITLE
Swap default mode, rename opt-out mode to v0

### DIFF
--- a/.changeset/warm-pigs-doubt.md
+++ b/.changeset/warm-pigs-doubt.md
@@ -1,0 +1,5 @@
+---
+"hpe-design-tokens": major
+---
+
+- Updated design token values to reflect new theme.

--- a/design-tokens/src/scripts/build-style-dictionary.js
+++ b/design-tokens/src/scripts/build-style-dictionary.js
@@ -204,7 +204,7 @@ try {
 const colorModeFiles = fs
   .readdirSync(`${TOKENS_DIR}/semantic`)
   .map(file =>
-    file.includes('color') && !file.includes('v1')
+    file.includes('color') && !file.includes('v0')
       ? `${TOKENS_DIR}/semantic/${file}`
       : undefined,
   )
@@ -319,7 +319,7 @@ try {
 const dimensionFiles = fs
   .readdirSync(`${TOKENS_DIR}/semantic`)
   .map(file =>
-    file.includes('dimension') && !file.includes('v1')
+    file.includes('dimension') && !file.includes('v0')
       ? `${TOKENS_DIR}/semantic/${file}`
       : undefined,
   )

--- a/design-tokens/tokens/component/component.default.json
+++ b/design-tokens/tokens/component/component.default.json
@@ -53,7 +53,7 @@
           },
           "borderWidth": {
             "$type": "number",
-            "$value": "{static.borderWidth.xsmall}",
+            "$value": "{static.borderWidth.default}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -656,7 +656,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{button.default.rest.borderColor}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -692,7 +692,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{fontWeight.bold}",
+          "$value": "{fontWeight.semibold}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -782,7 +782,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{button.primary.rest.borderColor}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -833,7 +833,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.background}",
+            "$value": "{color.background.primary.xstrong.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -845,7 +845,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.borderColor}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -857,7 +857,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.textColor}",
+            "$value": "{color.text.onPrimaryStrong.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -869,7 +869,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.iconColor}",
+            "$value": "{color.icon.onPrimaryStrong.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -895,7 +895,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.background}",
+            "$value": "{color.background.primary.xstrong.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -907,7 +907,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.borderColor}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -919,7 +919,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.textColor}",
+            "$value": "{color.text.onPrimaryStrong.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -931,7 +931,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.iconColor}",
+            "$value": "{color.icon.onPrimaryStrong.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2000,7 +2000,7 @@
       "rest": {
         "background": {
           "$type": "color",
-          "$value": "{button.default.rest.background}",
+          "$value": "{color.background.contrast.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2012,7 +2012,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.background.primary.strong.REST}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2024,7 +2024,7 @@
         },
         "textColor": {
           "$type": "color",
-          "$value": "{button.default.rest.textColor}",
+          "$value": "{color.text.primary.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2036,7 +2036,7 @@
         },
         "iconColor": {
           "$type": "color",
-          "$value": "{button.default.rest.iconColor}",
+          "$value": "{color.icon.primary.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2048,7 +2048,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{button.default.rest.fontWeight}",
+          "$value": "{fontWeight.medium}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2062,7 +2062,7 @@
       "hover": {
         "background": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.background.contrast.DEFAULT.hover}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2074,7 +2074,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{base.color.green.700}",
+          "$value": "{button.secondary.rest.borderColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2137,7 +2137,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.border.disabled.DEFAULT.REST}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2189,7 +2189,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.background}",
+            "$value": "{color.background.selected.primary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2201,7 +2201,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.borderColor}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2213,7 +2213,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2225,7 +2225,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2237,7 +2237,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.secondary.rest.fontWeight}",
+            "$value": "{fontWeight.semibold}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2251,7 +2251,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.background}",
+            "$value": "{color.background.selected.primary.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2263,7 +2263,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.borderColor}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2275,7 +2275,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2287,7 +2287,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.hover.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2299,7 +2299,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.secondary.rest.fontWeight}",
+            "$value": "{fontWeight.semibold}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2742,7 +2742,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": 4,
+          "$value": "{element.medium.paddingY}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2766,7 +2766,7 @@
         },
         "borderWidth": {
           "$type": "number",
-          "$value": "{static.borderWidth.small}",
+          "$value": "{button.default.medium.borderWidth}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2839,7 +2839,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": 7,
+            "$value": 8,
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2950,7 +2950,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": 8,
+          "$value": 9,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2974,7 +2974,7 @@
         },
         "borderWidth": {
           "$type": "number",
-          "$value": "{static.borderWidth.small}",
+          "$value": "{button.default.large.borderWidth}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3131,7 +3131,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": 11,
+            "$value": 12,
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3243,7 +3243,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": 22,
+            "$value": 23,
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3268,7 +3268,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": 19,
+          "$value": 20,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3292,7 +3292,7 @@
         },
         "borderWidth": {
           "$type": "number",
-          "$value": "{static.borderWidth.small}",
+          "$value": "{button.default.xlarge.borderWidth}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3404,7 +3404,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{fontWeight.semibold}",
+          "$value": "{fontWeight.medium}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3419,7 +3419,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.rest.background}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3431,7 +3431,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.rest.borderColor}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3569,7 +3569,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.rest.textColor}",
+            "$value": "{color.text.primary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3581,7 +3581,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.rest.iconColor}",
+            "$value": "{color.icon.primary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3593,7 +3593,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.default.rest.fontWeight}",
+            "$value": "{fontWeight.semibold}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3607,7 +3607,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.active}",
+            "$value": "{color.background.contrast.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3619,7 +3619,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.selected.rest.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3631,7 +3631,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.rest.textColor}",
+            "$value": "{button.default.selected.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3643,7 +3643,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.rest.iconColor}",
+            "$value": "{button.default.selected.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3655,7 +3655,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.default.rest.fontWeight}",
+            "$value": "{button.default.selected.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4724,7 +4724,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.border.default.REST}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4736,7 +4736,7 @@
         },
         "textColor": {
           "$type": "color",
-          "$value": "{button.default.rest.textColor}",
+          "$value": "{color.text.default.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4748,7 +4748,7 @@
         },
         "iconColor": {
           "$type": "color",
-          "$value": "{button.default.rest.iconColor}",
+          "$value": "{color.icon.default.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4760,7 +4760,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{button.default.rest.fontWeight}",
+          "$value": "{fontWeight.medium}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4822,7 +4822,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{button.default.rest.fontWeight}",
+          "$value": "{button.toolbar.rest.fontWeight}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4837,7 +4837,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.disabled.DEFAULT.REST}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4885,7 +4885,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.default.rest.fontWeight}",
+            "$value": "{button.toolbar.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4901,7 +4901,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.background}",
+            "$value": "{color.background.selected.primary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4913,7 +4913,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.border.default.REST}",
+            "$value": "{color.border.selected.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4925,7 +4925,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4937,7 +4937,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4949,7 +4949,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.default.rest.fontWeight}",
+            "$value": "{button.toolbar.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4963,7 +4963,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.background}",
+            "$value": "{color.background.selected.primary.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4975,7 +4975,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.borderColor}",
+            "$value": "{color.border.selected.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4987,7 +4987,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4999,7 +4999,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -5011,7 +5011,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.default.rest.fontWeight}",
+            "$value": "{button.toolbar.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6389,7 +6389,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{radius.none}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6464,7 +6464,7 @@
           "container": {
             "paddingY": {
               "$type": "number",
-              "$value": "{static.spacing.none}",
+              "$value": "{static.spacing.3xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6476,7 +6476,7 @@
             },
             "paddingX": {
               "$type": "number",
-              "$value": "{static.spacing.none}",
+              "$value": "{static.spacing.3xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6587,7 +6587,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.default.REST}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6613,7 +6613,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.default.REST}",
+            "$value": "{color.background.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6718,7 +6718,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.REST}",
+              "$value": "{color.background.selected.primary.strong.hover}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6796,7 +6796,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.REST}",
+              "$value": "{color.background.selected.primary.strong.hover}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6849,7 +6849,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.medium}",
+            "$value": "{fontWeight.regular}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -7047,7 +7047,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xxsmall}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -7068,7 +7068,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.default.REST}",
+              "$value": "{color.decorative.neutral.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7080,7 +7080,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.border.default.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7094,7 +7094,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.default.REST}",
+              "$value": "{color.decorative.neutral.DEFAULT.hover}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7106,7 +7106,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.border.strong.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7121,7 +7121,7 @@
             "rest": {
               "background": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.background.disabled.DEFAULT.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7133,7 +7133,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.disabled.DEFAULT.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7161,7 +7161,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.default.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7175,7 +7175,7 @@
             "hover": {
               "background": {
                 "$type": "color",
-                "$value": "{color.background.selected.primary.strong.REST}",
+                "$value": "{color.background.selected.primary.strong.hover}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7187,7 +7187,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.strong.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7216,7 +7216,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.border.default.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7254,7 +7254,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.border.default.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7293,7 +7293,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.disabled.DEFAULT.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7333,7 +7333,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.default.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7371,7 +7371,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.default.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7413,7 +7413,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.medium}",
+            "$value": "{fontWeight.regular}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -7626,7 +7626,7 @@
           "handle": {
             "height": {
               "$type": "number",
-              "$value": "{base.dimension.600}",
+              "$value": "{base.dimension.500}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7638,7 +7638,7 @@
             },
             "width": {
               "$type": "number",
-              "$value": "{base.dimension.600}",
+              "$value": "{base.dimension.500}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7685,7 +7685,7 @@
             "item": {
               "paddingX": {
                 "$type": "number",
-                "$value": "{static.spacing.xsmall}",
+                "$value": "{static.spacing.xxsmall}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7733,7 +7733,7 @@
               },
               "borderRadius": {
                 "$type": "number",
-                "$value": "{radius.none}",
+                "$value": "{radius.xsmall}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7783,7 +7783,7 @@
               },
               "paddingY": {
                 "$type": "number",
-                "$value": "{static.spacing.3xsmall}",
+                "$value": "{static.spacing.none}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7795,7 +7795,7 @@
               },
               "borderWidth": {
                 "$type": "number",
-                "$value": "{borderWidth.default}",
+                "$value": "{static.borderWidth.none}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7858,7 +7858,7 @@
             },
             "borderRadius": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{static.radius.small}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -8123,7 +8123,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.medium}",
+            "$value": "{fontWeight.regular}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8153,7 +8153,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{formField.default.input.container.rest.borderColor}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -8455,7 +8455,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.strong.REST}",
+                "$value": "{color.border.critical.DEFAULT.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -8471,7 +8471,7 @@
             "rest": {
               "background": {
                 "$type": "color",
-                "$value": "{color.background.disabled.DEFAULT.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -8622,7 +8622,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.strong.REST}",
+              "$value": "{color.icon.disabled.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -8913,7 +8913,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.default.REST}",
+            "$value": "{color.icon.critical.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8927,7 +8927,7 @@
         "hover": {
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.default.REST}",
+            "$value": "{color.icon.critical.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8955,7 +8955,7 @@
         "rest": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.default.REST}",
+            "$value": "{color.text.strong.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8969,7 +8969,7 @@
         "hover": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.default.REST}",
+            "$value": "{color.text.strong.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8984,7 +8984,7 @@
           "rest": {
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.default.REST}",
+              "$value": "{color.text.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -9016,7 +9016,7 @@
           "rest": {
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.default.REST}",
+              "$value": "{color.text.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -9060,7 +9060,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.border.weak.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -9189,7 +9189,7 @@
         "rest": {
           "textColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9201,7 +9201,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9225,7 +9225,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.DEFAULT.active}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9239,7 +9239,7 @@
         "hover": {
           "textColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9251,7 +9251,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9275,7 +9275,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.contrast.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9452,7 +9452,7 @@
         },
         "paddingTop": {
           "$type": "number",
-          "$value": "{static.spacing.3xsmall}",
+          "$value": "{static.spacing.xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -9464,7 +9464,7 @@
         },
         "paddingBottom": {
           "$type": "number",
-          "$value": 5,
+          "$value": 11,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -9731,7 +9731,7 @@
         "rest": {
           "textColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9743,7 +9743,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9767,7 +9767,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.DEFAULT.active}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9781,7 +9781,7 @@
         "hover": {
           "textColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.textColor}",
+            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9793,7 +9793,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{dataCell.default.rest.iconColor}",
+            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9817,7 +9817,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.contrast.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -10662,7 +10662,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.default.REST}",
+              "$value": "{color.background.selected.primary.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10674,7 +10674,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.border.selected.DEFAULT.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10686,7 +10686,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.decorative.brand.DEFAULT.REST}",
+              "$value": "{color.icon.onSelectedPrimaryStrong.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10700,7 +10700,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.default.REST}",
+              "$value": "{color.background.selected.primary.strong.hover}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10712,7 +10712,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.border.selected.DEFAULT.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10724,7 +10724,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.decorative.brand.DEFAULT.REST}",
+              "$value": "{color.icon.onSelectedPrimaryStrong.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10753,7 +10753,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.medium}",
+            "$value": "{fontWeight.regular}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -11705,7 +11705,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.none}",
+            "$value": "{radius.full}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -11819,7 +11819,7 @@
               },
               "borderRadius": {
                 "$type": "number",
-                "$value": "{static.radius.none}",
+                "$value": "{static.radius.full}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -13054,7 +13054,7 @@
       "track": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.contrast.DEFAULT.REST}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13472,7 +13472,7 @@
       "track": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.neutral.xstrong.REST}",
+          "$value": "{color.background.contrast.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13513,7 +13513,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": 0,
+            "$value": "{static.radius.full}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -13539,7 +13539,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{radius.none}",
+            "$value": "{static.radius.full}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -13690,7 +13690,7 @@
           "track": {
             "paddingX": {
               "$type": "number",
-              "$value": "{static.spacing.none}",
+              "$value": "{static.spacing.hair}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -13746,7 +13746,7 @@
       "hover": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.DEFAULT.hover}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13823,7 +13823,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.hover}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -13952,7 +13952,7 @@
         },
         "paddingX": {
           "$type": "number",
-          "$value": "{element.medium.paddingX.narrow}",
+          "$value": "{static.spacing.none}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13964,7 +13964,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": "{element.medium.paddingY}",
+          "$value": "{static.spacing.none}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13988,7 +13988,7 @@
         },
         "height": {
           "$type": "number",
-          "$value": "{element.medium.height}",
+          "$value": "{base.dimension.450}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14000,7 +14000,7 @@
         },
         "width": {
           "$type": "number",
-          "$value": "{element.medium.width}",
+          "$value": "{base.dimension.450}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14037,7 +14037,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{spacing.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14141,7 +14141,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14153,7 +14153,7 @@
           },
           "border": {
             "$type": "color",
-            "$value": "{color.border.weak.REST}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14204,7 +14204,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.background.selected.primary.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14216,7 +14216,7 @@
             },
             "border": {
               "$type": "color",
-              "$value": "{color.border.selected.DEFAULT.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14228,7 +14228,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.strong.REST}",
+              "$value": "{color.text.onSelectedPrimaryStrong.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14240,7 +14240,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.strong.REST}",
+              "$value": "{color.icon.onSelectedPrimaryStrong.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14266,7 +14266,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.background.selected.primary.strong.hover}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14278,7 +14278,7 @@
             },
             "border": {
               "$type": "color",
-              "$value": "{color.border.selected.DEFAULT.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14290,7 +14290,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.strong.REST}",
+              "$value": "{color.text.onSelectedPrimaryStrong.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14302,7 +14302,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.strong.REST}",
+              "$value": "{color.text.onSelectedPrimaryStrong.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14406,7 +14406,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{color.border.weak.REST}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14433,7 +14433,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{radius.none}",
+            "$value": "{radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14530,7 +14530,7 @@
           "selected": {
             "borderWidth": {
               "$type": "number",
-              "$value": "{borderWidth.medium}",
+              "$value": "{borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14569,7 +14569,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{spacing.none}",
+            "$value": "{spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14774,7 +14774,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.full}",
+          "$value": "{radius.xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14846,7 +14846,7 @@
         },
         "edgeToElement": {
           "$type": "number",
-          "$value": "{static.spacing.3xsmall}",
+          "$value": "{static.spacing.none}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14859,7 +14859,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{button.default.xsmall.borderRadius}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14875,7 +14875,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{button.default.small.borderRadius}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14900,7 +14900,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.full}",
+          "$value": "{radius.xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14972,7 +14972,7 @@
         },
         "edgeToElement": {
           "$type": "number",
-          "$value": "{static.spacing.3xsmall}",
+          "$value": "{static.spacing.hair}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14998,7 +14998,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.full}",
+          "$value": "{radius.xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15022,7 +15022,7 @@
         },
         "paddingX": {
           "$type": "number",
-          "$value": "{element.medium.paddingX.wide}",
+          "$value": "{element.medium.paddingX.default}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15070,7 +15070,7 @@
         },
         "edgeToElement": {
           "$type": "number",
-          "$value": "{static.spacing.3xsmall}",
+          "$value": "{static.spacing.5xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15083,7 +15083,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{button.default.medium.borderRadius}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15111,7 +15111,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{button.default.large.borderRadius}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15124,7 +15124,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.full}",
+          "$value": "{radius.xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15222,7 +15222,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.full}",
+          "$value": "{radius.medium}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15307,7 +15307,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{button.default.xlarge.borderRadius}",
+            "$value": "{static.radius.medium}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15362,7 +15362,7 @@
       "hover": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.DEFAULT.hover}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15439,7 +15439,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.hover}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15568,7 +15568,7 @@
         },
         "paddingX": {
           "$type": "number",
-          "$value": "{element.medium.paddingX.narrow}",
+          "$value": "{static.spacing.none}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15580,7 +15580,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": "{element.medium.paddingY}",
+          "$value": "{static.spacing.none}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15604,7 +15604,7 @@
         },
         "height": {
           "$type": "number",
-          "$value": "{element.medium.height}",
+          "$value": "{base.dimension.450}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15616,7 +15616,7 @@
         },
         "width": {
           "$type": "number",
-          "$value": "{element.medium.width}",
+          "$value": "{base.dimension.450}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15653,7 +15653,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{static.spacing.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15799,7 +15799,7 @@
           },
           "border": {
             "$type": "color",
-            "$value": "{color.border.default.REST}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15861,7 +15861,7 @@
           },
           "border": {
             "$type": "color",
-            "$value": "{color.border.default.REST}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15912,7 +15912,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.DEFAULT.active}",
+              "$value": "{color.background.selected.primary.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -15924,7 +15924,7 @@
             },
             "border": {
               "$type": "color",
-              "$value": "{color.border.default.REST}",
+              "$value": "{color.border.selected.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16052,7 +16052,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{color.border.default.REST}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -16068,7 +16068,7 @@
           "first": {
             "borderWidthLeft": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16092,7 +16092,7 @@
             },
             "borderWidthTop": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16104,7 +16104,7 @@
             },
             "borderWidthBottom": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16140,7 +16140,7 @@
             },
             "borderRadiusTopRight": {
               "$type": "number",
-              "$value": "{radius.none}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16152,7 +16152,7 @@
             },
             "borderRadiusBottomRight": {
               "$type": "number",
-              "$value": "{radius.none}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16250,7 +16250,7 @@
           "middle": {
             "borderWidthLeft": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16274,7 +16274,7 @@
             },
             "borderWidthTop": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16286,7 +16286,7 @@
             },
             "borderWidthBottom": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16298,7 +16298,7 @@
             },
             "borderRadius": {
               "$type": "number",
-              "$value": "{radius.none}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16396,7 +16396,7 @@
           "last": {
             "borderWidthLeft": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{borderWidth.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16408,7 +16408,7 @@
             },
             "borderWidthRight": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16420,7 +16420,7 @@
             },
             "borderWidthTop": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16432,7 +16432,7 @@
             },
             "borderWidthBottom": {
               "$type": "number",
-              "$value": "{static.borderWidth.none}",
+              "$value": "{static.borderWidth.default}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16468,7 +16468,7 @@
             },
             "borderRadiusTopLeft": {
               "$type": "number",
-              "$value": "{radius.none}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16480,7 +16480,7 @@
             },
             "borderRadiusBottomLeft": {
               "$type": "number",
-              "$value": "{radius.none}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16579,7 +16579,7 @@
         "group": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{borderWidth.xsmall}",
+            "$value": "{static.borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -16603,7 +16603,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{spacing.none}",
+            "$value": "{static.spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -16806,7 +16806,7 @@
             },
             "borderRadius": {
               "$type": "number",
-              "$value": "{static.radius.none}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17047,7 +17047,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{static.spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17059,7 +17059,7 @@
           },
           "gapY": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{static.spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17203,7 +17203,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.none}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17230,7 +17230,7 @@
           "Container": {
             "paddingX": {
               "$type": "number",
-              "$value": "{static.spacing.3xsmall}",
+              "$value": "{static.spacing.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17242,7 +17242,7 @@
             },
             "paddingY": {
               "$type": "number",
-              "$value": "{static.spacing.3xsmall}",
+              "$value": "{static.spacing.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17390,7 +17390,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.onWarning.DEFAULT.REST}",
+              "$value": "{color.text.onWarning.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17522,7 +17522,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.unknown.DEFAULT.REST}",
+              "$value": "{color.background.info.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17573,7 +17573,7 @@
         "medium": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{borderWidth.none}",
+            "$value": "{static.borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17728,7 +17728,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.onWarning.DEFAULT.REST}",
+              "$value": "{color.text.onWarning.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17808,7 +17808,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.unknown.DEFAULT.REST}",
+              "$value": "{color.background.info.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17859,7 +17859,7 @@
         "medium": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{borderWidth.none}",
+            "$value": "{static.borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18141,7 +18141,7 @@
         "medium": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{borderWidth.none}",
+            "$value": "{static.borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18257,7 +18257,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.none}",
+            "$value": "{static.radius.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18271,7 +18271,7 @@
         "drop": {
           "paddingX": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{static.spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18283,7 +18283,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{static.spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18295,7 +18295,7 @@
           },
           "gapY": {
             "$type": "number",
-            "$value": "{static.spacing.none}",
+            "$value": "{static.spacing.3xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {

--- a/design-tokens/tokens/component/component.v0.json
+++ b/design-tokens/tokens/component/component.v0.json
@@ -53,7 +53,7 @@
           },
           "borderWidth": {
             "$type": "number",
-            "$value": "{static.borderWidth.default}",
+            "$value": "{static.borderWidth.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -656,7 +656,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{button.default.rest.borderColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -692,7 +692,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{fontWeight.semibold}",
+          "$value": "{fontWeight.bold}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -782,7 +782,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{button.primary.rest.borderColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -833,7 +833,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.primary.xstrong.REST}",
+            "$value": "{button.default.selected.rest.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -845,7 +845,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.selected.rest.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -857,7 +857,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onPrimaryStrong.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -869,7 +869,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onPrimaryStrong.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -895,7 +895,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.primary.xstrong.REST}",
+            "$value": "{button.default.selected.hover.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -907,7 +907,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.selected.hover.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -919,7 +919,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onPrimaryStrong.DEFAULT.REST}",
+            "$value": "{button.default.selected.hover.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -931,7 +931,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onPrimaryStrong.DEFAULT.REST}",
+            "$value": "{button.default.selected.hover.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2000,7 +2000,7 @@
       "rest": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.contrast.DEFAULT.REST}",
+          "$value": "{button.default.rest.background}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2012,7 +2012,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.background.primary.strong.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2024,7 +2024,7 @@
         },
         "textColor": {
           "$type": "color",
-          "$value": "{color.text.primary.DEFAULT.REST}",
+          "$value": "{button.default.rest.textColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2036,7 +2036,7 @@
         },
         "iconColor": {
           "$type": "color",
-          "$value": "{color.icon.primary.DEFAULT.REST}",
+          "$value": "{button.default.rest.iconColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2048,7 +2048,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{fontWeight.medium}",
+          "$value": "{button.default.rest.fontWeight}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2062,7 +2062,7 @@
       "hover": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.contrast.DEFAULT.hover}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2074,7 +2074,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{button.secondary.rest.borderColor}",
+          "$value": "{base.color.green.700}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2137,7 +2137,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.border.disabled.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2189,7 +2189,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.selected.primary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2201,7 +2201,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.selected.rest.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2213,7 +2213,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2225,7 +2225,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2237,7 +2237,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.semibold}",
+            "$value": "{button.secondary.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2251,7 +2251,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.selected.primary.DEFAULT.hover}",
+            "$value": "{button.default.selected.hover.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2263,7 +2263,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.selected.hover.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2275,7 +2275,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.hover.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2287,7 +2287,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.hover.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2299,7 +2299,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.semibold}",
+            "$value": "{button.secondary.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2742,7 +2742,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": "{element.medium.paddingY}",
+          "$value": 4,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2766,7 +2766,7 @@
         },
         "borderWidth": {
           "$type": "number",
-          "$value": "{button.default.medium.borderWidth}",
+          "$value": "{static.borderWidth.small}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2839,7 +2839,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": 8,
+            "$value": 7,
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -2950,7 +2950,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": 9,
+          "$value": 8,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -2974,7 +2974,7 @@
         },
         "borderWidth": {
           "$type": "number",
-          "$value": "{button.default.large.borderWidth}",
+          "$value": "{static.borderWidth.small}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3268,7 +3268,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": 20,
+          "$value": 19,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3292,7 +3292,7 @@
         },
         "borderWidth": {
           "$type": "number",
-          "$value": "{button.default.xlarge.borderWidth}",
+          "$value": "{static.borderWidth.small}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3404,7 +3404,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{fontWeight.medium}",
+          "$value": "{fontWeight.semibold}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -3419,7 +3419,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.rest.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3431,7 +3431,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{button.default.rest.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3569,7 +3569,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.primary.DEFAULT.REST}",
+            "$value": "{button.default.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3581,7 +3581,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.primary.DEFAULT.REST}",
+            "$value": "{button.default.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3593,7 +3593,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.semibold}",
+            "$value": "{button.default.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3607,7 +3607,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.contrast.DEFAULT.hover}",
+            "$value": "{color.background.DEFAULT.active}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3619,7 +3619,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.borderColor}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3631,7 +3631,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.textColor}",
+            "$value": "{button.default.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3643,7 +3643,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{button.default.selected.rest.iconColor}",
+            "$value": "{button.default.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -3655,7 +3655,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.default.selected.rest.fontWeight}",
+            "$value": "{button.default.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4724,7 +4724,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.border.default.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4736,7 +4736,7 @@
         },
         "textColor": {
           "$type": "color",
-          "$value": "{color.text.default.REST}",
+          "$value": "{button.default.rest.textColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4748,7 +4748,7 @@
         },
         "iconColor": {
           "$type": "color",
-          "$value": "{color.icon.default.REST}",
+          "$value": "{button.default.rest.iconColor}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4760,7 +4760,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{fontWeight.medium}",
+          "$value": "{button.default.rest.fontWeight}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4822,7 +4822,7 @@
         },
         "fontWeight": {
           "$type": "number",
-          "$value": "{button.toolbar.rest.fontWeight}",
+          "$value": "{button.default.rest.fontWeight}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4837,7 +4837,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.disabled.DEFAULT.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4885,7 +4885,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.toolbar.rest.fontWeight}",
+            "$value": "{button.default.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4901,7 +4901,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.selected.primary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4913,7 +4913,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.border.selected.DEFAULT.REST}",
+            "$value": "{color.border.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4925,7 +4925,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4937,7 +4937,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4949,7 +4949,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.toolbar.rest.fontWeight}",
+            "$value": "{button.default.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4963,7 +4963,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.selected.primary.DEFAULT.hover}",
+            "$value": "{button.default.selected.rest.background}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4975,7 +4975,7 @@
           },
           "borderColor": {
             "$type": "color",
-            "$value": "{color.border.selected.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.borderColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4987,7 +4987,7 @@
           },
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -4999,7 +4999,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{button.default.selected.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -5011,7 +5011,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{button.toolbar.rest.fontWeight}",
+            "$value": "{button.default.rest.fontWeight}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6389,7 +6389,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{radius.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6464,7 +6464,7 @@
           "container": {
             "paddingY": {
               "$type": "number",
-              "$value": "{static.spacing.3xsmall}",
+              "$value": "{static.spacing.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6476,7 +6476,7 @@
             },
             "paddingX": {
               "$type": "number",
-              "$value": "{static.spacing.3xsmall}",
+              "$value": "{static.spacing.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6587,7 +6587,7 @@
         "rest": {
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6613,7 +6613,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.hover}",
+            "$value": "{color.background.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -6718,7 +6718,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.hover}",
+              "$value": "{color.background.selected.primary.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6796,7 +6796,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.hover}",
+              "$value": "{color.background.selected.primary.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -6849,7 +6849,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.regular}",
+            "$value": "{fontWeight.medium}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -7047,7 +7047,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{static.radius.xxsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -7068,7 +7068,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.decorative.neutral.DEFAULT.REST}",
+              "$value": "{color.background.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7080,7 +7080,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7094,7 +7094,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.decorative.neutral.DEFAULT.hover}",
+              "$value": "{color.background.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7106,7 +7106,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7121,7 +7121,7 @@
             "rest": {
               "background": {
                 "$type": "color",
-                "$value": "{color.background.disabled.DEFAULT.REST}",
+                "$value": "{color.transparent}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7133,7 +7133,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.border.disabled.DEFAULT.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7161,7 +7161,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.border.default.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7175,7 +7175,7 @@
             "hover": {
               "background": {
                 "$type": "color",
-                "$value": "{color.background.selected.primary.strong.hover}",
+                "$value": "{color.background.selected.primary.strong.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7187,7 +7187,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.border.strong.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7216,7 +7216,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7254,7 +7254,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7293,7 +7293,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.border.disabled.DEFAULT.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7333,7 +7333,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.border.default.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7371,7 +7371,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.border.default.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7413,7 +7413,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.regular}",
+            "$value": "{fontWeight.medium}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -7626,7 +7626,7 @@
           "handle": {
             "height": {
               "$type": "number",
-              "$value": "{base.dimension.500}",
+              "$value": "{base.dimension.600}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7638,7 +7638,7 @@
             },
             "width": {
               "$type": "number",
-              "$value": "{base.dimension.500}",
+              "$value": "{base.dimension.600}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -7685,7 +7685,7 @@
             "item": {
               "paddingX": {
                 "$type": "number",
-                "$value": "{static.spacing.xxsmall}",
+                "$value": "{static.spacing.xsmall}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7733,7 +7733,7 @@
               },
               "borderRadius": {
                 "$type": "number",
-                "$value": "{radius.xsmall}",
+                "$value": "{radius.none}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7783,7 +7783,7 @@
               },
               "paddingY": {
                 "$type": "number",
-                "$value": "{static.spacing.none}",
+                "$value": "{static.spacing.3xsmall}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7795,7 +7795,7 @@
               },
               "borderWidth": {
                 "$type": "number",
-                "$value": "{static.borderWidth.none}",
+                "$value": "{borderWidth.default}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -7858,7 +7858,7 @@
             },
             "borderRadius": {
               "$type": "number",
-              "$value": "{static.radius.small}",
+              "$value": "{static.radius.xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -8123,7 +8123,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.regular}",
+            "$value": "{fontWeight.medium}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8153,7 +8153,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{formField.default.input.container.rest.borderColor}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -8455,7 +8455,7 @@
               },
               "borderColor": {
                 "$type": "color",
-                "$value": "{color.border.critical.DEFAULT.REST}",
+                "$value": "{color.border.strong.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -8471,7 +8471,7 @@
             "rest": {
               "background": {
                 "$type": "color",
-                "$value": "{color.transparent}",
+                "$value": "{color.background.disabled.DEFAULT.REST}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -8622,7 +8622,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.disabled.DEFAULT.REST}",
+              "$value": "{color.icon.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -8913,7 +8913,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.critical.DEFAULT.REST}",
+            "$value": "{color.icon.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8927,7 +8927,7 @@
         "hover": {
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.critical.DEFAULT.REST}",
+            "$value": "{color.icon.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8955,7 +8955,7 @@
         "rest": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{color.text.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8969,7 +8969,7 @@
         "hover": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{color.text.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -8984,7 +8984,7 @@
           "rest": {
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.strong.REST}",
+              "$value": "{color.text.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -9016,7 +9016,7 @@
           "rest": {
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.strong.REST}",
+              "$value": "{color.text.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -9060,7 +9060,7 @@
         },
         "borderColor": {
           "$type": "color",
-          "$value": "{color.border.weak.REST}",
+          "$value": "{color.transparent}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -9189,7 +9189,7 @@
         "rest": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9201,7 +9201,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9225,7 +9225,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.active}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9239,7 +9239,7 @@
         "hover": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9251,7 +9251,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9275,7 +9275,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.background.contrast.DEFAULT.hover}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9452,7 +9452,7 @@
         },
         "paddingTop": {
           "$type": "number",
-          "$value": "{static.spacing.xsmall}",
+          "$value": "{static.spacing.3xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -9464,7 +9464,7 @@
         },
         "paddingBottom": {
           "$type": "number",
-          "$value": 11,
+          "$value": 5,
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -9731,7 +9731,7 @@
         "rest": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9743,7 +9743,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9767,7 +9767,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.active}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9781,7 +9781,7 @@
         "hover": {
           "textColor": {
             "$type": "color",
-            "$value": "{color.text.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.textColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9793,7 +9793,7 @@
           },
           "iconColor": {
             "$type": "color",
-            "$value": "{color.icon.onSelectedPrimary.DEFAULT.REST}",
+            "$value": "{dataCell.default.rest.iconColor}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -9817,7 +9817,7 @@
           },
           "background": {
             "$type": "color",
-            "$value": "{color.background.contrast.DEFAULT.hover}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -10662,7 +10662,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.REST}",
+              "$value": "{color.background.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10674,7 +10674,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.selected.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10686,7 +10686,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.onSelectedPrimaryStrong.DEFAULT.REST}",
+              "$value": "{color.decorative.brand.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10700,7 +10700,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.hover}",
+              "$value": "{color.background.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10712,7 +10712,7 @@
             },
             "borderColor": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.selected.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10724,7 +10724,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.onSelectedPrimaryStrong.DEFAULT.REST}",
+              "$value": "{color.decorative.brand.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -10753,7 +10753,7 @@
           },
           "fontWeight": {
             "$type": "number",
-            "$value": "{fontWeight.regular}",
+            "$value": "{fontWeight.medium}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -11705,7 +11705,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{radius.full}",
+            "$value": "{static.radius.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -11819,7 +11819,7 @@
               },
               "borderRadius": {
                 "$type": "number",
-                "$value": "{static.radius.full}",
+                "$value": "{static.radius.none}",
                 "$description": "",
                 "$extensions": {
                   "com.figma": {
@@ -13054,7 +13054,7 @@
       "track": {
         "background": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.background.contrast.DEFAULT.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13472,7 +13472,7 @@
       "track": {
         "background": {
           "$type": "color",
-          "$value": "{color.background.contrast.DEFAULT.REST}",
+          "$value": "{color.background.neutral.xstrong.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13513,7 +13513,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.full}",
+            "$value": 0,
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -13539,7 +13539,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.full}",
+            "$value": "{radius.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -13690,7 +13690,7 @@
           "track": {
             "paddingX": {
               "$type": "number",
-              "$value": "{static.spacing.hair}",
+              "$value": "{static.spacing.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -13746,7 +13746,7 @@
       "hover": {
         "background": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.background.DEFAULT.hover}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13823,7 +13823,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -13952,7 +13952,7 @@
         },
         "paddingX": {
           "$type": "number",
-          "$value": "{static.spacing.none}",
+          "$value": "{element.medium.paddingX.narrow}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13964,7 +13964,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": "{static.spacing.none}",
+          "$value": "{element.medium.paddingY}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -13988,7 +13988,7 @@
         },
         "height": {
           "$type": "number",
-          "$value": "{base.dimension.450}",
+          "$value": "{element.medium.height}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14000,7 +14000,7 @@
         },
         "width": {
           "$type": "number",
-          "$value": "{base.dimension.450}",
+          "$value": "{element.medium.width}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14037,7 +14037,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{spacing.xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14141,7 +14141,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.background.DEFAULT.hover}",
+            "$value": "{color.transparent}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14153,7 +14153,7 @@
           },
           "border": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.border.weak.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14204,7 +14204,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.REST}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14216,7 +14216,7 @@
             },
             "border": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.selected.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14228,7 +14228,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.onSelectedPrimaryStrong.DEFAULT.REST}",
+              "$value": "{color.text.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14240,7 +14240,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.icon.onSelectedPrimaryStrong.DEFAULT.REST}",
+              "$value": "{color.icon.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14266,7 +14266,7 @@
           "hover": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.strong.hover}",
+              "$value": "{color.transparent}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14278,7 +14278,7 @@
             },
             "border": {
               "$type": "color",
-              "$value": "{color.transparent}",
+              "$value": "{color.border.selected.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14290,7 +14290,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.onSelectedPrimaryStrong.DEFAULT.REST}",
+              "$value": "{color.text.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14302,7 +14302,7 @@
             },
             "iconColor": {
               "$type": "color",
-              "$value": "{color.text.onSelectedPrimaryStrong.DEFAULT.REST}",
+              "$value": "{color.icon.strong.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14406,7 +14406,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.border.weak.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14433,7 +14433,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{radius.xsmall}",
+            "$value": "{radius.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14530,7 +14530,7 @@
           "selected": {
             "borderWidth": {
               "$type": "number",
-              "$value": "{borderWidth.none}",
+              "$value": "{borderWidth.medium}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -14569,7 +14569,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{spacing.3xsmall}",
+            "$value": "{spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14774,7 +14774,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.xsmall}",
+          "$value": "{radius.full}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14846,7 +14846,7 @@
         },
         "edgeToElement": {
           "$type": "number",
-          "$value": "{static.spacing.none}",
+          "$value": "{static.spacing.3xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14859,7 +14859,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{button.default.xsmall.borderRadius}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14875,7 +14875,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{button.default.small.borderRadius}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -14900,7 +14900,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.xsmall}",
+          "$value": "{radius.full}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14972,7 +14972,7 @@
         },
         "edgeToElement": {
           "$type": "number",
-          "$value": "{static.spacing.hair}",
+          "$value": "{static.spacing.3xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -14998,7 +14998,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.xsmall}",
+          "$value": "{radius.full}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15022,7 +15022,7 @@
         },
         "paddingX": {
           "$type": "number",
-          "$value": "{element.medium.paddingX.default}",
+          "$value": "{element.medium.paddingX.wide}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15070,7 +15070,7 @@
         },
         "edgeToElement": {
           "$type": "number",
-          "$value": "{static.spacing.5xsmall}",
+          "$value": "{static.spacing.3xsmall}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15083,7 +15083,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{button.default.medium.borderRadius}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15111,7 +15111,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{button.default.large.borderRadius}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15124,7 +15124,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.xsmall}",
+          "$value": "{radius.full}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15222,7 +15222,7 @@
         },
         "borderRadius": {
           "$type": "number",
-          "$value": "{radius.medium}",
+          "$value": "{radius.full}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15307,7 +15307,7 @@
         "button": {
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.medium}",
+            "$value": "{button.default.xlarge.borderRadius}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15362,7 +15362,7 @@
       "hover": {
         "background": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.background.DEFAULT.hover}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15439,7 +15439,7 @@
         "hover": {
           "background": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.background.DEFAULT.hover}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15568,7 +15568,7 @@
         },
         "paddingX": {
           "$type": "number",
-          "$value": "{static.spacing.none}",
+          "$value": "{element.medium.paddingX.narrow}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15580,7 +15580,7 @@
         },
         "paddingY": {
           "$type": "number",
-          "$value": "{static.spacing.none}",
+          "$value": "{element.medium.paddingY}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15604,7 +15604,7 @@
         },
         "height": {
           "$type": "number",
-          "$value": "{base.dimension.450}",
+          "$value": "{element.medium.height}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15616,7 +15616,7 @@
         },
         "width": {
           "$type": "number",
-          "$value": "{base.dimension.450}",
+          "$value": "{element.medium.width}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -15653,7 +15653,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{static.spacing.xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15799,7 +15799,7 @@
           },
           "border": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.border.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15861,7 +15861,7 @@
           },
           "border": {
             "$type": "color",
-            "$value": "{color.transparent}",
+            "$value": "{color.border.default.REST}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -15912,7 +15912,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.selected.primary.DEFAULT.REST}",
+              "$value": "{color.background.DEFAULT.active}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -15924,7 +15924,7 @@
             },
             "border": {
               "$type": "color",
-              "$value": "{color.border.selected.DEFAULT.REST}",
+              "$value": "{color.border.default.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16052,7 +16052,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{color.transparent}",
+          "$value": "{color.border.default.REST}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -16068,7 +16068,7 @@
           "first": {
             "borderWidthLeft": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16092,7 +16092,7 @@
             },
             "borderWidthTop": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16104,7 +16104,7 @@
             },
             "borderWidthBottom": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16140,7 +16140,7 @@
             },
             "borderRadiusTopRight": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{radius.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16152,7 +16152,7 @@
             },
             "borderRadiusBottomRight": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{radius.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16250,7 +16250,7 @@
           "middle": {
             "borderWidthLeft": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16274,7 +16274,7 @@
             },
             "borderWidthTop": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16286,7 +16286,7 @@
             },
             "borderWidthBottom": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16298,7 +16298,7 @@
             },
             "borderRadius": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{radius.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16396,7 +16396,7 @@
           "last": {
             "borderWidthLeft": {
               "$type": "number",
-              "$value": "{borderWidth.xsmall}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16408,7 +16408,7 @@
             },
             "borderWidthRight": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16420,7 +16420,7 @@
             },
             "borderWidthTop": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16432,7 +16432,7 @@
             },
             "borderWidthBottom": {
               "$type": "number",
-              "$value": "{static.borderWidth.default}",
+              "$value": "{static.borderWidth.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16468,7 +16468,7 @@
             },
             "borderRadiusTopLeft": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{radius.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16480,7 +16480,7 @@
             },
             "borderRadiusBottomLeft": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{radius.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -16579,7 +16579,7 @@
         "group": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{static.borderWidth.none}",
+            "$value": "{borderWidth.xsmall}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -16603,7 +16603,7 @@
           },
           "gapx": {
             "$type": "number",
-            "$value": "{static.spacing.3xsmall}",
+            "$value": "{spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -16806,7 +16806,7 @@
             },
             "borderRadius": {
               "$type": "number",
-              "$value": "{static.radius.xsmall}",
+              "$value": "{static.radius.none}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17047,7 +17047,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": "{static.spacing.3xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17059,7 +17059,7 @@
           },
           "gapY": {
             "$type": "number",
-            "$value": "{static.spacing.3xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17203,7 +17203,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{static.radius.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17230,7 +17230,7 @@
           "Container": {
             "paddingX": {
               "$type": "number",
-              "$value": "{static.spacing.none}",
+              "$value": "{static.spacing.3xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17242,7 +17242,7 @@
             },
             "paddingY": {
               "$type": "number",
-              "$value": "{static.spacing.none}",
+              "$value": "{static.spacing.3xsmall}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17390,7 +17390,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.onWarning.strong.REST}",
+              "$value": "{color.text.onWarning.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17522,7 +17522,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.info.DEFAULT.REST}",
+              "$value": "{color.background.unknown.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17573,7 +17573,7 @@
         "medium": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{static.borderWidth.none}",
+            "$value": "{borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -17728,7 +17728,7 @@
             },
             "textColor": {
               "$type": "color",
-              "$value": "{color.text.onWarning.strong.REST}",
+              "$value": "{color.text.onWarning.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17808,7 +17808,7 @@
           "rest": {
             "background": {
               "$type": "color",
-              "$value": "{color.background.info.DEFAULT.REST}",
+              "$value": "{color.background.unknown.DEFAULT.REST}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -17859,7 +17859,7 @@
         "medium": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{static.borderWidth.none}",
+            "$value": "{borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18141,7 +18141,7 @@
         "medium": {
           "borderWidth": {
             "$type": "number",
-            "$value": "{static.borderWidth.none}",
+            "$value": "{borderWidth.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18257,7 +18257,7 @@
           },
           "borderRadius": {
             "$type": "number",
-            "$value": "{static.radius.xsmall}",
+            "$value": "{static.radius.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18271,7 +18271,7 @@
         "drop": {
           "paddingX": {
             "$type": "number",
-            "$value": "{static.spacing.3xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18283,7 +18283,7 @@
           },
           "paddingY": {
             "$type": "number",
-            "$value": "{static.spacing.3xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -18295,7 +18295,7 @@
           },
           "gapY": {
             "$type": "number",
-            "$value": "{static.spacing.3xsmall}",
+            "$value": "{static.spacing.none}",
             "$description": "",
             "$extensions": {
               "com.figma": {

--- a/design-tokens/tokens/semantic/color.dark.json
+++ b/design-tokens/tokens/semantic/color.dark.json
@@ -137,7 +137,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity50}",
+            "$value": "{base.color.black.opacity12}",
             "$description": "The background color for the overlay that sits behind modal layers.",
             "$extensions": {
               "com.figma": {
@@ -201,7 +201,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.background.contrast.DEFAULT.REST}",
+            "$value": "{base.color.blue.400-Opacity12}",
             "$description": "Use for backgrounds communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -233,7 +233,7 @@
         "strong": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.600}",
+            "$value": "#007c60",
             "$description": "The strong variant of background-primary. Primary palette is derived from the brand color and used for high visual prominence.",
             "$extensions": {
               "com.figma": {
@@ -245,7 +245,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.green.700}",
+            "$value": "#00513f",
             "$description": "Hover variant of background-primary.",
             "$extensions": {
               "com.figma": {
@@ -276,7 +276,7 @@
           "strong": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.brand}",
+              "$value": "{color.background.primary.strong.REST}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -288,7 +288,7 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{base.color.brand}",
+              "$value": "{color.background.primary.strong.hover}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -423,7 +423,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.border.default.REST}",
+            "$value": "{color.foreground.critical.DEFAULT.REST}",
             "$description": "Use for borders communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -623,7 +623,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.default.REST}",
+            "$value": "{color.foreground.critical.DEFAULT.REST}",
             "$description": "Use for text on standard backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -719,7 +719,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{color.text.primary.DEFAULT.REST}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -731,7 +731,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{color.text.primary.DEFAULT.hover}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -1005,7 +1005,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.550}",
+            "$value": "{color.foreground.critical.DEFAULT.REST}",
             "$description": "Use for icons communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -1021,7 +1021,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.icon.default.REST}",
+            "$value": "{base.color.blue.700}",
             "$description": "Use for icons communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -1069,7 +1069,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.700}",
+            "$value": "{base.color.grey.800}",
             "$description": "Use for icons communicating unknown status.",
             "$extensions": {
               "com.figma": {
@@ -1085,7 +1085,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.600}",
+            "$value": "{base.color.green.500}",
             "$description": "High emphasis color for icons that should draw from the primary palette. Often used to highlight that interacting with a given element will result in an action.",
             "$extensions": {
               "com.figma": {
@@ -1450,7 +1450,7 @@
     },
     "focus": {
       "$type": "color",
-      "$value": "{base.color.teal.400}",
+      "$value": "#004233",
       "$description": "",
       "$extensions": {
         "com.figma": {

--- a/design-tokens/tokens/semantic/color.light.json
+++ b/design-tokens/tokens/semantic/color.light.json
@@ -137,7 +137,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity50}",
+            "$value": "{base.color.black.opacity12}",
             "$description": "The background color for the overlay that sits behind modal layers.",
             "$extensions": {
               "com.figma": {
@@ -169,7 +169,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.orange.400-Opacity24}",
+            "$value": "{base.color.orange.400-Opacity12}",
             "$description": "Use for borders communicating warning or caution.",
             "$extensions": {
               "com.figma": {
@@ -185,7 +185,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.400-Opacity24}",
+            "$value": "{base.color.green.400-Opacity12}",
             "$description": "Use for backgrounds communicating success.",
             "$extensions": {
               "com.figma": {
@@ -201,7 +201,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.background.contrast.DEFAULT.REST}",
+            "$value": "{base.color.blue.400-Opacity12}",
             "$description": "Use for backgrounds communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -217,7 +217,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.500-Opacity24}",
+            "$value": "{base.color.red.500-Opacity12}",
             "$description": "Use for backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -233,7 +233,7 @@
         "strong": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.600}",
+            "$value": "{base.color.green.700}",
             "$description": "The strong variant of background-primary. Primary palette is derived from the brand color and used for high visual prominence.",
             "$extensions": {
               "com.figma": {
@@ -245,7 +245,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.green.700}",
+            "$value": "{base.color.green.800}",
             "$description": "Hover variant of background-primary.",
             "$extensions": {
               "com.figma": {
@@ -276,7 +276,7 @@
           "strong": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.brand}",
+              "$value": "{color.background.primary.strong.REST}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -288,7 +288,7 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{base.color.brand}",
+              "$value": "{color.background.primary.strong.hover}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -407,7 +407,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.600}",
+            "$value": "{base.color.green.700}",
             "$description": "Selected border color. Used for ‘selected’ state.",
             "$extensions": {
               "com.figma": {
@@ -423,7 +423,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.border.default.REST}",
+            "$value": "{base.color.red.800}",
             "$description": "Use for borders communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -623,7 +623,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.default.REST}",
+            "$value": "{base.color.red.800}",
             "$description": "Use for text on standard backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -719,7 +719,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{color.text.primary.DEFAULT.REST}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -731,7 +731,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{color.text.primary.DEFAULT.hover}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -763,7 +763,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.strong.REST}",
+            "$value": "{base.color.green.900}",
             "$description": "Text color to be used for text sitting on non-strong variants of background-selected.",
             "$extensions": {
               "com.figma": {
@@ -1021,7 +1021,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.icon.default.REST}",
+            "$value": "{base.color.blue.900}",
             "$description": "Use for icons communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -1085,7 +1085,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.600}",
+            "$value": "{base.color.green.800}",
             "$description": "High emphasis color for icons that should draw from the primary palette. Often used to highlight that interacting with a given element will result in an action.",
             "$extensions": {
               "com.figma": {
@@ -1450,7 +1450,7 @@
     },
     "focus": {
       "$type": "color",
-      "$value": "{base.color.teal.400}",
+      "$value": "#004233",
       "$description": "",
       "$extensions": {
         "com.figma": {

--- a/design-tokens/tokens/semantic/color.v0-dark.json
+++ b/design-tokens/tokens/semantic/color.v0-dark.json
@@ -4,7 +4,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.100}",
+          "$value": "{base.color.grey.1300}",
           "$description": "Default background color to be used on containers.",
           "$extensions": {
             "com.figma": {
@@ -19,7 +19,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.50}",
+            "$value": "{base.color.grey.1300}",
             "$description": "Elevation level 0. Used for the overall page background. It creates a  backdrop for containers to sit on.",
             "$extensions": {
               "com.figma": {
@@ -35,7 +35,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.100}",
+            "$value": "{base.color.grey.1200}",
             "$description": "Elevation level 1. Lowest level of elevation for containers/surfaces that sit directly on top of the page. Example: a container that houses a data table.",
             "$extensions": {
               "com.figma": {
@@ -51,7 +51,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.100}",
+            "$value": "{base.color.grey.1100}",
             "$description": "Elevation level 2. The highest level of elevation for elements that sit above everything else. Example: drop downs, layers",
             "$extensions": {
               "com.figma": {
@@ -67,7 +67,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity4}",
+            "$value": "{base.color.white.opacity12}",
             "$description": "Use to create a subtle differentiation between a component or container and the region it sits on.",
             "$extensions": {
               "com.figma": {
@@ -79,7 +79,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.black.opacity8}",
+            "$value": "{base.color.white.opacity20}",
             "$description": "Use to create a subtle differentiation between a component or container and the region it sits on.",
             "$extensions": {
               "com.figma": {
@@ -94,7 +94,7 @@
       "DEFAULT": {
         "hover": {
           "$type": "color",
-          "$value": "{color.background.contrast.DEFAULT.REST}",
+          "$value": "{base.color.white.opacity6}",
           "$description": "Generic hover state of components that have no fill in their resting state. For example, menu items.",
           "$extensions": {
             "com.figma": {
@@ -106,7 +106,7 @@
         },
         "active": {
           "$type": "color",
-          "$value": "{color.background.DEFAULT.hover}",
+          "$value": "{base.color.white.opacity6}",
           "$description": "Standard active state color",
           "$extensions": {
             "com.figma": {
@@ -121,7 +121,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity4}",
+            "$value": "{base.color.white.opacity7}",
             "$description": "Disabled background color. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -137,7 +137,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity12}",
+            "$value": "{base.color.black.opacity50}",
             "$description": "The background color for the overlay that sits behind modal layers.",
             "$extensions": {
               "com.figma": {
@@ -153,7 +153,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity4}",
+            "$value": "{base.color.white.opacity6}",
             "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
@@ -169,7 +169,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.orange.400-Opacity12}",
+            "$value": "{base.color.yellow.400-Opacity12}",
             "$description": "Use for borders communicating warning or caution.",
             "$extensions": {
               "com.figma": {
@@ -185,7 +185,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.400-Opacity12}",
+            "$value": "{base.color.green.500-Opacity30}",
             "$description": "Use for backgrounds communicating success.",
             "$extensions": {
               "com.figma": {
@@ -201,7 +201,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.blue.400-Opacity12}",
+            "$value": "{color.background.contrast.DEFAULT.REST}",
             "$description": "Use for backgrounds communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -217,7 +217,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.500-Opacity12}",
+            "$value": "{base.color.red.800-Opacity30}",
             "$description": "Use for backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -233,7 +233,7 @@
         "strong": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.700}",
+            "$value": "{base.color.green.600}",
             "$description": "The strong variant of background-primary. Primary palette is derived from the brand color and used for high visual prominence.",
             "$extensions": {
               "com.figma": {
@@ -245,7 +245,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.green.800}",
+            "$value": "{base.color.green.700}",
             "$description": "Hover variant of background-primary.",
             "$extensions": {
               "com.figma": {
@@ -276,7 +276,7 @@
           "strong": {
             "REST": {
               "$type": "color",
-              "$value": "{color.background.primary.strong.REST}",
+              "$value": "{base.color.brand}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -288,7 +288,7 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{color.background.primary.strong.hover}",
+              "$value": "{base.color.brand}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -302,7 +302,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.green.100}",
+              "$value": "{base.color.green.1000}",
               "$description": "Lower emphasis variant of background-selected-strong.",
               "$extensions": {
                 "com.figma": {
@@ -314,7 +314,7 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{base.color.green.125}",
+              "$value": "{base.color.green.900}",
               "$description": "Hover variant of background-selected-weak.",
               "$extensions": {
                 "com.figma": {
@@ -331,7 +331,7 @@
         "xstrong": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.1000}",
+            "$value": "{base.color.grey.50}",
             "$description": "Highest emphasis variant of neutral palette.",
             "$extensions": {
               "com.figma": {
@@ -348,7 +348,7 @@
       "strong": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.black.opacity72}",
+          "$value": "{base.color.white.opacity72}",
           "$description": "Emphasized variant of border color.",
           "$extensions": {
             "com.figma": {
@@ -362,7 +362,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.black.opacity36}",
+          "$value": "{base.color.white.opacity36}",
           "$description": "Default border color.",
           "$extensions": {
             "com.figma": {
@@ -376,7 +376,7 @@
       "weak": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.black.opacity12}",
+          "$value": "{base.color.white.opacity12}",
           "$description": "Subtle variant of border color for reduced visual emphasis.",
           "$extensions": {
             "com.figma": {
@@ -391,7 +391,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity12}",
+            "$value": "{base.color.white.opacity12}",
             "$description": "Disabled color for borders. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -407,7 +407,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.700}",
+            "$value": "{base.color.green.600}",
             "$description": "Selected border color. Used for ‘selected’ state.",
             "$extensions": {
               "com.figma": {
@@ -423,7 +423,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.800}",
+            "$value": "{color.border.default.REST}",
             "$description": "Use for borders communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -504,7 +504,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.800}",
+          "$value": "{base.color.white.100}",
           "$description": "Default text color that is accessible on standard background colors.",
           "$extensions": {
             "com.figma": {
@@ -518,7 +518,7 @@
       "strong": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.1000}",
+          "$value": "{base.color.white.100}",
           "$description": "Emphasized text color for increased visual prominence.",
           "$extensions": {
             "com.figma": {
@@ -532,7 +532,7 @@
       "weak": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.700}",
+          "$value": "{base.color.white.opacity50}",
           "$description": "Subtle text color for reduced visual prominence. Often used for supporting text.",
           "$extensions": {
             "com.figma": {
@@ -563,7 +563,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity24}",
+            "$value": "{base.color.white.opacity24}",
             "$description": "Disabled color for text. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -595,7 +595,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.800}",
+            "$value": "{base.color.green.500}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -607,7 +607,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.green.900}",
+            "$value": "{base.color.green.450}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -623,7 +623,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.800}",
+            "$value": "{color.text.default.REST}",
             "$description": "Use for text on standard backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -719,7 +719,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.primary.DEFAULT.REST}",
+            "$value": "{color.text.strong.REST}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -731,7 +731,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{color.text.primary.DEFAULT.hover}",
+            "$value": "{color.text.strong.REST}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -763,7 +763,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.900}",
+            "$value": "{color.text.strong.REST}",
             "$description": "Text color to be used for text sitting on non-strong variants of background-selected.",
             "$extensions": {
               "com.figma": {
@@ -779,7 +779,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.100}",
+            "$value": "{base.color.grey.1200}",
             "$description": "Text color to be used on strong backgrounds. For example, background-neutral-xstrong.",
             "$extensions": {
               "com.figma": {
@@ -946,7 +946,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.800}",
+          "$value": "{base.color.white.100}",
           "$description": "Default icon color that is accessible on standard background colors.",
           "$extensions": {
             "com.figma": {
@@ -960,7 +960,7 @@
       "strong": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.1000}",
+          "$value": "{base.color.white.100}",
           "$description": "Emphasized icon color for increased visual prominence.",
           "$extensions": {
             "com.figma": {
@@ -974,7 +974,7 @@
       "weak": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.700}",
+          "$value": "{base.color.white.opacity50}",
           "$description": "Subtle icon color for reduced visual prominence.",
           "$extensions": {
             "com.figma": {
@@ -989,7 +989,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity24}",
+            "$value": "{base.color.white.opacity24}",
             "$description": "Disabled color for icons. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -1005,7 +1005,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.600}",
+            "$value": "{base.color.red.550}",
             "$description": "Use for icons communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -1021,7 +1021,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.blue.900}",
+            "$value": "{color.icon.default.REST}",
             "$description": "Use for icons communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -1037,7 +1037,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.650}",
+            "$value": "{base.color.green.500}",
             "$description": "Use for icons communicating success.",
             "$extensions": {
               "com.figma": {
@@ -1069,7 +1069,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.600}",
+            "$value": "{base.color.grey.700}",
             "$description": "Use for icons communicating unknown status.",
             "$extensions": {
               "com.figma": {
@@ -1085,7 +1085,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.800}",
+            "$value": "{base.color.green.600}",
             "$description": "High emphasis color for icons that should draw from the primary palette. Often used to highlight that interacting with a given element will result in an action.",
             "$extensions": {
               "com.figma": {
@@ -1167,7 +1167,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.400}",
+            "$value": "{base.color.green.700}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1183,7 +1183,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.purple.500}",
+            "$value": "{base.color.purple.900}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1199,7 +1199,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.teal.200}",
+            "$value": "{base.color.teal.700}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1215,7 +1215,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.blue.400}",
+            "$value": "{base.color.blue.700}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1231,7 +1231,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.500}",
+            "$value": "{base.color.red.850}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1247,7 +1247,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.orange.400}",
+            "$value": "{base.color.orange.700}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1263,7 +1263,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.yellow.200}",
+            "$value": "{base.color.yellow.700}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1279,7 +1279,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.600}",
+            "$value": "{base.color.grey.500}",
             "$description": "Highest emphasis variant of neutral palette.",
             "$extensions": {
               "com.figma": {
@@ -1291,7 +1291,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.grey.700}",
+            "$value": "{base.color.grey.400}",
             "$description": "Highest emphasis variant of neutral palette.",
             "$extensions": {
               "com.figma": {
@@ -1326,7 +1326,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.darkblue1}",
+              "$value": "{base.color.dataVis.darkblue2}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1342,7 +1342,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.gold1}",
+              "$value": "{base.color.dataVis.gold2}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1358,7 +1358,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.purple1}",
+              "$value": "{base.color.dataVis.purple2}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1374,7 +1374,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.lightblue1}",
+              "$value": "{base.color.dataVis.lightblue2}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1390,7 +1390,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.pink1}",
+              "$value": "{base.color.dataVis.pink2}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1406,7 +1406,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.blue1}",
+              "$value": "{base.color.dataVis.blue2}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1422,7 +1422,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.grape1}",
+              "$value": "{base.color.dataVis.purple3}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1450,7 +1450,7 @@
     },
     "focus": {
       "$type": "color",
-      "$value": "#004233",
+      "$value": "{base.color.teal.400}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -1481,7 +1481,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.600}",
+            "$value": "{base.color.red.550}",
             "$description": "Use for foreground regions communicating error or danger. Often used to color values in a meter or progress bar.",
             "$extensions": {
               "com.figma": {
@@ -1513,7 +1513,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.600}",
+            "$value": "{base.color.grey.700}",
             "$description": "Use for foreground regions communicating unknown status. Often used to color values in a meter or progress bar.",
             "$extensions": {
               "com.figma": {
@@ -1536,7 +1536,7 @@
           "offsetY": "{base.dimension.50}",
           "blur": "{base.dimension.100}",
           "spread": 0,
-          "color": "{base.color.black.opacity12}"
+          "color": "{base.color.black.opacity24}"
         }
       ],
       "$description": "",
@@ -1556,7 +1556,7 @@
           "offsetY": "{static.spacing.3xsmall}",
           "blur": "{static.spacing.xsmall}",
           "spread": "{static.spacing.none}",
-          "color": "{base.color.black.opacity12}"
+          "color": "{base.color.black.opacity36}"
         }
       ],
       "$description": "",
@@ -1576,7 +1576,7 @@
           "offsetY": "{static.spacing.xsmall}",
           "blur": "{static.spacing.medium}",
           "spread": "{static.spacing.none}",
-          "color": "{base.color.black.opacity24}"
+          "color": "{base.color.black.opacity48}"
         }
       ],
       "$description": "",

--- a/design-tokens/tokens/semantic/color.v0-light.json
+++ b/design-tokens/tokens/semantic/color.v0-light.json
@@ -4,7 +4,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.grey.1300}",
+          "$value": "{base.color.white.100}",
           "$description": "Default background color to be used on containers.",
           "$extensions": {
             "com.figma": {
@@ -19,7 +19,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.1300}",
+            "$value": "{base.color.grey.50}",
             "$description": "Elevation level 0. Used for the overall page background. It creates a  backdrop for containers to sit on.",
             "$extensions": {
               "com.figma": {
@@ -35,7 +35,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.1200}",
+            "$value": "{base.color.white.100}",
             "$description": "Elevation level 1. Lowest level of elevation for containers/surfaces that sit directly on top of the page. Example: a container that houses a data table.",
             "$extensions": {
               "com.figma": {
@@ -51,7 +51,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.1100}",
+            "$value": "{base.color.white.100}",
             "$description": "Elevation level 2. The highest level of elevation for elements that sit above everything else. Example: drop downs, layers",
             "$extensions": {
               "com.figma": {
@@ -67,7 +67,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.opacity12}",
+            "$value": "{base.color.black.opacity4}",
             "$description": "Use to create a subtle differentiation between a component or container and the region it sits on.",
             "$extensions": {
               "com.figma": {
@@ -79,7 +79,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.white.opacity20}",
+            "$value": "{base.color.black.opacity8}",
             "$description": "Use to create a subtle differentiation between a component or container and the region it sits on.",
             "$extensions": {
               "com.figma": {
@@ -94,7 +94,7 @@
       "DEFAULT": {
         "hover": {
           "$type": "color",
-          "$value": "{base.color.white.opacity6}",
+          "$value": "{color.background.contrast.DEFAULT.REST}",
           "$description": "Generic hover state of components that have no fill in their resting state. For example, menu items.",
           "$extensions": {
             "com.figma": {
@@ -106,7 +106,7 @@
         },
         "active": {
           "$type": "color",
-          "$value": "{base.color.white.opacity6}",
+          "$value": "{color.background.DEFAULT.hover}",
           "$description": "Standard active state color",
           "$extensions": {
             "com.figma": {
@@ -121,7 +121,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.opacity7}",
+            "$value": "{base.color.black.opacity4}",
             "$description": "Disabled background color. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -137,7 +137,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.black.opacity12}",
+            "$value": "{base.color.black.opacity50}",
             "$description": "The background color for the overlay that sits behind modal layers.",
             "$extensions": {
               "com.figma": {
@@ -153,7 +153,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.opacity6}",
+            "$value": "{base.color.black.opacity4}",
             "$description": "Use for backgrounds communicating an unknown status.",
             "$extensions": {
               "com.figma": {
@@ -169,7 +169,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.yellow.400-Opacity12}",
+            "$value": "{base.color.orange.400-Opacity24}",
             "$description": "Use for borders communicating warning or caution.",
             "$extensions": {
               "com.figma": {
@@ -185,7 +185,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.500-Opacity30}",
+            "$value": "{base.color.green.400-Opacity24}",
             "$description": "Use for backgrounds communicating success.",
             "$extensions": {
               "com.figma": {
@@ -201,7 +201,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.blue.400-Opacity12}",
+            "$value": "{color.background.contrast.DEFAULT.REST}",
             "$description": "Use for backgrounds communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -217,7 +217,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.800-Opacity30}",
+            "$value": "{base.color.red.500-Opacity24}",
             "$description": "Use for backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -233,7 +233,7 @@
         "strong": {
           "REST": {
             "$type": "color",
-            "$value": "#007c60",
+            "$value": "{base.color.green.600}",
             "$description": "The strong variant of background-primary. Primary palette is derived from the brand color and used for high visual prominence.",
             "$extensions": {
               "com.figma": {
@@ -245,7 +245,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "#00513f",
+            "$value": "{base.color.green.700}",
             "$description": "Hover variant of background-primary.",
             "$extensions": {
               "com.figma": {
@@ -276,7 +276,7 @@
           "strong": {
             "REST": {
               "$type": "color",
-              "$value": "{color.background.primary.strong.REST}",
+              "$value": "{base.color.brand}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -288,7 +288,7 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{color.background.primary.strong.hover}",
+              "$value": "{base.color.brand}",
               "$description": "Selected (or checked) color. Used for ‘selected’ state. Examples include, checked checkboxes, checked radios, on toggle, active tabs.",
               "$extensions": {
                 "com.figma": {
@@ -302,7 +302,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.green.1000}",
+              "$value": "{base.color.green.100}",
               "$description": "Lower emphasis variant of background-selected-strong.",
               "$extensions": {
                 "com.figma": {
@@ -314,7 +314,7 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{base.color.green.900}",
+              "$value": "{base.color.green.125}",
               "$description": "Hover variant of background-selected-weak.",
               "$extensions": {
                 "com.figma": {
@@ -331,7 +331,7 @@
         "xstrong": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.50}",
+            "$value": "{base.color.grey.1000}",
             "$description": "Highest emphasis variant of neutral palette.",
             "$extensions": {
               "com.figma": {
@@ -348,7 +348,7 @@
       "strong": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.opacity72}",
+          "$value": "{base.color.black.opacity72}",
           "$description": "Emphasized variant of border color.",
           "$extensions": {
             "com.figma": {
@@ -362,7 +362,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.opacity36}",
+          "$value": "{base.color.black.opacity36}",
           "$description": "Default border color.",
           "$extensions": {
             "com.figma": {
@@ -376,7 +376,7 @@
       "weak": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.opacity12}",
+          "$value": "{base.color.black.opacity12}",
           "$description": "Subtle variant of border color for reduced visual emphasis.",
           "$extensions": {
             "com.figma": {
@@ -391,7 +391,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.opacity12}",
+            "$value": "{base.color.black.opacity12}",
             "$description": "Disabled color for borders. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -423,7 +423,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.foreground.critical.DEFAULT.REST}",
+            "$value": "{color.border.default.REST}",
             "$description": "Use for borders communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -504,7 +504,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.100}",
+          "$value": "{base.color.grey.800}",
           "$description": "Default text color that is accessible on standard background colors.",
           "$extensions": {
             "com.figma": {
@@ -518,7 +518,7 @@
       "strong": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.100}",
+          "$value": "{base.color.grey.1000}",
           "$description": "Emphasized text color for increased visual prominence.",
           "$extensions": {
             "com.figma": {
@@ -532,7 +532,7 @@
       "weak": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.opacity50}",
+          "$value": "{base.color.grey.700}",
           "$description": "Subtle text color for reduced visual prominence. Often used for supporting text.",
           "$extensions": {
             "com.figma": {
@@ -563,7 +563,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.opacity24}",
+            "$value": "{base.color.black.opacity24}",
             "$description": "Disabled color for text. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -595,7 +595,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.500}",
+            "$value": "{base.color.green.800}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -607,7 +607,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.green.450}",
+            "$value": "{base.color.green.900}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -623,7 +623,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.foreground.critical.DEFAULT.REST}",
+            "$value": "{color.text.default.REST}",
             "$description": "Use for text on standard backgrounds communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -719,7 +719,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.text.primary.DEFAULT.REST}",
+            "$value": "{color.text.strong.REST}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -731,7 +731,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{color.text.primary.DEFAULT.hover}",
+            "$value": "{color.text.strong.REST}",
             "$description": "Text color for headings.",
             "$extensions": {
               "com.figma": {
@@ -779,7 +779,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.1200}",
+            "$value": "{base.color.white.100}",
             "$description": "Text color to be used on strong backgrounds. For example, background-neutral-xstrong.",
             "$extensions": {
               "com.figma": {
@@ -946,7 +946,7 @@
       "default": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.100}",
+          "$value": "{base.color.grey.800}",
           "$description": "Default icon color that is accessible on standard background colors.",
           "$extensions": {
             "com.figma": {
@@ -960,7 +960,7 @@
       "strong": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.100}",
+          "$value": "{base.color.grey.1000}",
           "$description": "Emphasized icon color for increased visual prominence.",
           "$extensions": {
             "com.figma": {
@@ -974,7 +974,7 @@
       "weak": {
         "REST": {
           "$type": "color",
-          "$value": "{base.color.white.opacity50}",
+          "$value": "{base.color.grey.700}",
           "$description": "Subtle icon color for reduced visual prominence.",
           "$extensions": {
             "com.figma": {
@@ -989,7 +989,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.white.opacity24}",
+            "$value": "{base.color.black.opacity24}",
             "$description": "Disabled color for icons. Using disabled colors ensures that disabled components are consistently styled.",
             "$extensions": {
               "com.figma": {
@@ -1005,7 +1005,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{color.foreground.critical.DEFAULT.REST}",
+            "$value": "{base.color.red.600}",
             "$description": "Use for icons communicating errors or danger.",
             "$extensions": {
               "com.figma": {
@@ -1021,7 +1021,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.blue.700}",
+            "$value": "{color.icon.default.REST}",
             "$description": "Use for icons communicating neutral information.",
             "$extensions": {
               "com.figma": {
@@ -1037,7 +1037,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.500}",
+            "$value": "{base.color.green.650}",
             "$description": "Use for icons communicating success.",
             "$extensions": {
               "com.figma": {
@@ -1069,7 +1069,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.800}",
+            "$value": "{base.color.grey.600}",
             "$description": "Use for icons communicating unknown status.",
             "$extensions": {
               "com.figma": {
@@ -1085,7 +1085,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.500}",
+            "$value": "{base.color.green.600}",
             "$description": "High emphasis color for icons that should draw from the primary palette. Often used to highlight that interacting with a given element will result in an action.",
             "$extensions": {
               "com.figma": {
@@ -1167,7 +1167,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.green.700}",
+            "$value": "{base.color.green.400}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1183,7 +1183,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.purple.900}",
+            "$value": "{base.color.purple.500}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1199,7 +1199,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.teal.700}",
+            "$value": "{base.color.teal.200}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1215,7 +1215,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.blue.700}",
+            "$value": "{base.color.blue.400}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1231,7 +1231,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.850}",
+            "$value": "{base.color.red.500}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1247,7 +1247,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.orange.700}",
+            "$value": "{base.color.orange.400}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1263,7 +1263,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.yellow.700}",
+            "$value": "{base.color.yellow.200}",
             "$description": "Use for decorative purposes when color has no specific meaning.",
             "$extensions": {
               "com.figma": {
@@ -1279,7 +1279,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.500}",
+            "$value": "{base.color.grey.600}",
             "$description": "Highest emphasis variant of neutral palette.",
             "$extensions": {
               "com.figma": {
@@ -1291,7 +1291,7 @@
           },
           "hover": {
             "$type": "color",
-            "$value": "{base.color.grey.400}",
+            "$value": "{base.color.grey.700}",
             "$description": "Highest emphasis variant of neutral palette.",
             "$extensions": {
               "com.figma": {
@@ -1326,7 +1326,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.darkblue2}",
+              "$value": "{base.color.dataVis.darkblue1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1342,7 +1342,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.gold2}",
+              "$value": "{base.color.dataVis.gold1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1358,7 +1358,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.purple2}",
+              "$value": "{base.color.dataVis.purple1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1374,7 +1374,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.lightblue2}",
+              "$value": "{base.color.dataVis.lightblue1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1390,7 +1390,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.pink2}",
+              "$value": "{base.color.dataVis.pink1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1406,7 +1406,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.blue2}",
+              "$value": "{base.color.dataVis.blue1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1422,7 +1422,7 @@
           "DEFAULT": {
             "REST": {
               "$type": "color",
-              "$value": "{base.color.dataVis.purple3}",
+              "$value": "{base.color.dataVis.grape1}",
               "$description": "",
               "$extensions": {
                 "com.figma": {
@@ -1450,7 +1450,7 @@
     },
     "focus": {
       "$type": "color",
-      "$value": "#004233",
+      "$value": "{base.color.teal.400}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -1481,7 +1481,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.red.550}",
+            "$value": "{base.color.red.600}",
             "$description": "Use for foreground regions communicating error or danger. Often used to color values in a meter or progress bar.",
             "$extensions": {
               "com.figma": {
@@ -1513,7 +1513,7 @@
         "DEFAULT": {
           "REST": {
             "$type": "color",
-            "$value": "{base.color.grey.700}",
+            "$value": "{base.color.grey.600}",
             "$description": "Use for foreground regions communicating unknown status. Often used to color values in a meter or progress bar.",
             "$extensions": {
               "com.figma": {
@@ -1536,7 +1536,7 @@
           "offsetY": "{base.dimension.50}",
           "blur": "{base.dimension.100}",
           "spread": 0,
-          "color": "{base.color.black.opacity24}"
+          "color": "{base.color.black.opacity12}"
         }
       ],
       "$description": "",
@@ -1556,7 +1556,7 @@
           "offsetY": "{static.spacing.3xsmall}",
           "blur": "{static.spacing.xsmall}",
           "spread": "{static.spacing.none}",
-          "color": "{base.color.black.opacity36}"
+          "color": "{base.color.black.opacity12}"
         }
       ],
       "$description": "",
@@ -1576,7 +1576,7 @@
           "offsetY": "{static.spacing.xsmall}",
           "blur": "{static.spacing.medium}",
           "spread": "{static.spacing.none}",
-          "color": "{base.color.black.opacity48}"
+          "color": "{base.color.black.opacity24}"
         }
       ],
       "$description": "",

--- a/design-tokens/tokens/semantic/dimension.default.json
+++ b/design-tokens/tokens/semantic/dimension.default.json
@@ -851,7 +851,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -901,7 +901,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -951,7 +951,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1001,7 +1001,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1029,7 +1029,7 @@
     "xlarge": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1041,7 +1041,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.600}",
+        "$value": 36,
         "$description": "Font size typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1053,7 +1053,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.500}",
+        "$value": 40,
         "$description": "Line height typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1067,7 +1067,7 @@
     "large": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1079,7 +1079,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.500}",
+        "$value": 28,
         "$description": "Font size typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1091,7 +1091,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.200}",
+        "$value": 32,
         "$description": "Line height typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1105,7 +1105,7 @@
     "medium": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.300}",
+        "$value": 24,
         "$description": "Font size typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1117,7 +1117,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.100}",
+        "$value": 28,
         "$description": "Line height typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1129,7 +1129,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1143,7 +1143,7 @@
     "small": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.100}",
+        "$value": 20,
         "$description": "Font size typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1155,7 +1155,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.90}",
+        "$value": 24,
         "$description": "Line height typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1167,7 +1167,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1181,7 +1181,7 @@
     "xsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.80}",
+        "$value": 18,
         "$description": "Font size typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1193,7 +1193,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.80}",
+        "$value": 20,
         "$description": "Line height typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1205,7 +1205,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.semibold}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1219,7 +1219,7 @@
     "xxsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.80}",
+        "$value": 16,
         "$description": "Font size typically used on h6.",
         "$extensions": {
           "com.figma": {
@@ -1231,7 +1231,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.80}",
+        "$value": 18,
         "$description": "Line height typically used on h6.",
         "$extensions": {
           "com.figma": {

--- a/design-tokens/tokens/semantic/dimension.small.json
+++ b/design-tokens/tokens/semantic/dimension.small.json
@@ -851,7 +851,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -901,7 +901,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -951,7 +951,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1001,7 +1001,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.light}",
+        "$value": "{fontWeight.regular}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1029,7 +1029,7 @@
     "xlarge": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1041,7 +1041,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.500}",
+        "$value": 28,
         "$description": "Font size typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1053,7 +1053,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.200}",
+        "$value": 32,
         "$description": "Line height typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1067,7 +1067,7 @@
     "large": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1079,7 +1079,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.300}",
+        "$value": 24,
         "$description": "Font size typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1091,7 +1091,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.100}",
+        "$value": 28,
         "$description": "Line height typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1105,7 +1105,7 @@
     "medium": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.100}",
+        "$value": 20,
         "$description": "Font size typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1117,7 +1117,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.90}",
+        "$value": 24,
         "$description": "Line height typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1129,7 +1129,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.regular}",
         "$description": "Font weight typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1143,7 +1143,7 @@
     "small": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.80}",
+        "$value": 18,
         "$description": "Font size typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1155,7 +1155,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.80}",
+        "$value": 20,
         "$description": "Line height typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1181,7 +1181,7 @@
     "xsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.80}",
+        "$value": 16,
         "$description": "Font size typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1193,7 +1193,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.80}",
+        "$value": 18,
         "$description": "Line height typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1219,7 +1219,7 @@
     "xxsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": "{base.fontSize.80}",
+        "$value": 16,
         "$description": "Font size typically used on h6.",
         "$extensions": {
           "com.figma": {
@@ -1231,7 +1231,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": "{base.lineHeight.80}",
+        "$value": 18,
         "$description": "Line height typically used on h6.",
         "$extensions": {
           "com.figma": {

--- a/design-tokens/tokens/semantic/dimension.v0-default.json
+++ b/design-tokens/tokens/semantic/dimension.v0-default.json
@@ -38,7 +38,7 @@
     },
     "4xsmall": {
       "$type": "number",
-      "$value": "{static.spacing.5xsmall}",
+      "$value": "{static.spacing.4xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -50,7 +50,7 @@
     },
     "3xsmall": {
       "$type": "number",
-      "$value": "{static.spacing.5xsmall}",
+      "$value": "{static.spacing.3xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -62,7 +62,7 @@
     },
     "xxsmall": {
       "$type": "number",
-      "$value": "{static.spacing.4xsmall}",
+      "$value": "{static.spacing.xxsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -74,7 +74,7 @@
     },
     "xsmall": {
       "$type": "number",
-      "$value": "{static.spacing.3xsmall}",
+      "$value": "{static.spacing.xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -86,7 +86,7 @@
     },
     "small": {
       "$type": "number",
-      "$value": "{static.spacing.xxsmall}",
+      "$value": "{static.spacing.small}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -98,7 +98,7 @@
     },
     "medium": {
       "$type": "number",
-      "$value": "{static.spacing.xsmall}",
+      "$value": "{static.spacing.medium}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -110,7 +110,7 @@
     },
     "large": {
       "$type": "number",
-      "$value": "{static.spacing.small}",
+      "$value": "{static.spacing.large}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -122,7 +122,7 @@
     },
     "xlarge": {
       "$type": "number",
-      "$value": "{static.spacing.medium}",
+      "$value": "{static.spacing.xlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -134,7 +134,7 @@
     },
     "xxlarge": {
       "$type": "number",
-      "$value": "{static.spacing.large}",
+      "$value": "{static.spacing.xxlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -146,7 +146,7 @@
     },
     "3xlarge": {
       "$type": "number",
-      "$value": "{static.spacing.xlarge}",
+      "$value": "{static.spacing.3xlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -184,7 +184,7 @@
     },
     "xxsmall": {
       "$type": "number",
-      "$value": "{static.radius.hair}",
+      "$value": "{static.radius.xxsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -196,7 +196,7 @@
     },
     "xsmall": {
       "$type": "number",
-      "$value": "{static.radius.xxsmall}",
+      "$value": "{static.radius.xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -208,7 +208,7 @@
     },
     "small": {
       "$type": "number",
-      "$value": "{static.radius.xsmall}",
+      "$value": "{static.radius.small}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -220,7 +220,7 @@
     },
     "medium": {
       "$type": "number",
-      "$value": "{static.radius.small}",
+      "$value": "{static.radius.medium}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -232,7 +232,7 @@
     },
     "large": {
       "$type": "number",
-      "$value": "{static.radius.medium}",
+      "$value": "{static.radius.large}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -244,7 +244,7 @@
     },
     "xlarge": {
       "$type": "number",
-      "$value": "{static.radius.large}",
+      "$value": "{static.radius.xlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -256,7 +256,7 @@
     },
     "xxlarge": {
       "$type": "number",
-      "$value": "{static.radius.xlarge}",
+      "$value": "{static.radius.xxlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -306,7 +306,7 @@
     },
     "small": {
       "$type": "number",
-      "$value": "{static.borderWidth.xsmall}",
+      "$value": "{static.borderWidth.small}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -318,7 +318,7 @@
     },
     "medium": {
       "$type": "number",
-      "$value": "{static.borderWidth.small}",
+      "$value": "{static.borderWidth.medium}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -330,7 +330,7 @@
     },
     "large": {
       "$type": "number",
-      "$value": "{static.borderWidth.medium}",
+      "$value": "{static.borderWidth.large}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -851,7 +851,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -901,7 +901,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -951,7 +951,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1001,7 +1001,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1029,7 +1029,7 @@
     "xlarge": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1041,7 +1041,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": 28,
+        "$value": "{base.fontSize.600}",
         "$description": "Font size typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1053,7 +1053,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 32,
+        "$value": "{base.lineHeight.500}",
         "$description": "Line height typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1067,7 +1067,7 @@
     "large": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1079,7 +1079,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": 24,
+        "$value": "{base.fontSize.500}",
         "$description": "Font size typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1091,7 +1091,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 28,
+        "$value": "{base.lineHeight.200}",
         "$description": "Line height typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1105,7 +1105,7 @@
     "medium": {
       "fontSize": {
         "$type": "number",
-        "$value": 20,
+        "$value": "{base.fontSize.300}",
         "$description": "Font size typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1117,7 +1117,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 24,
+        "$value": "{base.lineHeight.100}",
         "$description": "Line height typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1129,7 +1129,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1143,7 +1143,7 @@
     "small": {
       "fontSize": {
         "$type": "number",
-        "$value": 18,
+        "$value": "{base.fontSize.100}",
         "$description": "Font size typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1155,7 +1155,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 20,
+        "$value": "{base.lineHeight.90}",
         "$description": "Line height typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1181,7 +1181,7 @@
     "xsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": 16,
+        "$value": "{base.fontSize.80}",
         "$description": "Font size typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1193,7 +1193,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 18,
+        "$value": "{base.lineHeight.80}",
         "$description": "Line height typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1219,7 +1219,7 @@
     "xxsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": 16,
+        "$value": "{base.fontSize.80}",
         "$description": "Font size typically used on h6.",
         "$extensions": {
           "com.figma": {
@@ -1231,7 +1231,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 18,
+        "$value": "{base.lineHeight.80}",
         "$description": "Line height typically used on h6.",
         "$extensions": {
           "com.figma": {

--- a/design-tokens/tokens/semantic/dimension.v0-small.json
+++ b/design-tokens/tokens/semantic/dimension.v0-small.json
@@ -38,7 +38,7 @@
     },
     "4xsmall": {
       "$type": "number",
-      "$value": "{static.spacing.4xsmall}",
+      "$value": "{static.spacing.5xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -50,7 +50,7 @@
     },
     "3xsmall": {
       "$type": "number",
-      "$value": "{static.spacing.3xsmall}",
+      "$value": "{static.spacing.5xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -62,7 +62,7 @@
     },
     "xxsmall": {
       "$type": "number",
-      "$value": "{static.spacing.xxsmall}",
+      "$value": "{static.spacing.4xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -74,7 +74,7 @@
     },
     "xsmall": {
       "$type": "number",
-      "$value": "{static.spacing.xsmall}",
+      "$value": "{static.spacing.3xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -86,7 +86,7 @@
     },
     "small": {
       "$type": "number",
-      "$value": "{static.spacing.small}",
+      "$value": "{static.spacing.xxsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -98,7 +98,7 @@
     },
     "medium": {
       "$type": "number",
-      "$value": "{static.spacing.medium}",
+      "$value": "{static.spacing.xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -110,7 +110,7 @@
     },
     "large": {
       "$type": "number",
-      "$value": "{static.spacing.large}",
+      "$value": "{static.spacing.small}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -122,7 +122,7 @@
     },
     "xlarge": {
       "$type": "number",
-      "$value": "{static.spacing.xlarge}",
+      "$value": "{static.spacing.medium}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -134,7 +134,7 @@
     },
     "xxlarge": {
       "$type": "number",
-      "$value": "{static.spacing.xxlarge}",
+      "$value": "{static.spacing.large}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -146,7 +146,7 @@
     },
     "3xlarge": {
       "$type": "number",
-      "$value": "{static.spacing.3xlarge}",
+      "$value": "{static.spacing.xlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -184,7 +184,7 @@
     },
     "xxsmall": {
       "$type": "number",
-      "$value": "{static.radius.xxsmall}",
+      "$value": "{static.radius.hair}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -196,7 +196,7 @@
     },
     "xsmall": {
       "$type": "number",
-      "$value": "{static.radius.xsmall}",
+      "$value": "{static.radius.xxsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -208,7 +208,7 @@
     },
     "small": {
       "$type": "number",
-      "$value": "{static.radius.small}",
+      "$value": "{static.radius.xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -220,7 +220,7 @@
     },
     "medium": {
       "$type": "number",
-      "$value": "{static.radius.medium}",
+      "$value": "{static.radius.small}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -232,7 +232,7 @@
     },
     "large": {
       "$type": "number",
-      "$value": "{static.radius.large}",
+      "$value": "{static.radius.medium}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -244,7 +244,7 @@
     },
     "xlarge": {
       "$type": "number",
-      "$value": "{static.radius.xlarge}",
+      "$value": "{static.radius.large}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -256,7 +256,7 @@
     },
     "xxlarge": {
       "$type": "number",
-      "$value": "{static.radius.xxlarge}",
+      "$value": "{static.radius.xlarge}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -306,7 +306,7 @@
     },
     "small": {
       "$type": "number",
-      "$value": "{static.borderWidth.small}",
+      "$value": "{static.borderWidth.xsmall}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -318,7 +318,7 @@
     },
     "medium": {
       "$type": "number",
-      "$value": "{static.borderWidth.medium}",
+      "$value": "{static.borderWidth.small}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -330,7 +330,7 @@
     },
     "large": {
       "$type": "number",
-      "$value": "{static.borderWidth.large}",
+      "$value": "{static.borderWidth.medium}",
       "$description": "",
       "$extensions": {
         "com.figma": {
@@ -851,7 +851,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -901,7 +901,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -951,7 +951,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1001,7 +1001,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.light}",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -1029,7 +1029,7 @@
     "xlarge": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1041,7 +1041,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": 36,
+        "$value": "{base.fontSize.500}",
         "$description": "Font size typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1053,7 +1053,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 40,
+        "$value": "{base.lineHeight.200}",
         "$description": "Line height typically used on h1.",
         "$extensions": {
           "com.figma": {
@@ -1067,7 +1067,7 @@
     "large": {
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1079,7 +1079,7 @@
       },
       "fontSize": {
         "$type": "number",
-        "$value": 28,
+        "$value": "{base.fontSize.300}",
         "$description": "Font size typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1091,7 +1091,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 32,
+        "$value": "{base.lineHeight.100}",
         "$description": "Line height typically used on h2.",
         "$extensions": {
           "com.figma": {
@@ -1105,7 +1105,7 @@
     "medium": {
       "fontSize": {
         "$type": "number",
-        "$value": 24,
+        "$value": "{base.fontSize.100}",
         "$description": "Font size typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1117,7 +1117,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 28,
+        "$value": "{base.lineHeight.90}",
         "$description": "Line height typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1129,7 +1129,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h3.",
         "$extensions": {
           "com.figma": {
@@ -1143,7 +1143,7 @@
     "small": {
       "fontSize": {
         "$type": "number",
-        "$value": 20,
+        "$value": "{base.fontSize.80}",
         "$description": "Font size typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1155,7 +1155,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 24,
+        "$value": "{base.lineHeight.80}",
         "$description": "Line height typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1167,7 +1167,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.regular}",
+        "$value": "{fontWeight.medium}",
         "$description": "Font weight typically used on h4.",
         "$extensions": {
           "com.figma": {
@@ -1181,7 +1181,7 @@
     "xsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": 18,
+        "$value": "{base.fontSize.80}",
         "$description": "Font size typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1193,7 +1193,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 20,
+        "$value": "{base.lineHeight.80}",
         "$description": "Line height typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1205,7 +1205,7 @@
       },
       "fontWeight": {
         "$type": "number",
-        "$value": "{fontWeight.medium}",
+        "$value": "{fontWeight.semibold}",
         "$description": "Font weight typically used on h5.",
         "$extensions": {
           "com.figma": {
@@ -1219,7 +1219,7 @@
     "xxsmall": {
       "fontSize": {
         "$type": "number",
-        "$value": 16,
+        "$value": "{base.fontSize.80}",
         "$description": "Font size typically used on h6.",
         "$extensions": {
           "com.figma": {
@@ -1231,7 +1231,7 @@
       },
       "lineHeight": {
         "$type": "number",
-        "$value": 18,
+        "$value": "{base.lineHeight.80}",
         "$description": "Line height typically used on h6.",
         "$extensions": {
           "com.figma": {

--- a/sandbox/grommet-app/src/themes/theme.jsx
+++ b/sandbox/grommet-app/src/themes/theme.jsx
@@ -25,7 +25,6 @@ import {
 } from 'grommet-icons';
 // import { hpe } from 'grommet-theme-hpe';
 
-// TO DO should these be added as tokens?
 const backgrounds = {
   'datawave-green-1':
     'url(https://d3hq6blov2iije.cloudfront.net/images/textures/AdobeStock-57301038_800_0_72_RGB+19849.jpg)',
@@ -86,39 +85,6 @@ const backgrounds = {
         hsl(46deg 100% 50%) 100%
     );`,
 };
-
-// const dropKeyFrames = keyframes`
-//   0% {
-//     opacity: 0;
-//     transform: scale(1, 0.1);
-//   }
-//   100% {
-//     opacity: 1;
-//     transform: scale(1, 1);
-//   }
-// `;
-
-// const standardDrop = keyframes`
-//   0% {
-//     opacity: 0.5;
-//     transform: scale(0.5);
-//   }
-//   100% {
-//     opacity: 1;
-//     transform: scale(1);
-//   }
-// `;
-
-// const skeletonAnimation = keyframes`
-// 0% {
-//   transform: translateX(-100%);
-// }
-// 100% {
-//   transform: translateX(100%);
-// }
-// `;
-
-// const themeModeTransition = `background ${base.motion.duration[375]} ${base.motion.easing.simple.inOut}`;
 
 const baseSpacing = 24;
 
@@ -326,8 +292,6 @@ const buildTheme = (tokens, flags) => {
     'neutral-4': undefined,
     'neutral-5': undefined,
     'status-error': undefined,
-    // ----------- These ones we need to map manually for backwards compatibility -----------
-    // ----------- with current color namespace ---------------
     control: 'background-primary-strong',
     'active-text': 'text-strong',
     'text-primary-button': components.hpe.button.primary.rest.textColor,
@@ -840,7 +804,7 @@ const buildTheme = (tokens, flags) => {
   return deepFreeze({
     defaultMode: 'light',
     global: {
-      backgrounds, // TO DO backgrounds
+      backgrounds,
       ...dimensions,
       colors,
       control: {
@@ -876,17 +840,27 @@ const buildTheme = (tokens, flags) => {
                 .borderColor,
           },
         },
-        extend: `
+        extend: ({ theme }) => `
+          color: ${getThemeColor(
+            components.hpe.formField.default.value.rest.textColor,
+            theme,
+          )};
           &::-webkit-input-placeholder {
-          font-weight: ${components.hpe.formField.default.medium.placeholder.fontWeight};
+          font-weight: ${
+            components.hpe.formField.default.medium.placeholder.fontWeight
+          };
         }
       
         &::-moz-placeholder {
-          font-weight: ${components.hpe.formField.default.medium.placeholder.fontWeight};
+          font-weight: ${
+            components.hpe.formField.default.medium.placeholder.fontWeight
+          };
         }
       
         &:-ms-input-placeholder {
-          font-weight: ${components.hpe.formField.default.medium.placeholder.fontWeight};
+          font-weight: ${
+            components.hpe.formField.default.medium.placeholder.fontWeight
+          };
         }
         `,
       },
@@ -1028,12 +1002,17 @@ const buildTheme = (tokens, flags) => {
       color: components.hpe.anchor.default.rest.textColor,
       textDecoration: components.hpe.anchor.default.rest.textDecoration,
       fontWeight: components.hpe.anchor.default.rest.fontWeight,
-      gap: components.hpe.anchor.default.medium.gapX, // TO DO not size specific
+      gap: components.hpe.anchor.default.medium.gapX,
       icon: {
         color: 'icon-primary',
       },
       hover: {
         textDecoration: components.hpe.anchor.default.hover.textDecoration,
+        extend: ({ theme }) =>
+          `color: ${getThemeColor(
+            components.hpe.anchor.default.hover.textColor,
+            theme,
+          )};`,
       },
       size: anchorSizeTheme,
     },
@@ -1073,7 +1052,7 @@ const buildTheme = (tokens, flags) => {
           background: 'background-neutral-xstrong',
         },
         size: {
-          medium: '18px', // Q: what token should be used here? no token for this at the moments
+          medium: '18px',
         },
         text: {
           size: {
@@ -1081,14 +1060,12 @@ const buildTheme = (tokens, flags) => {
           },
         },
       },
-      // TO DO add cta-primary variant
       'cta-primary': {
         ...buttonKindTheme.primary,
         icon: <Hpe />,
         reverse: true,
         extend: '',
       },
-      // TO DO add cta-alternate variant
       'cta-alternate': {
         ...buttonKindTheme.secondary,
         icon: <Hpe color="icon-brand" />,
@@ -1147,10 +1124,7 @@ const buildTheme = (tokens, flags) => {
       },
       hover: {
         'cta-primary': buttonStatesTheme.hover.primary,
-        'cta-alternate': {
-          ...buttonStatesTheme.hover.secondary,
-          extend: '', // TO DO can remove when merging, temp to override extend
-        },
+        'cta-alternate': buttonStatesTheme.hover.secondary,
         ...buttonStatesTheme.hover,
         option: {
           background: components.hpe.select.default.option.hover.background,
@@ -1161,11 +1135,14 @@ const buildTheme = (tokens, flags) => {
           extend: props =>
             props['aria-selected'] &&
             `
-          background: ${
-            props.theme.global.colors[
-              components.hpe.select.default.option.selected.hover.background
-            ][props.theme.dark ? 'dark' : 'light']
-          };
+           background: ${getThemeColor(
+             components.hpe.select.default.option.selected.hover.background,
+             props.theme,
+           )};
+          color: ${getThemeColor(
+            components.hpe.select.default.option.selected.hover.textColor,
+            props.theme,
+          )}
           `,
         },
       },
@@ -1182,22 +1159,8 @@ const buildTheme = (tokens, flags) => {
         },
       },
       extend: ({ sizeProp, hasIcon, hasLabel, kind, plain }) => {
-        // necessary so primary label is accessible on HPE green background
         let style = '';
         const iconOnly = hasIcon && !hasLabel;
-        if ((sizeProp === 'medium' || sizeProp === undefined) && !iconOnly) {
-          const themeObj =
-            kind === 'option'
-              ? components.hpe.select.default.medium[kind]
-              : components.hpe.button[
-                  typeof kind === 'string' ? kind : 'default'
-                ].medium;
-          const { fontSize, lineHeight } = themeObj;
-
-          style += `font-size: ${fontSize};
-        line-height: ${lineHeight};`;
-        }
-
         // kind and size specific icon-only padding
         if (
           !plain &&
@@ -1214,8 +1177,34 @@ const buildTheme = (tokens, flags) => {
         adjacent: {
           color: 'text-weak',
         },
-        extend: ({ isSelected, theme }) =>
-          isSelected && `color: ${theme.global.colors['text-primary-button']};`,
+        hover: {
+          background: 'background-hover',
+          color: 'text-strong',
+        },
+        selected: {
+          background: 'background-selected-primary-strong',
+          color: 'text-onSelectedPrimaryStrong',
+          hover: {
+            background: 'background-selected-primary-strong-hover',
+          },
+          font: {
+            weight: global.hpe.fontWeight.medium,
+          },
+        },
+        inRange: {
+          color: 'text-onSelectedPrimary',
+          hover: {
+            background: 'background-selected-primary-hover',
+            color: 'text-onSelectedPrimary',
+          },
+          font: {
+            weight: global.hpe.fontWeight.medium,
+          },
+        },
+        extend: '',
+      },
+      range: {
+        background: 'background-selected-primary',
       },
       icons: {
         // next: Next,
@@ -1225,9 +1214,27 @@ const buildTheme = (tokens, flags) => {
         fontSize: '13.6px',
         lineHeight: 1.375,
         daySize: '27.43px',
+        day: {
+          round: 'full',
+        },
+        range: {
+          round: 'none',
+          start: {
+            round: {
+              corner: 'left',
+              size: 'full',
+            },
+          },
+          end: {
+            round: {
+              corner: 'right',
+              size: 'full',
+            },
+          },
+        },
         title: {
           size: 'medium',
-          weight: 500,
+          weight: global.hpe.fontWeight.normal,
           color: 'text-strong',
         },
       },
@@ -1235,9 +1242,27 @@ const buildTheme = (tokens, flags) => {
         fontSize: '18px',
         lineHeight: 1.45,
         daySize: '54.86px',
+        day: {
+          round: 'full',
+        },
+        range: {
+          round: 'none',
+          start: {
+            round: {
+              corner: 'left',
+              size: 'full',
+            },
+          },
+          end: {
+            round: {
+              corner: 'right',
+              size: 'full',
+            },
+          },
+        },
         title: {
           size: 'large',
-          weight: 500,
+          weight: global.hpe.fontWeight.normal,
           color: 'text-strong',
         },
       },
@@ -1245,9 +1270,27 @@ const buildTheme = (tokens, flags) => {
         fontSize: '31.2px',
         lineHeight: 1.11,
         daySize: '109.71px',
+        day: {
+          round: 'full',
+        },
+        range: {
+          round: 'none',
+          start: {
+            round: {
+              corner: 'left',
+              size: 'full',
+            },
+          },
+          end: {
+            round: {
+              corner: 'right',
+              size: 'full',
+            },
+          },
+        },
         title: {
           size: 'xlarge',
-          weight: 500,
+          weight: global.hpe.fontWeight.normal,
           color: 'text-strong',
         },
       },
@@ -1255,7 +1298,7 @@ const buildTheme = (tokens, flags) => {
     card: {
       container: {
         background: 'background-front',
-        elevation: 'medium',
+        elevation: 'none',
         extend: 'transition: box-shadow 0.3s ease-in-out;',
       },
       body: {
@@ -1269,7 +1312,7 @@ const buildTheme = (tokens, flags) => {
       },
       hover: {
         container: {
-          elevation: 'large',
+          elevation: 'medium',
         },
       },
     },
@@ -1277,8 +1320,7 @@ const buildTheme = (tokens, flags) => {
       hover: {
         border: {
           // applies directly to control (checkbox and toggle switch)
-          // TO DO remove from applying to switch
-          color: components.hpe.checkbox.default.control.hover.borderColor,
+          color: undefined,
           width:
             dimensions.borderSize[
               components.hpe.checkbox.default.medium.control.borderWidth
@@ -1286,7 +1328,7 @@ const buildTheme = (tokens, flags) => {
         },
         // applies to container around control and label
         background: {
-          color: 'background-hover',
+          color: undefined,
         },
         extend: ({ theme, toggle, checked }) => {
           let borderColor;
@@ -1355,11 +1397,16 @@ const buildTheme = (tokens, flags) => {
               theme,
             );
           }
-          if (disabled)
+          if (disabled) {
+            background = getThemeColor(
+              components.hpe.checkbox.default.control.disabled.rest.background,
+              theme,
+            );
             borderColor = getThemeColor(
               components.hpe.checkbox.default.control.disabled.rest.borderColor,
               theme,
             );
+          }
           return `
             background: ${background};
             border-color: ${borderColor};
@@ -1381,19 +1428,23 @@ const buildTheme = (tokens, flags) => {
       label: {
         align: 'start',
       },
-      pad: {
-        vertical: components.hpe.element?.medium.paddingY,
-        horizontal:
-          components.hpe.formField.default.medium.input.container.paddingX,
-      },
+      pad: 'none',
       size: components.hpe.checkbox.default.medium.control.width,
       toggle: {
         background: components.hpe.switch.default.control.track.rest.background,
         color: components.hpe.switch.default.control.handle.rest.background,
         size: components.hpe.switch.default.medium.control.track.width,
-        // TO DO need token for handle elevation
         knob: {
-          extend: ({ theme, checked, disabled }) => `
+          extend: ({ theme, checked, disabled }) => {
+            const insetHandle =
+              dimensions.borderSize[
+                components.hpe.switch.default.medium.control.handle.borderWidth
+              ] ||
+              dimensions.borderSize[
+                components.hpe.switch.default.medium.control.handle.borderWidth
+              ];
+
+            return `
           box-shadow: ${
             theme.global.elevation[theme.dark ? 'dark' : 'light'][
               components.hpe.switch.default.control.handle.rest.boxShadow
@@ -1404,17 +1455,18 @@ const buildTheme = (tokens, flags) => {
               components.hpe.switch.default.medium.control.handle.borderWidth
             ]
           } solid ${getThemeColor(
-            disabled
-              ? components.hpe.switch.default.control.handle.disabled.rest
-                  .borderColor
-              : components.hpe.switch.default.control.handle.rest.borderColor,
-            theme,
-          )};
+              disabled
+                ? components.hpe.switch.default.control.handle.disabled.rest
+                    .borderColor
+                : components.hpe.switch.default.control.handle.rest.borderColor,
+              theme,
+            )};
           width: ${components.hpe.switch.default.medium.control.handle.width};
           height: ${components.hpe.switch.default.medium.control.handle.height};
-          // top: 1px; // TO DO token?
-          // ${!checked ? 'left: 1px;' : ''} // TO DO token?
-          `,
+          top: ${insetHandle};
+          left: ${!checked ? insetHandle : '25px'};
+          `;
+          },
         },
         // applies to track around handle
         extend: ({ checked, theme, disabled }) => {
@@ -1441,7 +1493,8 @@ const buildTheme = (tokens, flags) => {
           }
           if (disabled) {
             background = getThemeColor(
-              components.hpe.switch.default.control.track.disabled.rest,
+              components.hpe.switch.default.control.track.disabled.rest
+                .background,
               theme,
             );
             borderColor = getThemeColor(
@@ -1456,7 +1509,6 @@ const buildTheme = (tokens, flags) => {
             &:hover {
               ${!disabled ? `background: ${hoverBackground};` : ''}
             }
-            
         `;
         },
       },
@@ -1472,6 +1524,9 @@ const buildTheme = (tokens, flags) => {
         components.hpe.formField.default.input.group.item.rest.borderColor,
         theme,
       )};
+      & input:checked + span[class*=CheckBoxToggle] > span[class*=CheckBoxKnob] {
+        left: 25px;
+      }
       ${
         // override built in disabled opacity: 0.5 from grommet
         disabled &&
@@ -1486,12 +1541,9 @@ const buildTheme = (tokens, flags) => {
     },
     checkBoxGroup: {
       container: {
-        gap: 'none', // TO DO missing token
-        margin: {
-          vertical:
-            components.hpe.formField.default.medium.input.group.container
-              .paddingY,
-        },
+        cssGap: true,
+        gap: 'small',
+        margin: 'none',
       },
     },
     data: {
@@ -1518,6 +1570,14 @@ const buildTheme = (tokens, flags) => {
         selected: {
           background:
             components.hpe.dataCell.default.selected?.rest?.background,
+        },
+        row: {
+          extend: `&:last-child td {
+              border-color: transparent;
+            }
+            &:last-child th {
+              border-color: transparent;
+            }`,
         },
       },
       groupHeader: {
@@ -1601,11 +1661,10 @@ const buildTheme = (tokens, flags) => {
         },
       },
       primary: {
-        weight: components.hpe.dataCell.primary.fontWeight,
+        weight: components.hpe.dataCell.primary.medium.fontWeight,
         color: components.hpe.dataCell.primary.rest.textColor,
       },
       resize: {
-        // Q: missing tokens
         border: {
           color: 'border',
           side: 'end',
@@ -1623,12 +1682,12 @@ const buildTheme = (tokens, flags) => {
         color:
           components.hpe.formField.default.input.container.rest.borderColor,
         side: 'all',
-        style: 'dashed',
+        style: 'solid',
         size: components.hpe.formField.default.medium.input.container
           .borderWidth,
       },
       button: {
-        background: components.hpe.button.default.rest.background,
+        background: components.hpe.button.secondary.rest.background,
         border: {
           radius: components.hpe.button.default.medium.borderRadius,
         },
@@ -1636,13 +1695,13 @@ const buildTheme = (tokens, flags) => {
           vertical: components.hpe.button.default.medium.paddingY,
           horizontal: components.hpe.button.default.medium.paddingX,
         },
-        color: components.hpe.button.default.rest.textColor,
+        color: components.hpe.button.secondary.rest.textColor,
         font: {
-          weight: components.hpe.button.default.rest.fontWeight,
+          weight: components.hpe.button.secondary.rest.fontWeight,
         },
         hover: {
-          background: components.hpe.button.default.hover.background,
-          color: components.hpe.button.default.hover.textColor,
+          background: components.hpe.button.secondary.hover.background,
+          color: components.hpe.button.secondary.hover.textColor,
         },
       },
       dragOver: {
@@ -1670,30 +1729,78 @@ const buildTheme = (tokens, flags) => {
     formField: {
       extend: ({ theme }) =>
         `
-          input:disabled { 
-          color: ${getThemeColor(
-            components.hpe.formField.default.value.disabled.rest.textColor,
-            theme,
-          )};
+          input:disabled {
+            color: ${getThemeColor(
+              components.hpe.formField.default.value.disabled.rest.textColor,
+              theme,
+            )};
           }
-          [role="group"], [role="radiogroup"] {
+          [class*="ContentBox"] {
             label {
-              border: ${
-                dimensions.borderSize[
+              padding-block: ${
+                components.hpe.formField.default.medium.input.group.item
+                  .paddingY
+              };
+              padding-inline: ${
+                components.hpe.formField.default.medium.input.group.item
+                  .paddingX
+              };
+              &:hover {
+                background: ${getThemeColor(
+                  components.hpe.formField.default.input.container.hover
+                    .background,
+                  theme,
+                )};
+              }
+            }
+            [role="group"], [role="radiogroup"] {
+              gap: 0;
+              padding-block: ${
+                components.hpe.formField.default.medium.input.group.container
+                  .paddingY
+              };
+              padding-inline: ${
+                components.hpe.formField.default.medium.input.group.container
+                  .paddingX
+              };
+              label {
+                border: ${
+                  dimensions.borderSize[
+                    components.hpe.formField.default.medium.input.group.item
+                      .borderWidth
+                  ] ||
                   components.hpe.formField.default.medium.input.group.item
                     .borderWidth
-                ] ||
-                components.hpe.formField.default.medium.input.group.item
-                  .borderWidth
-              } solid ${getThemeColor(
+                } solid ${getThemeColor(
           components.hpe.formField.default.input.group.item.rest.borderColor,
           theme,
         )};
+                padding-block: ${
+                  components.hpe.formField.default.medium.input.group.item
+                    .paddingY
+                };
+                padding-inline: ${
+                  components.hpe.formField.default.medium.input.group.item
+                    .paddingX
+                };
+                border-radius: ${
+                  dimensions.edgeSize[
+                    components.hpe.formField.default.medium.input.group.item
+                      .borderRadius
+                  ]
+                };
+                &:hover {
+                  background: ${getThemeColor(
+                    components.hpe.formField.default.input.group.item.hover
+                      .background,
+                    theme,
+                  )};
+                }
+              }
             }
           }
       `,
       content: {
-        // Q: missing tokens
         margin: { vertical: 'xsmall' },
         pad: 'none',
       },
@@ -1706,6 +1813,48 @@ const buildTheme = (tokens, flags) => {
         color:
           components.hpe.formField.default.input.container.rest.borderColor,
         side: 'all',
+      },
+      checkBox: {
+        pad: {
+          horizontal:
+            components.hpe.formField.default.medium.input.group.item.paddingX,
+          vertical:
+            components.hpe.formField.default.medium.input.group.item.paddingY,
+        },
+        container: {
+          extend: ({ error }) =>
+            `border-color: ${
+              error
+                ? components.hpe.formField.default.input.group.container.error
+                    .rest.borderColor
+                : components.hpe.formField.default.input.group.container.rest
+                    .borderColor
+            }; `,
+        },
+      },
+      checkBoxGroup: {
+        container: {
+          extend: ({ error }) =>
+            `border-color: ${
+              error
+                ? components.hpe.formField.default.input.group.container.error
+                    .rest.borderColor
+                : components.hpe.formField.default.input.group.container.rest
+                    .borderColor
+            }; `,
+        },
+      },
+      radioButtonGroup: {
+        container: {
+          extend: ({ error }) =>
+            `border-color: ${
+              error
+                ? components.hpe.formField.default.input.group.container.error
+                    .rest.borderColor
+                : components.hpe.formField.default.input.group.container.rest
+                    .borderColor
+            }; `,
+        },
       },
       disabled: {
         background:
@@ -1720,7 +1869,7 @@ const buildTheme = (tokens, flags) => {
           color: components.hpe.formField.default.label.disabled.rest.textColor,
         },
         help: {
-          color: components.hpe.formField.default.help.disabled.rest.color,
+          color: components.hpe.formField.default.help.disabled.rest.textColor,
         },
         info: {
           color: components.hpe.formField.default.info.disabled.rest.textColor,
@@ -1733,19 +1882,21 @@ const buildTheme = (tokens, flags) => {
               .background,
         },
         container: {
-          gap: 'xsmall', // Q: missing token
+          gap: 'xsmall',
         },
-        icon: <CircleAlert size="small" color={light.hpe.color.icon.default} />,
-        size: 'xsmall', // Q: missing token
+        icon: (
+          <CircleAlert size="small" color={light.hpe.color.icon.critical} />
+        ),
+        size: 'xsmall',
         color: components.hpe.formField.default.error.rest.textColor,
         margin: {
-          // Q: missing token
           bottom: 'xsmall',
           top: 'none',
           horizontal: 'none',
         },
       },
       focus: {
+        containerFocus: false,
         background: undefined, // Intentionally not carrying this style through to tokens to rely on global focus indicator
         border: {
           color: undefined, // Intentionally not carrying this style through to tokens to rely on global focus indicator
@@ -1754,13 +1905,12 @@ const buildTheme = (tokens, flags) => {
       help: {
         size: 'xsmall',
         color: components.hpe.formField.default.help.rest.color,
-        margin: 'none', // TO DO missing token
+        margin: 'none',
       },
       info: {
         size: 'xsmall',
         color: components.hpe.formField.default.info.rest.color,
         margin: {
-          // Q: missing token
           bottom: 'xsmall',
           top: 'none',
           horizontal: 'none',
@@ -1768,9 +1918,8 @@ const buildTheme = (tokens, flags) => {
       },
       label: {
         size: 'xsmall',
-        color: components.hpe.formField.default.label.rest.color,
+        color: components.hpe.formField.default.label.rest.textColor,
         margin: {
-          // Q: missing token
           bottom: 'none',
           top: 'xsmall',
           horizontal: 'none',
@@ -1779,11 +1928,10 @@ const buildTheme = (tokens, flags) => {
         weight: components.hpe.formField.default.medium.label.fontWeight,
       },
       margin: {
-        bottom: 'none', // TO DO missing token
+        bottom: 'none',
       },
       round:
         components.hpe.formField.default.medium.input.container.borderRadius,
-      // TO DO no tokens
       survey: {
         label: {
           margin: { bottom: 'none' },
@@ -1802,7 +1950,6 @@ const buildTheme = (tokens, flags) => {
           },
           small: {
             // this value is off because we didn't have the same typography system before
-            // TO DO could hard code with v6 backwards compatibility flag
             size: large.hpe.heading.large.fontSize,
             height: large.hpe.heading.large.lineHeight,
           },
@@ -1811,12 +1958,10 @@ const buildTheme = (tokens, flags) => {
             height: large.hpe.heading.xlarge.lineHeight,
           },
           large: {
-            // Q: missing tokens
             size: '48px',
             height: '48px',
           },
           xlarge: {
-            // Q: missing tokens
             size: '60px',
             height: '60px',
           },
@@ -1838,7 +1983,6 @@ const buildTheme = (tokens, flags) => {
             height: large.hpe.heading.xlarge.lineHeight,
           },
           xlarge: {
-            // Q: missing tokens
             size: '48px',
             height: '48px',
           },
@@ -2000,15 +2144,16 @@ const buildTheme = (tokens, flags) => {
           left: 'left',
         },
       },
-      // treat flat array of menu items as a single "group" stylistically
       container: {
         pad: {
+          vertical: components.hpe.menu.default.medium.group.container.paddingY,
           horizontal:
             components.hpe.menu.default.medium.group.container.paddingX,
-          vertical: components.hpe.menu.default.medium.group.container.paddingY,
         },
+        gap: components.hpe.menu.default.medium.group.container.gapY,
       },
       group: {
+        drop: {},
         container: {
           pad: {
             horizontal:
@@ -2016,11 +2161,12 @@ const buildTheme = (tokens, flags) => {
             vertical:
               components.hpe.menu.default.medium.group.container.paddingY,
           },
+          gap: components.hpe.menu.default.medium.group.container.gapY,
         },
         separator: {
           color: components.hpe.menu.default.group.separator.background,
           size: components.hpe.menu.default.medium.group.separator.height,
-          pad: 'none', // TO DO no token
+          pad: 'none',
         },
       },
       icons: {
@@ -2400,7 +2546,6 @@ const buildTheme = (tokens, flags) => {
       },
     },
     paragraph: {
-      // TO DO this is enabling more than xxlarge
       ...paragraphTheme,
     },
     radioButton: {
@@ -2419,9 +2564,6 @@ const buildTheme = (tokens, flags) => {
       container: {
         extend: ({ theme }) => `
           width: auto;
-          padding-inline: ${
-            components.hpe.formField.default.medium.input.group.item.paddingX
-          };
           &:has(input[checked]) {
             & div:has(> svg[aria-hidden="true"]) {
               background: ${getThemeColor(
@@ -2452,14 +2594,10 @@ const buildTheme = (tokens, flags) => {
           }
           `,
       },
-      extend: () => `
-      padding-block: ${components.hpe.formField.default.medium.input.group.item.paddingY};
-    `,
       gap: components.hpe.radioButton.default.medium.gapX,
       hover: {
         background: {
-          color:
-            components.hpe.formField.default.input.group.item.hover.background,
+          color: 'transparent',
         },
         border: {
           color: components.hpe.radioButton.default.control.hover.borderColor,
@@ -2483,12 +2621,9 @@ const buildTheme = (tokens, flags) => {
     },
     radioButtonGroup: {
       container: {
-        gap: 'none', // TO DO should be token?
-        margin: {
-          vertical:
-            components.hpe.formField.default.medium.input.group.container
-              .paddingY,
-        },
+        cssGap: true,
+        gap: 'small',
+        margin: 'none',
       },
     },
     rangeInput: {
@@ -2500,8 +2635,9 @@ const buildTheme = (tokens, flags) => {
           color: 'background-primary-strong',
         },
         upper: {
-          color: 'border',
+          color: primitives.hpe.base.color['grey-500'],
         },
+        extend: () => `border-radius: ${large.hpe.radius.full};`,
       },
     },
     select: {
@@ -2516,23 +2652,41 @@ const buildTheme = (tokens, flags) => {
             horizontal: components.hpe.select.default.medium.drop.paddingX,
           },
           hover: {
-            background: 'background-contrast',
+            background: 'background-hover',
           },
           round: 'xsmall',
         },
         text: {
-          color: 'text-strong',
-          weight: 600,
+          color: components.hpe.button.default.rest.textColor,
+          weight: components.hpe.button.default.rest.fontWeight,
         },
       },
       control: {
-        extend: ({ disabled }) => css`
+        extend: ({ disabled, theme }) => css`
           ${disabled &&
           `
           opacity: 0.3;
           input {
             cursor: default;
           }`}
+
+          &[class*="SelectMultiple"] [role="listbox"] {
+            padding-block: ${components.hpe.select.default.medium.drop
+              .paddingY};
+            padding-inline: ${components.hpe.select.default.medium.drop
+              .paddingX};
+            & [role='option'] {
+              border-radius: ${dimensions.edgeSize[
+                components.hpe.select.default.medium.option.borderRadius
+              ] || components.hpe.select.default.medium.option.borderRadius};
+              &:hover {
+                background: ${getThemeColor(
+                  components.hpe.select.default.option.hover.backgroud,
+                  theme,
+                )};
+              }
+            }
+          }
         `,
       },
       emptySearchMessage: {
@@ -2564,6 +2718,27 @@ const buildTheme = (tokens, flags) => {
           display: flex;
           flex-direction: column;
           gap: ${components.hpe.select.default.medium.drop.gapY};
+          [role="option"] {
+            border-radius: ${components.hpe.select.default.medium.option.borderRadius};
+          }
+        `,
+      },
+    },
+    selectMultiple: {
+      listbox: {
+        extend: () => `
+          padding-block: ${components.hpe.select.default.medium.drop.paddingY};
+          padding-inline: ${components.hpe.select.default.medium.drop.paddingX};
+          display: flex;
+          flex-direction: column;
+          [role="option"] {
+              border-radius: ${
+                dimensions.edgeSize[
+                  components.hpe.select.default.medium.option.borderRadius
+                ] || components.hpe.select.default.medium.option.borderRadius
+              };
+            }
+          }
         `,
       },
     },
@@ -2572,10 +2747,10 @@ const buildTheme = (tokens, flags) => {
         pad: 'none',
         color: 'foreground-primary',
         border: [
-          { color: 'border-weak', side: 'all', size: 'medium' },
-          { color: 'border-weak', side: 'right', size: 'medium' },
-          { color: 'border-weak', side: 'top', size: 'medium' },
-          { color: 'border-weak', side: 'left', size: 'medium' },
+          { color: 'transparent', side: 'all', size: 'medium' },
+          { color: 'transparent', side: 'right', size: 'medium' },
+          { color: 'transparent', side: 'top', size: 'medium' },
+          { color: 'transparent', side: 'left', size: 'medium' },
         ],
       },
       size: {
@@ -2592,52 +2767,59 @@ const buildTheme = (tokens, flags) => {
     tab: {
       color: 'text',
       active: {
-        background: undefined,
-        color: 'text-strong',
-        weight: 600,
+        background: 'background-selected-primary-strong',
+        color: 'text-onSelectedPrimaryStrong',
+        weight: 500,
       },
       hover: {
-        background: 'transparent',
+        background: 'background-hover',
         color: 'text',
       },
       border: {
-        side: 'bottom',
+        side: 'all',
         color: 'transparent',
-        size: 'medium',
+        size:
+          dimensions[components.hpe.element?.medium.borderWidth] ||
+          components.hpe.element?.medium.borderWidth,
         active: {
-          color: 'brand',
+          color: 'transparent',
         },
         disabled: {
           color: undefined,
         },
         hover: {
-          color: 'border-weak',
+          color: undefined,
         },
       },
       disabled: {
+        background: 'background-disabled',
         color: 'text-disabled',
       },
       pad: {
-        // top and bottom pad need to be defined individually, specifying
-        // "vertical" only applies to top
-        bottom: '9px',
-        top: '9px',
-        // align horizontal pad with button
-        horizontal: '18px',
+        bottom: components.hpe.element?.medium.paddingY,
+        top: components.hpe.element?.medium.paddingY,
+        horizontal: components.hpe.element?.medium?.paddingX?.wide,
       },
       margin: {
-        // bring the overall tabs border behind invidual tab borders
-        vertical: '-1px',
+        vertical: 'none',
         horizontal: 'none',
       },
+      extend: ({ theme }) => `border-radius: ${theme.global.edgeSize.xsmall};`,
     },
     tabs: {
+      gap: 'xsmall',
       header: {
-        border: {
-          side: 'bottom',
-          size: 'xsmall',
-          color: 'border-weak',
-        },
+        border: undefined,
+        extend: ({ theme }) => `
+          border-radius: ${theme.global.edgeSize.xsmall}; 
+          & button[aria-selected="true"]:hover > div {
+            background: ${getThemeColor(
+              'background-selected-primary-strong-hover',
+              theme,
+            )};
+            color: ${getThemeColor('text-onSelectedPrimaryStrong', theme)};
+          }
+        `,
       },
       step: {
         xsmall: 1,
@@ -2664,7 +2846,7 @@ const buildTheme = (tokens, flags) => {
           horizontal: components.hpe.dataCell.default.medium.paddingX,
         },
         border: {
-          side: 'bottom', // TO DO this causes issues on the last row with the footer border
+          side: 'bottom',
           color: components.hpe.dataCell.default.rest.borderColor,
         },
         extend: ({ theme }) =>
@@ -2693,7 +2875,7 @@ const buildTheme = (tokens, flags) => {
     },
     tag: {
       border: {
-        color: 'border',
+        color: 'border-weak',
       },
       icons: {
         remove: Close,
@@ -2708,7 +2890,7 @@ const buildTheme = (tokens, flags) => {
       value: {
         weight: global.hpe.fontWeight.medium,
       },
-      round: 'large',
+      round: 'xsmall',
       size: {
         xsmall: {
           icon: undefined,
@@ -2737,7 +2919,6 @@ const buildTheme = (tokens, flags) => {
             },
           },
         },
-        // TO DO tag rounding is overriding "default" rounding, do we expect this?
         medium: {
           icon: undefined,
           pad: {
@@ -2821,25 +3002,20 @@ const buildTheme = (tokens, flags) => {
     },
     toggleGroup: {
       button: {
-        pad: {
-          // these are fine since it is built with buttons
-          vertical: '6px',
-          horizontal: '12px',
-        },
-        iconOnly: {
-          // Q this will be a token?
-          pad: {
-            vertical: parseInt(mediumIconOnlyPad, 10),
-            horizontal: parseInt(mediumIconOnlyPad, 10),
-          },
-        },
+        kind: 'toolbar',
       },
       container: {
-        border: {
-          color: components.hpe.button.toolbar.rest.borderColor,
-          size: components.hpe.button.toolbar.medium.borderWidth,
-        },
+        border: false,
+        extend: ({ theme }) => `
+        gap: ${
+          dimensions.edgeSize[large.hpe.spacing['5xsmall']] ||
+          large.hpe.spacing['5xsmall']
+        };
+        &:hover {
+          background: ${getThemeColor('background-hover', theme)};
+        }`,
       },
+      divider: false,
     },
     // Theme-Designer only parameters
     name: 'HPE 1',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
https://deploy-preview-4766--rad-shortbread-897892.netlify.app/

#### What does this PR do?

Making v1 design tokens the "default" values, and moving v0 values into the "opt-out" mode for Figma.

Updates build-style-dictionary script to now exclude any file with `v0` (similar to how the [original PR](https://github.com/grommet/hpe-design-system/pull/4726/files) excluded any file with `v1`).

Copied v1 specific theming into sandbox/grommet-app so that deploy preview represents new theming.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
