### PR TITLE
Added accessibility information for textarea

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -410,6 +410,7 @@ export const components = [
       'TextArea is a field used in forms to capture longer text. This component provides the user with space to type more characters than the TextInput field.',
     seoDescription:
       'When you need to allow the user to provide longer forms of content, use a TextArea component.',
+      accessibility: 'Passed WCAG 2.2 AA',
     sections: [],
     preview: {
       component: () => <TextAreaPreview />,

--- a/aries-site/src/data/wcag/textarea.json
+++ b/aries-site/src/data/wcag/textarea.json
@@ -446,7 +446,7 @@
     {
       "rule": "3.3.1",
       "label": "Error Identification",
-      "status": "",
+      "status": "not-applicable",
       "notes": ""
     },
     {

--- a/aries-site/src/data/wcag/textarea.json
+++ b/aries-site/src/data/wcag/textarea.json
@@ -1,0 +1,512 @@
+[
+    {
+      "rule": "1.1.1",
+      "label": "Non-text content",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.1",
+      "label": "Audio-only and Video-only (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.2",
+      "label": "Captions (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.3",
+      "label": "Audio Description or Media Alternative (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.4",
+      "label": "Captions (Live)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.5",
+      "label": "Audio Description (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.6",
+      "label": "Sign Language (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.7",
+      "label": "Extended Audio Description (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.8",
+      "label": "Media Alternative (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.9",
+      "label": "Audio-only (Live)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.1",
+      "label": "Info and Relationships",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.2",
+      "label": "Meaningful Sequence",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.3",
+      "label": "Sensory Characteristics",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.4",
+      "label": "Orientation",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.5",
+      "label": "Identify Input Purpose",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.6",
+      "label": "Identify Purpose",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.1",
+      "label": "Use of Color",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.2",
+      "label": "Audio Control",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.3",
+      "label": "Contrast (Minimum)",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.4",
+      "label": "Resize Text",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.5",
+      "label": "Images of Text",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.6",
+      "label": "Contrast (Enhanced)",
+      "status": "failed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.7",
+      "label": "Low or No Background Audio",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.8",
+      "label": "Visual Presentation",
+      "status": "conditional",
+      "notes": "Ensure the textarea defaults to a width of 80 characters or less, or provide a keyboard-accessible way to resize it."
+    },
+    {
+      "rule": "1.4.9",
+      "label": "Images of Text (No Exception)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.10",
+      "label": "Reflow",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.11",
+      "label": "Non-text Contrast",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.12",
+      "label": "Text Spacing",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.13",
+      "label": "Content on Hover or Focus",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.1.1",
+      "label": "Keyboard",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.1.2",
+      "label": "No Keyboard Trap",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.1.3",
+      "label": "Keyboard (No Exception)",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.1",
+      "label": "Timing Adjustable",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.2",
+      "label": "Pause, Stop, Hide",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.3",
+      "label": "No Timing",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.4",
+      "label": "Interruptions",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.5",
+      "label": "Re-authenticating",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.6",
+      "label": "Timeouts",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.3.1",
+      "label": "Three Flashes or Below Threshold",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.3.2",
+      "label": "Three Flashes",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.3.3",
+      "label": "Animation from Interactions",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.1",
+      "label": "Bypass Blocks",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.2",
+      "label": "Page Titled",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.3",
+      "label": "Focus Order",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.4",
+      "label": "Link Purpose (In Context)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.5",
+      "label": "Multiple Ways",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.6",
+      "label": "Headings and Labels",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.7",
+      "label": "Focus Visible",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.8",
+      "label": "Location",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.9",
+      "label": "Link Purpose (Link Only)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.10",
+      "label": "Section Headings",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.11",
+      "label": "Focus Not Obscured (Minimum)",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.12",
+      "label": "Focus Not Obscured (Enhanced)",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.13",
+      "label": "Focus Appearance",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.1",
+      "label": "Pointer Gestures",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.2",
+      "label": "Pointer Cancellation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.3",
+      "label": "Label in Name",
+      "status": "conditional",
+      "notes": "Additional context need to be added for the label i.e If the visible label is �Comments�, the accessible name must include �Comments�."
+    },
+    {
+      "rule": "2.5.4",
+      "label": "Motion Actuation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.5",
+      "label": "Target Size (Enhanced)",
+      "status": "conditional",
+      "notes": "Set a minimum height and width of at least 24x24 CSS pixels on the textarea."
+    },
+    {
+      "rule": "2.5.6",
+      "label": "Concurrent Input Mechanisms",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.7",
+      "label": "Dragging Movements",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.8",
+      "label": "Target Size (Minimum)",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.1",
+      "label": "Language of Page",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.2",
+      "label": "Language of Parts",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.3",
+      "label": "Unusual Words",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.4",
+      "label": "Abbreviations",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.5",
+      "label": "Reading Level",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.6",
+      "label": "Pronunciation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.1",
+      "label": "On Focus",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.2",
+      "label": "On Input",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.3",
+      "label": "Consistent Navigation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.4",
+      "label": "Consistent Identification",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.5",
+      "label": "Change on Request",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.6",
+      "label": "Consistent Help",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.1",
+      "label": "Error Identification",
+      "status": "",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.2",
+      "label": "Labels or Instructions",
+      "status": "not-applicable",
+      "notes": "Form Field related"
+    },
+    {
+      "rule": "3.3.3",
+      "label": "Error Suggestion",
+      "status": "not-applicable",
+      "notes": "Form Field related"
+    },
+    {
+      "rule": "3.3.4",
+      "label": "Error Prevention (Legal, Financial, Data)",
+      "status": "not-applicable",
+      "notes": "Form Field related"
+    },
+    {
+      "rule": "3.3.5",
+      "label": "Help",
+      "status": "not-applicable",
+      "notes": "Form Field related"
+    },
+    {
+      "rule": "3.3.6",
+      "label": "Error Prevention (All)",
+      "status": "not-applicable",
+      "notes": "Form Field related"
+    },
+    {
+      "rule": "3.3.7",
+      "label": "Redundant Entry",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.8",
+      "label": "Accessible Authentication (Minimum)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.9",
+      "label": "Accessible Authentication (Enhanced)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "4.1.2",
+      "label": "Name, Role, Value",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "4.1.3",
+      "label": "Status Messages",
+      "status": "not-applicable",
+      "notes": ""
+    }
+  ]

--- a/aries-site/src/data/wcag/textarea.json
+++ b/aries-site/src/data/wcag/textarea.json
@@ -447,7 +447,7 @@
       "rule": "3.3.1",
       "label": "Error Identification",
       "status": "not-applicable",
-      "notes": ""
+      "notes": "Form Field related"
     },
     {
       "rule": "3.3.2",

--- a/aries-site/src/pages/components/textarea.mdx
+++ b/aries-site/src/pages/components/textarea.mdx
@@ -1,4 +1,4 @@
-import { Example } from '../../layouts';
+import { AccessibilitySection, Example } from '../../layouts';
 import {
   TextAreaExample,
   TextAreaDisabledExample,
@@ -26,14 +26,6 @@ In order to give the user a hint about how long their response should be, set th
 
 In the context of a FormField, apply resize="vertical" on the TextArea to ensure the TextArea doesn't expand beyond the width of the FormField it is contained in. In other contexts, the TextArea should be allowed to resize both vertically and horizontally.
 
-### Accessibility
-
-In every case possible, TextArea should be used inside of a FormField to ensure that a label is appropriately paired with the input. This behavior is important to screen reader users who need to know what context the TextArea is referring to.
-
-If you need to use TextArea outside of the context of a FormField, it is important to make sure the TextArea is labeled in an alternate way to meet accessibility requirements.
-
-Placeholder text does not serve as a sufficient means of meeting accessibility requirements for labels. To meet accessbility requirements, placeholder text should be used in conjunction with a label or aria-labelledby attribute.
-
 ## Variants
 
 A TextArea's visual state informs the user of its ability to be interacted with or if any validation errors have occured.
@@ -59,3 +51,16 @@ Used to indicate that a TextArea cannot be interacted with.
 >
   <TextAreaDisabledExample />
 </Example>
+
+
+## Accessibility
+
+In every case possible, TextArea should be used inside of a FormField to ensure that a label is appropriately paired with the input. This behavior is important to screen reader users who need to know what context the TextArea is referring to.
+
+If you need to use TextArea outside of the context of a FormField, it is important to make sure the TextArea is labeled in an alternate way to meet accessibility requirements.
+
+Placeholder text does not serve as a sufficient means of meeting accessibility requirements for labels. To meet accessbility requirements, placeholder text should be used in conjunction with a label or aria-labelledby attribute.
+
+### WCAG compliance
+
+<AccessibilitySection title='textarea' />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Adds accessibility to Textarea component

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/4962

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

#### Notifications
[Update]TextArea

[Accessibility]

[WCAG rule documentation added]
