### PR TITLE
[UPDATE DOC]: for file input wcag rule 1.1.1 and 1.3.1 to pass

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -374,7 +374,7 @@ export const components = [
   },
   {
     name: 'FileInput',
-    accessibility: 'Failed WCAG 2.2 A',
+    accessibility: 'Passed WCAG 2.2 AA',
     category: 'Inputs',
     description:
       'An input field where a user can select and upload one or more files.',

--- a/aries-site/src/data/wcag/fileinput.json
+++ b/aries-site/src/data/wcag/fileinput.json
@@ -2,8 +2,8 @@
   {
     "rule": "1.1.1",
     "label": "Non-text content",
-    "status": "failed",
-    "notes": "Error icon is getting read out it is just not providing meaningful information to a screenreader user that the file is too large"
+    "status": "passed",
+    "notes": "Fixed in Grommet PR #7679. original issue: Error icon is getting read out it is just not providing meaningful information to a screen reader user that the file is too large"
   },
   {
     "rule": "1.2.1",
@@ -62,8 +62,8 @@
   {
     "rule": "1.3.1",
     "label": "Info and Relationships",
-    "status": "failed",
-    "notes": "Information given through presentation (the icon displayed when a file size is too large) is not available in text nor can it be programmatically determined."
+    "status": "passed",
+    "notes": "Fixed in Grommet PR #7679. Original issue: Information given through presentation (the icon displayed when a file size is too large) is not available in text nor can it be programmatically determined."
   },
   {
     "rule": "1.3.2",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- update file input wcag rule 1.1.1 and 1.3.1 to pass
- expand note to mention that Grommet PR [#7679](https://github.com/grommet/grommet/pull/7679) fixes these issues

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
- closes https://github.com/grommet/grommet/issues/7561

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
