### PR TITLE
Updated figma links in Card guidance

### DIFF
--- a/aries-site/src/pages/components/card/call-to-action-card.mdx
+++ b/aries-site/src/pages/components/card/call-to-action-card.mdx
@@ -17,7 +17,7 @@ This type of card is more commonly used within marketing contexts and should be 
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/CardKitchenSink.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <EventPromotionCard />
@@ -67,7 +67,7 @@ Event announcements are highly promotional, so they should leverage attention-gr
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/EventPromotionCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <EventPromotionCard />
@@ -81,7 +81,7 @@ Depending on where a card is presented in a layout, it may be more appropriate f
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/EventPromotionRowCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <EventPromotionRowCard />
@@ -95,7 +95,7 @@ Announcements about new offerings and features should excite current and potenti
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/FeaturePromotionCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <FeaturePromotionCard />
@@ -109,7 +109,7 @@ The use of this brand-approved texture subtley differentiates this card from sur
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/TrialPromotionCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <TrialPromotionCard />
@@ -123,7 +123,7 @@ Depending on where a card is presented in a layout, it may be more appropriate f
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/TrialPromotionRowCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <TrialPromotionRowCard />
@@ -137,7 +137,7 @@ A colored background can be used to differentiate a card from its surroundings.
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/TrialPromotionColorCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <TrialPromotionColorCard />
@@ -151,7 +151,7 @@ An attention-grabbing title attracts user attention and encourages them to upgra
   componentName="Card"
   code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/card/FeatureReleaseCard.js"
   docs="https://v2.grommet.io/card?theme=hpe#props"
-  figma="https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2"
+  figma="https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?node-id=3062-2494&t=ER8ttf2IxrXcy6CR-4"
   grommetSource="https://github.com/grommet/grommet/blob/master/src/js/components/Card/Card.js"
 >
   <FeatureReleaseCard />


### PR DESCRIPTION
Previous links pointed to deprecated v1 file.
New link points to v2 library.

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Points to new v2 file
#### Where should the reviewer start?
Check that urls are valid
