### PR TITLE
update the ruling that were failing for rangeSelector in datafilters …

### DIFF
--- a/aries-site/src/data/wcag/datafilter.json
+++ b/aries-site/src/data/wcag/datafilter.json
@@ -158,8 +158,8 @@
   {
     "rule": "1.4.11",
     "label": "Non-text Contrast",
-    "status": "failed",
-    "notes": "green color in RangeSelector againts the white does not pass 3:1 contrast ratio"
+    "status": "passed",
+    "notes": "middle green color does not meet 3:1 contrast ratio, but is not a failure because it is considered decorative and not essential to understanding the content"
   },
   {
     "rule": "1.4.12",

--- a/aries-site/src/data/wcag/datafilters.json
+++ b/aries-site/src/data/wcag/datafilters.json
@@ -158,8 +158,8 @@
   {
     "rule": "1.4.11",
     "label": "Non-text Contrast",
-    "status": "failed",
-    "notes": "green color in RangeSelector againts the white does not pass "
+    "status": "passed",
+    "notes": "middle green color does not meet 3:1 contrast ratio, but is not a failure because it is considered decorative and not essential to understanding the content"
   },
   {
     "rule": "1.4.12",


### PR DESCRIPTION
…and datafilter

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR updated the ruling that was previous failing based on the RangeSelector component
#### Where should the reviewer start?
datafilter.json
datafilters.json
#### What testing has been done on this PR?
locally 
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
locally 
#### Any background context you want to provide?
see issue 
https://github.com/grommet/grommet/issues/7649
#### What are the relevant issues?
closes https://github.com/grommet/grommet/issues/7649
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
maybe
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 