### PR TITLE
Update wcag 1.3.1, 1.3.6, 4.1.2 rules for pagination component

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -1561,7 +1561,7 @@ export const components = [
   },
   {
     name: 'Pagination',
-    accessibility: 'Failed WCAG 2.2 AA',
+    accessibility: 'Passed WCAG 2.2 AA',
     available: true,
     category: 'Controls',
     description: `Pagination enables the user to  navigate between pages

--- a/aries-site/src/data/wcag/pagination.json
+++ b/aries-site/src/data/wcag/pagination.json
@@ -53,8 +53,7 @@
   {
     "rule": "1.3.1",
     "label": "Info and Relationships",
-    "status": "failed",
-    "note": "Not possible to assign an aria-label to the Items per page Select"
+    "status": "passed"
   },
   {
     "rule": "1.3.2",
@@ -79,8 +78,7 @@
   {
     "rule": "1.3.6",
     "label": "Identify Purpose",
-    "status": "failed",
-    "note": "No method to pass a label to the items per page Select step"
+    "status": "passed"
   },
   {
     "rule": "1.4.1",
@@ -394,8 +392,7 @@
   {
     "rule": "4.1.2",
     "label": "Name, Role, Value",
-    "status": "failed",
-    "notes": "Items per page select do not have accessible names."
+    "status": "passed"
   },
   {
     "rule": "4.1.3",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
WCAG evaluation/update and site content:Pagination component

This PR update pagination component wcag rules for 1.3.1, 1.3.6, 4.1.2 because Grommet PR [#7590](https://github.com/grommet/grommet/pull/7590) is now merged


#### Notifications
[Update]Pagination

[Accessibility]

[WCAG rule documentation updated]