### PR TITLE
Create DateInputInlineExample.js

### DIFF
--- a/aries-site/src/examples/components/dateinput/DateInputInlineExample.js
+++ b/aries-site/src/examples/components/dateinput/DateInputInlineExample.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, DateInput } from 'grommet';
+
+export const DateInputSimpleExample = () => {
+  const [value, setValue] = React.useState('');
+  const onChange = event => {
+    const nextValue = event.value;
+    setValue(nextValue);
+  };
+  return (
+    <Box align="center" pad="large">
+      <DateInput
+        aria-label="dateinput"
+        name="dateinput"
+        id="dateinput"
+        inline
+        value={value}
+        onChange={onChange}
+        format="mm/dd/yyyy"
+      />
+    </Box>
+  );
+};


### PR DESCRIPTION
Added date input inline variant example based on:

https://storybook.grommet.io/?path=/story/input-dateinput-inline--inline

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Adds a new configuration example to the site that was missing.
