### PR TITLE
All tokens - Nav menu tweaks

### DIFF
--- a/aries-site/src/components/content/DesignTokensTable.js
+++ b/aries-site/src/components/content/DesignTokensTable.js
@@ -24,6 +24,70 @@ import {
 } from './designTokenUtils';
 import { DesignTokenContext } from './DesignTokenContext';
 
+const tokenColumns = [
+  {
+    property: 'id',
+    header: 'Preview',
+    render: datum => {
+      if (datum.type === 'color') return <ColorPreview datum={datum} />;
+
+      if (
+        datum.token.includes('size') ||
+        datum.token.includes('dimension') ||
+        datum.token.includes('spacing') ||
+        datum.token.includes('gap')
+      )
+        return <DimensionPreview datum={datum} />;
+      if (
+        datum.token.includes('radius') ||
+        datum.token.includes('borderRadius') ||
+        /border.*Radius/.test(datum.token)
+      )
+        return <RadiusPreview datum={datum} />;
+      if (datum.token.includes('border'))
+        return <BorderPreview datum={datum} />;
+      if (datum.token.includes('weight') || datum.token.includes('fontWeight'))
+        return <WeightPreview datum={datum} />;
+      if (
+        (datum.token.includes('font') && datum.token.includes('size')) ||
+        datum.token.includes('fontSize')
+      )
+        return <TextPreview datum={datum} />;
+      return '--';
+    },
+    size: 'auto',
+    pin: true,
+  },
+  {
+    property: 'token',
+    header: 'Token',
+    render: datum => (
+      <Box direction="row">
+        <Box
+          background="background-contrast"
+          pad="xsmall"
+          round="xsmall"
+          style={{ fontFamily: 'Menlo' }}
+        >
+          <Text size="xsmall">{datum.token}</Text>
+        </Box>
+      </Box>
+    ),
+  },
+  {
+    property: 'description',
+    header: 'Description',
+    size: 'medium',
+    render: datum => (
+      <Text>{datum.description ? datum.description : '--'}</Text>
+    ),
+  },
+  {
+    property: 'value',
+    header: 'Output value',
+  },
+];
+
 export const DesignTokensTable = ({ active, maxHeight, toolbar }) => {
   const { data, setData, selectedMode, setSelectedMode, modes } =
     useContext(DesignTokenContext);
@@ -50,29 +114,31 @@ export const DesignTokensTable = ({ active, maxHeight, toolbar }) => {
             <DataSearch />
             {modeOptions?.length > 1 ? (
               // eslint-disable-next-line grommet/formfield-htmlfor-id
-              <FormField
-                label="Mode"
-                contentProps={{ margin: { bottom: 'none', top: 'xsmall' } }}
-                htmlFor={`mode-select-${active}__input`}
-                name={`mode-select-${active}`}
-              >
-                <Select
+              <Box width="small">
+                <FormField
+                  label="Mode"
+                  contentProps={{ margin: { bottom: 'none', top: 'xsmall' } }}
+                  htmlFor={`mode-select-${active}__input`}
                   name={`mode-select-${active}`}
-                  id={`mode-select-${active}`}
-                  options={modeOptions}
-                  value={mode}
-                  onChange={({ option }) => {
-                    const keyPath = active.split('.');
+                >
+                  <Select
+                    name={`mode-select-${active}`}
+                    id={`mode-select-${active}`}
+                    options={modeOptions}
+                    value={mode}
+                    onChange={({ option }) => {
+                      const keyPath = active.split('.');
 
-                    let res = structuredTokens;
-                    keyPath.forEach(key => {
-                      res = res[key];
-                    });
-                    handleData(getTokens(res, option));
-                    handleMode(option);
-                  }}
-                />
-              </FormField>
+                      let res = structuredTokens;
+                      keyPath.forEach(key => {
+                        res = res[key];
+                      });
+                      handleData(getTokens(res, option));
+                      handleMode(option);
+                    }}
+                  />
+                </FormField>
+              </Box>
             ) : undefined}
           </Toolbar>
           <DataSummary />
@@ -86,73 +152,7 @@ export const DesignTokensTable = ({ active, maxHeight, toolbar }) => {
           aria-describedby="token-table-heading"
           verticalAlign="top"
           primaryKey="token"
-          columns={[
-            {
-              property: 'id',
-              header: 'Preview',
-              render: datum => {
-                if (datum.type === 'color')
-                  return <ColorPreview datum={datum} />;
-
-                if (
-                  datum.token.includes('size') ||
-                  datum.token.includes('dimension') ||
-                  datum.token.includes('spacing') ||
-                  datum.token.includes('gap')
-                )
-                  return <DimensionPreview datum={datum} />;
-                if (
-                  datum.token.includes('radius') ||
-                  datum.token.includes('borderRadius') ||
-                  /border.*Radius/.test(datum.token)
-                )
-                  return <RadiusPreview datum={datum} />;
-                if (datum.token.includes('border'))
-                  return <BorderPreview datum={datum} />;
-                if (
-                  datum.token.includes('weight') ||
-                  datum.token.includes('fontWeight')
-                )
-                  return <WeightPreview datum={datum} />;
-                if (
-                  (datum.token.includes('font') &&
-                    datum.token.includes('size')) ||
-                  datum.token.includes('fontSize')
-                )
-                  return <TextPreview datum={datum} />;
-                return '--';
-              },
-              size: 'auto',
-            },
-            {
-              property: 'token',
-              header: 'Token',
-              render: datum => (
-                <Box direction="row">
-                  <Box
-                    background="background-contrast"
-                    pad="xsmall"
-                    round="xsmall"
-                    style={{ fontFamily: 'Menlo' }}
-                  >
-                    <Text size="xsmall">{datum.token}</Text>
-                  </Box>
-                </Box>
-              ),
-            },
-            {
-              property: 'description',
-              header: 'Description',
-              size: 'medium',
-              render: datum => (
-                <Text>{datum.description ? datum.description : '--'}</Text>
-              ),
-            },
-            {
-              property: 'value',
-              header: 'Output value',
-            },
-          ]}
+          columns={tokenColumns}
         />
       </Box>
     </Data>

--- a/aries-site/src/components/content/DesignTokensTable.js
+++ b/aries-site/src/components/content/DesignTokensTable.js
@@ -113,7 +113,6 @@ export const DesignTokensTable = ({ active, maxHeight, toolbar }) => {
           <Toolbar align="end">
             <DataSearch />
             {modeOptions?.length > 1 ? (
-              // eslint-disable-next-line grommet/formfield-htmlfor-id
               <Box width="small">
                 <FormField
                   label="Mode"

--- a/aries-site/src/components/content/designTokenUtils.js
+++ b/aries-site/src/components/content/designTokenUtils.js
@@ -5,20 +5,20 @@ import * as tokens from 'hpe-design-tokens/docs';
 import { Box, Text } from 'grommet';
 
 const structuredTokens = {
-  primitive: {},
+  primitives: {},
   semantic: {},
   component: {},
 };
 
 Object.keys(tokens).forEach(mode => {
-  // base, component, light, dark, etc.
+  // primitives, component, light, dark, etc.
   Object.keys(tokens[mode]).forEach(token => {
     const currentToken = tokens[mode][token];
 
     const parts = token.split('.');
     const category = parts[1];
     let level;
-    if (mode === 'base') level = 'primitive';
+    if (mode === 'primitives') level = 'primitives';
     else if (mode === 'components') level = 'component';
     else level = 'semantic';
 

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -27,7 +27,7 @@ const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
   );
 
   return (
-    <Box flex={false}>
+    <Box flex={false} gap="xxsmall">
       <Button
         icon={<Folder aria-hidden="true" />}
         a11yTitle={`${collection} token directory`}
@@ -37,7 +37,7 @@ const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
         onClick={() => setOpen(!open)}
       />
       <Collapsible open={open}>
-        <Box pad={{ left: 'medium' }} flex={false}>
+        <Box pad={{ left: 'medium' }} flex={false} gap="hair">
           {Object.keys(tokensObj[collection])
             .sort()
             .map(category => (
@@ -54,6 +54,7 @@ const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
     </Box>
   );
 };
+
 const Nav = ({ active, setActive, tokens: tokensObj }) => {
   return Object.keys(tokensObj).map(collection => (
     <NavSection
@@ -140,7 +141,7 @@ const AllTokens = () => {
 
   return (
     <DesignTokenContext.Provider value={contextValue}>
-      <Page kind="full">
+      <Page>
         <Box direction="row" gap="large">
           {['large', 'xlarge'].includes(breakpoint) ? (
             <Box {...menuStyle}>{navContent}</Box>

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -20,14 +20,12 @@ import {
   useDesignTokens,
 } from '../../components';
 
-const NavSection = ({
-  active,
-  collection,
-  setActive,
-  tokens: tokensObj,
-  open,
-  setOpen,
-}) => {
+const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
+  const activeParts = active.split('.');
+  const [open, setOpen] = useState(
+    activeParts[activeParts.length - 1] in structuredTokens[collection],
+  );
+
   return (
     <Box flex={false} gap="xxsmall">
       <Button
@@ -61,11 +59,6 @@ const NavSection = ({
 };
 
 const Nav = ({ active, setActive, tokens: tokensObj }) => {
-  const activeParts = active.split('.');
-  const [open, setOpen] = useState(
-    activeParts.at[-1] in tokensObj ? '' : activeParts[0],
-  );
-
   return Object.keys(tokensObj).map(collection => (
     <NavSection
       key={collection}
@@ -73,8 +66,6 @@ const Nav = ({ active, setActive, tokens: tokensObj }) => {
       collection={collection}
       active={active}
       setActive={setActive}
-      open={collection === open}
-      setOpen={setOpen}
     />
   ));
 };
@@ -83,9 +74,8 @@ const NavPane = ({ children, ...rest }) => {
   return (
     <Box
       background="background-contrast"
-      pad={{ horizontal: 'small', vertical: 'medium' }}
+      pad={{ left: 'small', right: 'large', vertical: 'medium' }}
       round="medium"
-      width="small"
       {...rest}
     >
       {children}
@@ -170,7 +160,7 @@ const AllTokens = () => {
               }}
               height="100vh"
             >
-              <NavPane>{navContent}</NavPane>
+              <NavPane overflow="auto">{navContent}</NavPane>
             </Box>
           ) : undefined}
           <PageContent pad="none" alignSelf="start">

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -20,12 +20,14 @@ import {
   useDesignTokens,
 } from '../../components';
 
-const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
-  const activeParts = active.split('.');
-  const [open, setOpen] = useState(
-    activeParts[activeParts.length - 1] in structuredTokens[collection],
-  );
-
+const NavSection = ({
+  active,
+  collection,
+  setActive,
+  tokens: tokensObj,
+  open,
+  setOpen,
+}) => {
   return (
     <Box flex={false} gap="xxsmall">
       <Button
@@ -34,7 +36,10 @@ const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
         justify="start"
         align="start"
         label={collection}
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          if (open) setOpen('');
+          else setOpen(collection);
+        }}
       />
       <Collapsible open={open}>
         <Box pad={{ left: 'medium' }} flex={false} gap="hair">
@@ -56,6 +61,11 @@ const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
 };
 
 const Nav = ({ active, setActive, tokens: tokensObj }) => {
+  const activeParts = active.split('.');
+  const [open, setOpen] = useState(
+    activeParts.at[-1] in tokensObj ? '' : activeParts[0],
+  );
+
   return Object.keys(tokensObj).map(collection => (
     <NavSection
       key={collection}
@@ -63,29 +73,22 @@ const Nav = ({ active, setActive, tokens: tokensObj }) => {
       collection={collection}
       active={active}
       setActive={setActive}
+      open={collection === open}
+      setOpen={setOpen}
     />
   ));
 };
 
-const NavPane = ({ children }) => {
-  const theme = useContext(ThemeContext);
+const NavPane = ({ children, ...rest }) => {
   return (
     <Box
-      flex={false}
-      style={{
-        position: 'sticky',
-        top: theme.global.edgeSize.medium,
-      }}
-      height="130vh"
+      background="background-contrast"
+      pad={{ horizontal: 'small', vertical: 'medium' }}
+      round="medium"
+      width="small"
+      {...rest}
     >
-      <Box
-        background="background-contrast"
-        pad={{ horizontal: 'small', vertical: 'medium' }}
-        round="medium"
-        width="small"
-      >
-        {children}
-      </Box>
+      {children}
     </Box>
   );
 };
@@ -109,6 +112,7 @@ const NavLayer = ({ children, onClose }) => {
 const AllTokens = () => {
   const [openLayer, setOpenLayer] = useState(false);
   const breakpoint = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
   const {
     data,
     setData,
@@ -153,7 +157,16 @@ const AllTokens = () => {
       <Page>
         <Box direction="row" gap="large">
           {['large', 'xlarge'].includes(breakpoint) ? (
-            <NavPane>{navContent}</NavPane>
+            <Box
+              flex="grow"
+              style={{
+                position: 'sticky',
+                top: theme.global.edgeSize.medium,
+              }}
+              height="100vh"
+            >
+              <NavPane>{navContent}</NavPane>
+            </Box>
           ) : undefined}
           <PageContent pad="none" alignSelf="start">
             <Box pad="medium" round="medium" background="background-front">

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -141,8 +141,13 @@ const AllTokens = () => {
     [data, setData, active, setActive, selectedMode, setSelectedMode, modes],
   );
 
+  const onActive = value => {
+    setActive(value);
+    if (openLayer) setOpenLayer(false);
+  };
+
   const navContent = (
-    <Nav tokens={structuredTokens} active={active} setActive={setActive} />
+    <Nav tokens={structuredTokens} active={active} setActive={onActive} />
   );
 
   const activeCollection = active

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -155,7 +155,7 @@ const AllTokens = () => {
           {['large', 'xlarge'].includes(breakpoint) ? (
             <NavPane>{navContent}</NavPane>
           ) : undefined}
-          <PageContent pad="none">
+          <PageContent pad="none" alignSelf="start">
             <Box pad="medium" round="medium" background="background-front">
               <Box direction="row" align="center" gap="small">
                 {!['large', 'xlarge'].includes(breakpoint) ? (

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -66,6 +66,22 @@ const Nav = ({ active, setActive, tokens: tokensObj }) => {
   ));
 };
 
+const NavLayer = ({ children, onClose }) => {
+  return (
+    <Layer onEsc={onClose} full>
+      <Box pad="medium" gap="small" overflow="auto">
+        <Button
+          icon={<Close />}
+          a11yTitle="Close design token navigation."
+          alignSelf="end"
+          onClick={onClose}
+        />
+        {children}
+      </Box>
+    </Layer>
+  );
+};
+
 const AllTokens = () => {
   const [openLayer, setOpenLayer] = useState(false);
   const breakpoint = useContext(ResponsiveContext);
@@ -115,6 +131,13 @@ const AllTokens = () => {
     width: 'small',
   };
 
+  const activeCollection = active
+    .split('.')
+    .map(
+      (part, index) =>
+        `${part} ${index < active.split('.').length - 1 ? '/ ' : ''}`,
+    );
+
   return (
     <DesignTokenContext.Provider value={contextValue}>
       <Page kind="full">
@@ -134,28 +157,8 @@ const AllTokens = () => {
                   />
                 ) : undefined}
                 <Heading level={2} margin="none" id="token-table-heading">
-                  {active
-                    .split('.')
-                    .map(
-                      (part, index) =>
-                        `${part} ${
-                          index < active.split('.').length - 1 ? '/ ' : ''
-                        }`,
-                    )}
+                  {activeCollection}
                 </Heading>
-                {openLayer ? (
-                  <Layer onEsc={() => setOpenLayer(false)} full>
-                    <Box pad="medium" gap="small" overflow="auto">
-                      <Button
-                        icon={<Close />}
-                        a11yTitle="Close design token navigation."
-                        alignSelf="end"
-                        onClick={() => setOpenLayer(false)}
-                      />
-                      {navContent}
-                    </Box>
-                  </Layer>
-                ) : undefined}
               </Box>
               {active.includes('primitive') ? (
                 <Notification
@@ -174,6 +177,11 @@ const AllTokens = () => {
               />
             </Box>
           </PageContent>
+          {openLayer && (
+            <NavLayer onClose={() => setOpenLayer(false)}>
+              {navContent}
+            </NavLayer>
+          )}
         </Box>
       </Page>
     </DesignTokenContext.Provider>

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -67,6 +67,29 @@ const Nav = ({ active, setActive, tokens: tokensObj }) => {
   ));
 };
 
+const NavPane = ({ children }) => {
+  const theme = useContext(ThemeContext);
+  return (
+    <Box
+      flex={false}
+      style={{
+        position: 'sticky',
+        top: theme.global.edgeSize.medium,
+      }}
+      height="130vh"
+    >
+      <Box
+        background="background-contrast"
+        pad={{ horizontal: 'small', vertical: 'medium' }}
+        round="medium"
+        width="small"
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
 const NavLayer = ({ children, onClose }) => {
   return (
     <Layer onEsc={onClose} full>
@@ -86,7 +109,6 @@ const NavLayer = ({ children, onClose }) => {
 const AllTokens = () => {
   const [openLayer, setOpenLayer] = useState(false);
   const breakpoint = useContext(ResponsiveContext);
-  const theme = useContext(ThemeContext);
   const {
     data,
     setData,
@@ -119,19 +141,6 @@ const AllTokens = () => {
     <Nav tokens={structuredTokens} active={active} setActive={setActive} />
   );
 
-  const menuStyle = {
-    flex: false,
-    style: {
-      position: 'sticky',
-      top: theme.global.edgeSize.medium,
-    },
-    height: '130vh',
-    background: 'background-contrast',
-    pad: { horizontal: 'small', vertical: 'medium' },
-    round: 'medium',
-    width: 'small',
-  };
-
   const activeCollection = active
     .split('.')
     .map(
@@ -144,7 +153,7 @@ const AllTokens = () => {
       <Page>
         <Box direction="row" gap="large">
           {['large', 'xlarge'].includes(breakpoint) ? (
-            <Box {...menuStyle}>{navContent}</Box>
+            <NavPane>{navContent}</NavPane>
           ) : undefined}
           <PageContent pad="none">
             <Box pad="medium" round="medium" background="background-front">

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -85,10 +85,6 @@ const AllTokens = () => {
       setOpenLayer(false);
   }, [breakpoint, openLayer]);
 
-  const navContent = (
-    <Nav tokens={structuredTokens} active={active} setActive={setActive} />
-  );
-
   const contextValue = useMemo(
     () => ({
       data,
@@ -102,27 +98,29 @@ const AllTokens = () => {
     [data, setData, active, setActive, selectedMode, setSelectedMode, modes],
   );
 
+  const navContent = (
+    <Nav tokens={structuredTokens} active={active} setActive={setActive} />
+  );
+
+  const menuStyle = {
+    flex: false,
+    style: {
+      position: 'sticky',
+      top: theme.global.edgeSize.medium,
+    },
+    height: '130vh',
+    background: 'background-contrast',
+    pad: { horizontal: 'small', vertical: 'medium' },
+    round: 'medium',
+    width: 'small',
+  };
+
   return (
     <DesignTokenContext.Provider value={contextValue}>
       <Page kind="full">
         <Box direction="row" gap="large">
           {['large', 'xlarge'].includes(breakpoint) ? (
-            <Box
-              width="medium"
-              pad="medium"
-              border={{ color: 'border-weak' }}
-              round="medium"
-              flex={false}
-              style={{
-                position: 'sticky',
-                top: theme.global.edgeSize.medium,
-                bottom: 0,
-              }}
-              height="100vh"
-              overflow="auto"
-            >
-              {navContent}
-            </Box>
+            <Box {...menuStyle}>{navContent}</Box>
           ) : undefined}
           <PageContent pad="none">
             <Box pad="medium" round="medium" background="background-front">

--- a/aries-site/src/pages/design-tokens/all-design-tokens.js
+++ b/aries-site/src/pages/design-tokens/all-design-tokens.js
@@ -38,15 +38,17 @@ const NavSection = ({ active, collection, setActive, tokens: tokensObj }) => {
       />
       <Collapsible open={open}>
         <Box pad={{ left: 'medium' }} flex={false}>
-          {Object.keys(tokensObj[collection]).map(category => (
-            <Button
-              key={category}
-              align="start"
-              label={category}
-              active={active === `${collection}.${category}`}
-              onClick={() => setActive(`${collection}.${category}`)}
-            />
-          ))}
+          {Object.keys(tokensObj[collection])
+            .sort()
+            .map(category => (
+              <Button
+                key={category}
+                align="start"
+                label={category}
+                active={active === `${collection}.${category}`}
+                onClick={() => setActive(`${collection}.${category}`)}
+              />
+            ))}
         </Box>
       </Collapsible>
     </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-4785--keen-mayer-a86c8b.netlify.app/design-tokens/all-design-tokens)

#### What does this PR do?

- Fixed primitives collection bug where 'base' was being referenced, but we renamed to primitives
- Some layout tweaks
  - Only occupy needed width
- Some nav menu styling tweaks
  - Trying to find styling which doesn't require borders (alternate is no background with single border on right)
- Changed nav menu behavior to only have one directory open at a time. This was to address the ability to support sticky menu, while avoiding menu item overflow / the need for an overflow scroll. Ensures the menu is always present without need for excessive div height to prevent overflow.
- Close Nav layer when menu item is selected.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
