### PR TITLE
A11y radiobuttongroup evaluated

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -1342,6 +1342,7 @@ export const components = [
       'RadioButtonGroup is a component that offers related options to a user, but only allows them to choose one.',
     seoDescription:
       'The RadioButtonGroup component is used when you want the user to choose only one out of a set of related options. See best UX practices, error messages, and how HPE styles the disabled state.',
+    accessibility: 'Passed WCAG 2.2 AA',
     sections: ['When to use RadioButtonGroup'],
     preview: {
       component: () => <RadioButtonGroupPreview />,

--- a/aries-site/src/data/wcag/radiobuttongroup.json
+++ b/aries-site/src/data/wcag/radiobuttongroup.json
@@ -308,7 +308,7 @@
   {
     "rule": "2.5.5",
     "label": "Target Size (Enhanced)",
-    "status": "needs discussion",
+    "status": "failed",
     "notes": "Width of radio button plus label exceeds 44px. Vertical spacing between radio buttons is 12px, creating overall 48px when above small breakpoint."
   },
   {

--- a/aries-site/src/data/wcag/radiobuttongroup.json
+++ b/aries-site/src/data/wcag/radiobuttongroup.json
@@ -1,0 +1,445 @@
+[
+  {
+    "rule": "1.1.1",
+    "label": "Non-text content",
+    "status": "conditional",
+    "notes": "Passes when strings or numbers are used as the option labels. If an element is used as a label and contains non-text content, it must have a text alternative."
+  },
+  {
+    "rule": "1.2.1",
+    "label": "Audio-only and Video-only (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.2",
+    "label": "Captions (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.3",
+    "label": "Audio Description or Media Alternative (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.4",
+    "label": "Captions (Live)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.5",
+    "label": "Audio Description (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.6",
+    "label": "Sign Language (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.7",
+    "label": "Extended Audio Description (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.8",
+    "label": "Media Alternative (Prerecorded)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.2.9",
+    "label": "Audio-only (Live)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.3.1",
+    "label": "Info and Relationships",
+    "status": "passed",
+    "notes": "Uses role='radiogroup', <label />, <input type='radio' /> to convey relationships."
+  },
+  {
+    "rule": "1.3.2",
+    "label": "Meaningful Sequence",
+    "status": "passed",
+    "notes": "Tab / arrow key navigation follows sequence."
+  },
+  {
+    "rule": "1.3.3",
+    "label": "Sensory Characteristics",
+    "status": "passed"
+  },
+  {
+    "rule": "1.3.4",
+    "label": "Orientation",
+    "status": "passed"
+  },
+  {
+    "rule": "1.3.5",
+    "label": "Identify Input Purpose",
+    "status": "not-applicable",
+    "notes": "Use cases likely do not collect information listed under input purposes."
+  },
+  {
+    "rule": "1.3.6",
+    "label": "Identify Purpose",
+    "status": "passed",
+    "notes": "Uses role='radiogroup', <label />, <input type='radio' /> identify purpose."
+  },
+  {
+    "rule": "1.4.1",
+    "label": "Use of Color",
+    "status": "passed",
+    "notes": "Uses distinct fill treatments and <input checked /> value to distinguish checked state."
+  },
+  {
+    "rule": "1.4.2",
+    "label": "Audio Control",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.4.3",
+    "label": "Contrast (Minimum)",
+    "status": "passed",
+    "notes": "Radio button border, background, and label have sufficient contrast with intended backgrounds."
+  },
+  {
+    "rule": "1.4.4",
+    "label": "Resize Text",
+    "status": "passed"
+  },
+  {
+    "rule": "1.4.5",
+    "label": "Images of Text",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.4.6",
+    "label": "Contrast (Enhanced)",
+    "status": "failed",
+    "notes": "Label text has contrast ratio of 7.45 which exceeds 7.1 requirement on background-front. Contrast ratio of 6.95 on background-back does not meet threshold."
+  },
+  {
+    "rule": "1.4.7",
+    "label": "Low or No Background Audio",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.4.8",
+    "label": "Visual Presentation",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.4.9",
+    "label": "Images of Text (No Exception)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "1.4.10",
+    "label": "Reflow",
+    "status": "passed"
+  },
+  {
+    "rule": "1.4.11",
+    "label": "Non-text Contrast",
+    "status": "passed",
+    "notes": "Radio button selected state has 4.61 contrast ratio."
+  },
+  {
+    "rule": "1.4.12",
+    "label": "Text Spacing",
+    "status": "passed"
+  },
+  {
+    "rule": "1.4.13",
+    "label": "Content on Hover or Focus",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.1.1",
+    "label": "Keyboard",
+    "status": "passed"
+  },
+  {
+    "rule": "2.1.2",
+    "label": "No Keyboard Trap",
+    "status": "passed"
+  },
+  {
+    "rule": "2.1.3",
+    "label": "Keyboard (No Exception)",
+    "status": "passed"
+  },
+  {
+    "rule": "2.1.4",
+    "label": "Character Key Shortcuts",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.2.1",
+    "label": "Timing Adjustable",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.2.2",
+    "label": "Pause, Stop, Hide",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.2.3",
+    "label": "No Timing",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.2.4",
+    "label": "Interruptions",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.2.5",
+    "label": "Re-authenticating",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.2.6",
+    "label": "Timeouts",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.3.1",
+    "label": "Three Flashes or Below Threshold",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.3.2",
+    "label": "Three Flashes",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.3.3",
+    "label": "Animation from Interactions",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.1",
+    "label": "Bypass Blocks",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.2",
+    "label": "Page Titled",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.3",
+    "label": "Focus Order",
+    "status": "passed"
+  },
+  {
+    "rule": "2.4.4",
+    "label": "Link Purpose (In Context)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.5",
+    "label": "Multiple Ways",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.6",
+    "label": "Headings and Labels",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.7",
+    "label": "Focus Visible",
+    "status": "passed"
+  },
+  {
+    "rule": "2.4.8",
+    "label": "Location",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.9",
+    "label": "Link Purpose (Link Only)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.10",
+    "label": "Section Headings",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.4.11",
+    "label": "Focus Not Obscured (Minimum)",
+    "status": "passed"
+  },
+  {
+    "rule": "2.4.12",
+    "label": "Focus Not Obscured (Enhanced)",
+    "status": "passed"
+  },
+  {
+    "rule": "2.4.13",
+    "label": "Focus Appearance",
+    "status": "passed"
+  },
+  {
+    "rule": "2.5.1",
+    "label": "Pointer Gestures",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.5.2",
+    "label": "Pointer Cancellation",
+    "status": "passed",
+    "notes": "No down event."
+  },
+  {
+    "rule": "2.5.3",
+    "label": "Label in Name",
+    "status": "conditional",
+    "notes": "Implementer needs to ensure the ARIA label is informative to the user."
+  },
+  {
+    "rule": "2.5.4",
+    "label": "Motion Actuation",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.5.5",
+    "label": "Target Size (Enhanced)",
+    "status": "needs discussion",
+    "notes": "Width of radio button plus label exceeds 44px. Vertical spacing between radio buttons is 12px, creating overall 48px when above small breakpoint."
+  },
+  {
+    "rule": "2.5.6",
+    "label": "Concurrent Input Mechanisms",
+    "status": "passed"
+  },
+  {
+    "rule": "2.5.7",
+    "label": "Dragging Movements",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "2.5.8",
+    "label": "Target Size (Minimum)",
+    "status": "passed"
+  },
+  {
+    "rule": "3.1.1",
+    "label": "Language of Page",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.1.2",
+    "label": "Language of Parts",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.1.3",
+    "label": "Unusual Words",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.1.4",
+    "label": "Abbreviations",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.1.5",
+    "label": "Reading Level",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.1.6",
+    "label": "Pronunciation",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.2.1",
+    "label": "On Focus",
+    "status": "passed"
+  },
+  {
+    "rule": "3.2.2",
+    "status": "conditional",
+    "notes": "Conditional based on the implementation of the onChange function"
+  },
+  {
+    "rule": "3.2.3",
+    "label": "Consistent Navigation",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.2.4",
+    "label": "Consistent Identification",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.2.5",
+    "label": "Change on Request",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.2.6",
+    "label": "Consistent Help",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.1",
+    "label": "Error Identification",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.2",
+    "label": "Labels or Instructions",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.3",
+    "label": "Error Suggestion",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.4",
+    "label": "Error Prevention (Legal, Financial, Data)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.5",
+    "label": "Help",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.6",
+    "label": "Error Prevention (All)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.7",
+    "label": "Redundant Entry",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.8",
+    "label": "Accessible Authentication (Minimum)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "3.3.9",
+    "label": "Accessible Authentication (Enhanced)",
+    "status": "not-applicable"
+  },
+  {
+    "rule": "4.1.2",
+    "label": "Name, Role, Value",
+    "status": "conditional",
+    "notes": "Implementer needs to ensure the ARIA label is informative to the user."
+  },
+  {
+    "rule": "4.1.3",
+    "label": "Status Messages",
+    "status": "not-applicable"
+  }
+]

--- a/aries-site/src/pages/components/radiobuttongroup.mdx
+++ b/aries-site/src/pages/components/radiobuttongroup.mdx
@@ -1,4 +1,4 @@
-import { Example } from '../../layouts';
+import { AccessibilitySection, Example } from '../../layouts';
 import {
   RadioButtonGroupDisabledExample,
   RadioButtonGroupExample,
@@ -62,3 +62,9 @@ Indicates that the RadioButtonGroup input exists but cannot be interacted with u
 >
   <RadioButtonGroupDisabledExample />
 </Example>
+
+## Accessibility
+
+### WCAG compliance
+
+<AccessibilitySection title='radiobuttongroup' />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Related to https://github.com/grommet/hpe-design-system/issues/4963

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

#### Notifications
[Update]RadioButtonGroup

[Accessibility]

[WCAG rule documentation added]
