### PR TITLE
Revert "Updated pr template to include notifications"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,5 @@
 <!--- Provide a general summary of the PR in the Title above -->
 
-<!---
-#### Notifications
-
-[Update/New tag]Exact name of component/template
-
-[name of the updated section within the guidance][Another update section]
-
-[Message to fill the inline notification]
-
-Example:
-[Update]Accordion
-
-[Accessibility]
-
-[WCAG rule documentation added]
--->
 
 <!--- Insert the PR's # for the deploy preview's URL -->
 [Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)


### PR DESCRIPTION
Reverts grommet/hpe-design-system#5011

I think this comment throws off the parsing of notifications because notifications are no longer being displayed on the site