### PR TITLE
Fix migration guide link in README.md

### DIFF
--- a/packages/icons/grommet/README.md
+++ b/packages/icons/grommet/README.md
@@ -126,7 +126,7 @@ packages/icons/grommet/
 
 ## Migrating from grommet-icons
 
-Information for migrating from grommet-icons to @hpe-design/icons-grommet can be found in this [migration guide](https://github.com/grommet/hpe-design-system/wiki/Migrating-from-grommet%E2%80%90icons-to-@hpe%E2%80%90design-icons%E2%80%90grommet).
+Information for migrating from grommet-icons to @hpe-design/icons-grommet can be found in this [migration guide](https://github.com/grommet/hpe-design-system/wiki/Migrating-from-grommet%E2%80%90icons-to-@hpe%E2%80%90design%5Cicons%E2%80%90grommet).
 
 ## Browser Support
 


### PR DESCRIPTION


#### What does this PR do?

This pull request updates the migration guide link in the `packages/icons/grommet/README.md` file to fix an encoding issue in the URL. This ensures that users can correctly access the migration documentation.

* Updated the migration guide URL in `README.md` to properly encode the path for `@hpe-design/icons-grommet`, improving accessibility to the migration instructions.

