### PR TITLE
Grommet token box shadow fix

### DIFF
--- a/design-tokens/src/formats/utils/getGrommetValue.ts
+++ b/design-tokens/src/formats/utils/getGrommetValue.ts
@@ -67,5 +67,10 @@ export const getGrommetValue = (token: any, dictionary: any) => {
     // references to "base" tokens or non-references should resolve to raw values
   } else result = token.$value;
 
+  // Temporary fix for focusIndicator box shadow in grommet theme
+  if (token.$type === 'shadow' && token.name.includes('focusIndicator')) {
+    result = token.original.$value[0];
+  }
+
   return result;
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Fix how the box shadow token is exported in the grommet folder so that it respects dark/light mode.

Previously the focus indicator box shadow was exported like this in the grommet folder:
"boxShadow": "0 0 0 2px #ffffff"

Now it should be exported like this:
"boxShadow": {
        "offsetX": 0,
        "offsetY": 0,
        "blur": 0,
        "spread": "{focusIndicator.outlineOffset}",
        "color": "{color.focus.support}"
      }

This aligns with the focus indicator outline approach.

None of the other exports should change

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
