### PR TITLE
Fix "Error processing JS/JSX files" when there's a large number of files

### DIFF
--- a/packages/codemods/bin/cli.js
+++ b/packages/codemods/bin/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable max-len */
 /**
  * Enhanced Codemod dispatcher CLI for grommet-theme-hpe
  * Usage: node bin/cli.js <transform> <path> [options]
@@ -132,17 +133,18 @@ function runJscodeshift({ files, parser, extensions, scan }) {
 
   // Create temporary file with filenames
   const os = require('os');
-  const tempFilePath = path.join(os.tmpdir(), `jscodeshift-files-${Date.now()}.txt`);
+  const tempFilePath = 
+    path.join(os.tmpdir(), `jscodeshift-files-${Date.now()}.txt`);
   
   try {
     // Write filenames to temporary file, one per line
     fs.writeFileSync(tempFilePath, files.join('\n'), 'utf8');
 
-    let cmd = `npx jscodeshift`;
+    let cmd = 'npx jscodeshift';
     if (parser) cmd += ` --parser=${parser}`;
-    if (scan) cmd += ` --scan=true`;
+    if (scan) cmd += ' --scan=true';
     if (extensions) cmd += ` --extensions=${extensions}`;
-    cmd += ` --stdin`; // Add stdin flag
+    cmd += ' --stdin'; // Add stdin flag
     cmd += ` -t "${transforms[transform]}"`;
     if (!scan) {
       if (dryFlag) cmd += ` ${dryFlag}`;


### PR DESCRIPTION
Fix "Error processing JS/JSX files" when there's a large number of files

This mainly happens on windows since the long list of filenames was passed on the command line.

Instead we tell jscodeshift to get the filenames from stdin and redirect the list of files in that way.

<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
