### PR TITLE
Update wcag info for Select, DataTable, and DataTableGroupBy

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -585,7 +585,7 @@ export const components = [
   },
   {
     name: 'Select',
-    accessibility: 'Failed WCAG 2.2 AA',
+    accessibility: 'Passed WCAG 2.2 AA',
     category: 'Inputs',
     description:
       'Select is a flexible input field that allows users to choose from a list of options.',
@@ -1499,7 +1499,7 @@ export const components = [
   },
   {
     name: 'DataTable',
-    accessibility: 'Failed WCAG 2.2 AA',
+    accessibility: 'Passed WCAG 2.2 AA',
     category: 'Visualizations',
     description: 'DataTable presents data in a column and row format.',
     preview: {
@@ -1916,7 +1916,7 @@ export const components = [
   },
   {
     name: 'DataTableGroupBy',
-    accessibility: 'Failed WCAG 2.2 AA',
+    accessibility: 'Passed WCAG 2.2 AA',
     available: true,
     category: 'Data',
     description:

--- a/aries-site/src/data/wcag/datatable.json
+++ b/aries-site/src/data/wcag/datatable.json
@@ -290,8 +290,8 @@
   {
     "rule": "2.4.7",
     "label": "Focus Visible",
-    "status": "failed",
-    "notes": "groupby expand/collapse does not receive indicator when navigating with keyboard"
+    "status": "passed",
+    "notes": ""
   },
   {
     "rule": "2.4.8",

--- a/aries-site/src/data/wcag/datatablegroupby.json
+++ b/aries-site/src/data/wcag/datatablegroupby.json
@@ -284,8 +284,8 @@
   {
     "rule": "2.4.7",
     "label": "Focus Visible",
-    "status": "failed",
-    "notes": "The focus on \"clear selection\" button looks like our hover state, not like all the other focus states inside select"
+    "status": "passed",
+    "notes": ""
   },
   {
     "rule": "2.4.8",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Updates Select, DataTable, and DataTableGroupBy to passing WCAG AA since v7 of the hpe theme has been released.
Related PRs:
https://github.com/grommet/grommet-theme-hpe/pull/483
https://github.com/grommet/grommet/pull/7697
https://github.com/grommet/hpe-design-system/pull/5196

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
