### PR TITLE
Added accessibility information for Spinner

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -1405,6 +1405,7 @@ export const components = [
   },
   {
     name: 'Spinner',
+    accessibility: 'Failed WCAG 2.2 AA',
     category: 'Visualizations',
     description:
       'Spinner is a small motion graphic element that indicates a loading state for quick, asynchronous tasks.',

--- a/aries-site/src/data/wcag/spinner.json
+++ b/aries-site/src/data/wcag/spinner.json
@@ -1,0 +1,512 @@
+[
+    {
+      "rule": "1.1.1",
+      "label": "Non-text content",
+      "status": "conditional",
+      "notes": "All non-text content that is presented to the user has a text alternative that serves the equivalent purpose, except for the situations listed below."
+    },
+    {
+      "rule": "1.2.1",
+      "label": "Audio-only and Video-only (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.2",
+      "label": "Captions (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.3",
+      "label": "Audio Description or Media Alternative (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.4",
+      "label": "Captions (Live)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.5",
+      "label": "Audio Description (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.6",
+      "label": "Sign Language (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.7",
+      "label": "Extended Audio Description (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.8",
+      "label": "Media Alternative (Prerecorded)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.2.9",
+      "label": "Audio-only (Live)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.1",
+      "label": "Info and Relationships",
+      "status": "conditional",
+      "notes": "Conditional on correct implementation of message property"
+    },
+    {
+      "rule": "1.3.2",
+      "label": "Meaningful Sequence",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.3",
+      "label": "Sensory Characteristics",
+      "status": "conditional",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.4",
+      "label": "Orientation",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.5",
+      "label": "Identify Input Purpose",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.3.6",
+      "label": "Identify Purpose",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.1",
+      "label": "Use of Color",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.2",
+      "label": "Audio Control",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.3",
+      "label": "Contrast (Minimum)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.4",
+      "label": "Resize Text",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.5",
+      "label": "Images of Text",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.6",
+      "label": "Contrast (Enhanced)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.7",
+      "label": "Low or No Background Audio",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.8",
+      "label": "Visual Presentation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.9",
+      "label": "Images of Text (No Exception)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.10",
+      "label": "Reflow",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.11",
+      "label": "Non-text Contrast",
+      "status": "failed",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.12",
+      "label": "Text Spacing",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "1.4.13",
+      "label": "Content on Hover or Focus",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.1.1",
+      "label": "Keyboard",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.1.2",
+      "label": "No Keyboard Trap",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.1.3",
+      "label": "Keyboard (No Exception)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.1",
+      "label": "Timing Adjustable",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.2",
+      "label": "Pause, Stop, Hide",
+      "status": "conditional",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.3",
+      "label": "No Timing",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.4",
+      "label": "Interruptions",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.5",
+      "label": "Re-authenticating",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.2.6",
+      "label": "Timeouts",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.3.1",
+      "label": "Three Flashes or Below Threshold",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.3.2",
+      "label": "Three Flashes",
+      "status": "passed",
+      "notes": ""
+    },
+    {
+      "rule": "2.3.3",
+      "label": "Animation from Interactions",
+      "status": "conditional",
+      "notes": "Motion animation triggered by interaction can be disabled, unless the animation is essential to the functionality or the information being conveyed."
+    },
+    {
+      "rule": "2.4.1",
+      "label": "Bypass Blocks",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.2",
+      "label": "Page Titled",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.3",
+      "label": "Focus Order",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.4",
+      "label": "Link Purpose (In Context)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.5",
+      "label": "Multiple Ways",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.6",
+      "label": "Headings and Labels",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.7",
+      "label": "Focus Visible",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.8",
+      "label": "Location",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.9",
+      "label": "Link Purpose (Link Only)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.10",
+      "label": "Section Headings",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.11",
+      "label": "Focus Not Obscured (Minimum)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.12",
+      "label": "Focus Not Obscured (Enhanced)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.4.13",
+      "label": "Focus Appearance",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.1",
+      "label": "Pointer Gestures",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.2",
+      "label": "Pointer Cancellation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.3",
+      "label": "Label in Name",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.4",
+      "label": "Motion Actuation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.5",
+      "label": "Target Size (Enhanced)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.6",
+      "label": "Concurrent Input Mechanisms",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.7",
+      "label": "Dragging Movements",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "2.5.8",
+      "label": "Target Size (Minimum)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.1",
+      "label": "Language of Page",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.2",
+      "label": "Language of Parts",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.3",
+      "label": "Unusual Words",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.4",
+      "label": "Abbreviations",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.5",
+      "label": "Reading Level",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.1.6",
+      "label": "Pronunciation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.1",
+      "label": "On Focus",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.2",
+      "label": "On Input",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.3",
+      "label": "Consistent Navigation",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.4",
+      "label": "Consistent Identification",
+      "status": "conditional",
+      "notes": "Depends on implementation of consistent labels for spinners across a web app"
+    },
+    {
+      "rule": "3.2.5",
+      "label": "Change on Request",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.2.6",
+      "label": "Consistent Help",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.1",
+      "label": "Error Identification",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.2",
+      "label": "Labels or Instructions",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.3",
+      "label": "Error Suggestion",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.4",
+      "label": "Error Prevention (Legal, Financial, Data)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.5",
+      "label": "Help",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.6",
+      "label": "Error Prevention (All)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.7",
+      "label": "Redundant Entry",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.8",
+      "label": "Accessible Authentication (Minimum)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "3.3.9",
+      "label": "Accessible Authentication (Enhanced)",
+      "status": "not-applicable",
+      "notes": ""
+    },
+    {
+      "rule": "4.1.2",
+      "label": "Name, Role, Value",
+      "status": "conditional",
+      "notes": "Must expose role (like status), accessible name (aria-label or text), and value if needed"
+    },
+    {
+      "rule": "4.1.3",
+      "label": "Status Messages",
+      "status": "conditional",
+      "notes": "If conveying a change (like loading), it must announce it automatically via aria-live, without stealing focus"
+    }
+  ]

--- a/aries-site/src/pages/components/spinner.mdx
+++ b/aries-site/src/pages/components/spinner.mdx
@@ -31,14 +31,6 @@ Avoid showing multiple Loading Spinners on a single page.
 - When fetching data or content, where the expected response time is greater than ~300ms.
 - When loading more information into a Table or List.
 
-### Accessibility
-
-For additional clarity for screen reader users, provide a [message](https://v2.grommet.io/spinner#message) to the spinner that would explain to the user that the content is being loaded.
-
-[Message](https://v2.grommet.io/spinner#message) can be provided as a string or as an object in the format of `{ start: ... , end: ... }`, where the "start" message is announced when the Spinner appears and the "end" message is announced when the Spinner closes.
-
-### WCAG compliance
-  <AccessibilitySection title='spinner' />
 
 ## Variants
 
@@ -78,3 +70,11 @@ A Spinner allows users to know when something is being loaded without explicitly
   <ContentSpinnerExample />
 </Example>
 
+## Accessibility
+
+For additional clarity for screen reader users, provide a [message](https://v2.grommet.io/spinner#message) to the spinner that would explain to the user that the content is being loaded.
+
+[Message](https://v2.grommet.io/spinner#message) can be provided as a string or as an object in the format of `{ start: ... , end: ... }`, where the "start" message is announced when the Spinner appears and the "end" message is announced when the Spinner closes.
+
+### WCAG compliance
+  <AccessibilitySection title='spinner' />

--- a/aries-site/src/pages/components/spinner.mdx
+++ b/aries-site/src/pages/components/spinner.mdx
@@ -1,4 +1,4 @@
-import { Example } from '../../layouts';
+import { AccessibilitySection, Example } from '../../layouts';
 import {
   AnnounceSpinnerExample,
   SpinnerExample,
@@ -37,6 +37,9 @@ For additional clarity for screen reader users, provide a [message](https://v2.g
 
 [Message](https://v2.grommet.io/spinner#message) can be provided as a string or as an object in the format of `{ start: ... , end: ... }`, where the "start" message is announced when the Spinner appears and the "end" message is announced when the Spinner closes.
 
+### WCAG compliance
+  <AccessibilitySection title='spinner' />
+
 ## Variants
 
 A Spinner can be used in various ways to indicate to the user that a task is in process.
@@ -74,3 +77,4 @@ A Spinner allows users to know when something is being loaded without explicitly
 >
   <ContentSpinnerExample />
 </Example>
+


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!---
#### Notifications

[Update/New tag]Exact name of component/template

[name of the updated section within the guidance][Another update section]

[Message to fill the inline notification]

Example:
[Update]Accordion

[Accessibility]

[WCAG rule documentation added]
-->

<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Adds accessibility information to Spinner

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5018

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
