### PR TITLE
[FIX] double accessibility section for tip comp. page

### DIFF
--- a/aries-site/src/pages/components/tip.mdx
+++ b/aries-site/src/pages/components/tip.mdx
@@ -33,11 +33,6 @@ Tips provide messages that give the user more information about an element.
 
 Make sure to test the Tip positioning to ensure that the content does not block other information pertinent to the user's goal.
 
-### Accessibility
-
-Tips should support both mouse hover and keyboard focus.
-Do not use Tips for information that is vital for the user to complete the task.
-
 ### Truncation with Tip
 
 To display the full text when truncation occurs, hover over the truncated text and a Tip will be shown with the full text.
@@ -87,6 +82,9 @@ Tip may be used for content varying in length. The size of the Tip will scale ac
 </Example>
 
 ## Accessibility
+
+Tips should support both mouse hover and keyboard focus.
+Do not use Tips for information that is vital for the user to complete the task.
 
 ### WCAG compliance
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- fix double accessibility section for tip comp. page

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
