### PR TITLE
Fix issue with default icon in wcag compliance accordion

### DIFF
--- a/aries-site/src/layouts/content/WCAGRuleDetail.js
+++ b/aries-site/src/layouts/content/WCAGRuleDetail.js
@@ -149,7 +149,7 @@ export const WCAGRuleDetail = ({ rules, version }) => {
                           ? item
                           : worst;
                       },
-                      { status: 'conditional' },
+                      { status: 'passed' },
                     ).status,
                   )}
                   <Heading margin={{ vertical: 'small' }} level={4}>


### PR DESCRIPTION


<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
The WCAG accordion was defualting to showing the conditional icon. This resulted in sections where all the rules are passing showing a conditional icon in the accordion header.

Before:
<img width="794" alt="Screenshot 2025-03-26 at 2 55 05 PM" src="https://github.com/user-attachments/assets/02b32440-a4a1-4f0d-8195-9a1455f7b4cc" />

After: 
<img width="799" alt="Screenshot 2025-03-26 at 2 55 58 PM" src="https://github.com/user-attachments/assets/91081a62-2b6a-4403-a1e9-85cdf74c37d5" />

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
