### PR TITLE
Change ariesPop to pull button styling from hpe theme instead of hpePop

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -49,7 +49,7 @@ export const aries = deepMerge(hpe, {
 
 export const ariesPop = deepMerge(aries, {
   ...hpePop,
-  // pulling in button from hpe theme
+// pulling in Button from HPE theme since the hpePop Button is too large
   button: {
     ...hpe.button,
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Change ariesPop to pull button styling from hpe theme instead of hpePop so that we don't get the thick padded buttons used in the pop theme. This doesn't align with out site use case.

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
