### PR TITLE
add verbage to the textinput accessibility for the defaultsuggestion …

### DIFF
--- a/aries-site/src/data/wcag/textinput.json
+++ b/aries-site/src/data/wcag/textinput.json
@@ -410,8 +410,8 @@
   {
     "rule": "3.2.1",
     "label": "On Focus",
-    "status": "failed",
-    "notes": ""
+    "status": "conditional",
+    "notes": "when using the defaultSuggestion prop this will fail so this prop should be used with caution."
   },
   {
     "rule": "3.2.2",

--- a/aries-site/src/pages/components/textinput.mdx
+++ b/aries-site/src/pages/components/textinput.mdx
@@ -118,7 +118,7 @@ If you need to use TextInput outside of the context of a FormField, it is import
 
 Placeholder text does not serve as a sufficient means of meeting accessibility requirements for labels. To meet accessbility requirements, placeholder text should be used in conjunction with a label or aria-labelledby attribute.
 
-Using the `defaultSuggestion` prop can cause accessibility issues. When the input receives focus, VoiceOver may jump straight to the suggestion, skipping over announcing the input field. This can violate WCAG 3.2.1: On Focus, which requires that focus does not trigger unexpected context changes.
+Using the `defaultSuggestion` prop can cause accessibility issues. When the input receives focus, VoiceOver may jump straight to the suggestion, skipping over announcing the input field. This can violate [WCAG 3.2.1](https://www.w3.org/TR/WCAG22/#on-focus): On Focus, which requires that focus does not trigger unexpected context changes.
 - Avoid using defaultSuggestion Instead, include the intended default suggestion at the top of the suggestions list.
 
 ### WCAG compliance

--- a/aries-site/src/pages/components/textinput.mdx
+++ b/aries-site/src/pages/components/textinput.mdx
@@ -118,6 +118,9 @@ If you need to use TextInput outside of the context of a FormField, it is import
 
 Placeholder text does not serve as a sufficient means of meeting accessibility requirements for labels. To meet accessbility requirements, placeholder text should be used in conjunction with a label or aria-labelledby attribute.
 
+Using the `defaultSuggestion` prop can cause accessibility issues. When the input receives focus, VoiceOver may jump straight to the suggestion, skipping over announcing the input field. This can violate WCAG 3.2.1: On Focus, which requires that focus does not trigger unexpected context changes.
+- Avoid using defaultSuggestion Instead, include the intended default suggestion at the top of the suggestions list.
+
 ### WCAG compliance
 
 <AccessibilitySection title="TextInput" />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR adds information about the `defaultSuggestion` prop and how it is not fully accessible 
#### Where should the reviewer start?
textinput.mdx
#### What testing has been done on this PR?
locally
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?
using voice over `defaultSuggestion` prop violates wcag 
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
maybe
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible