### PR TITLE
fix color pairing example

### DIFF
--- a/aries-site/src/components/content/designTokenUtils.js
+++ b/aries-site/src/components/content/designTokenUtils.js
@@ -36,12 +36,12 @@ Object.keys(tokens).forEach(mode => {
   });
 });
 
-const ColorPreview = ({ datum, ...rest }) => (
+const ColorPreview = ({ background, datum, ...rest }) => (
   <Box
     pad="medium"
     round="xsmall"
     flex={false}
-    background={datum.value}
+    background={background || datum.value}
     border={{ color: 'border-weak' }}
     {...rest}
   />

--- a/aries-site/src/pages/design-tokens/color-pairing.mdx
+++ b/aries-site/src/pages/design-tokens/color-pairing.mdx
@@ -1,3 +1,5 @@
+import { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
 import { Box, Grid, Notification, Text } from 'grommet';
 import { Trigger } from '@hpe-design/icons-grommet';
 import { ContentPane, Example } from '../../layouts';
@@ -85,7 +87,24 @@ Refer to this table below for examples of background colors paired with "on" col
 | <ColorPreview datum={{value: 'background-ok'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onOk">Aa</Text></ColorPreview>                                         | color.background.ok                      | color.text.onWarning, color.text.onWarning.strong                      |
 | <ColorPreview datum={{value: 'background-info'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onInfo">Aa</Text></ColorPreview>                                     | color.background.info                    | color.text.onInfo, color.text.onInfo.strong                            |
 | <ColorPreview datum={{value: 'background-unknown'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onUnknown">Aa</Text></ColorPreview>                               | color.background.unknown                 | color.text.onUnknown, color.text.onUnknown.strong                      |
-| <ColorPreview datum={{value: 'background-primary-strong'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreview>                  | color.background.primary.strong          | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |
-| <ColorPreview datum={{value: 'background-primary-xstrong'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreview>                 | color.background.primary.xstrong         | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |
+| <ColorPreviewWithMode color="background-primary-strong" pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreviewWithMode>             | color.background.primary.strong          | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |
+| <ColorPreviewWithMode color="background-primary-xstrong" pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreviewWithMode>            | color.background.primary.xstrong         | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |        
 | <ColorPreview datum={{value: 'background-selected-primary'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onSelectedPrimary">Aa</Text></ColorPreview>              | color.background.selected.primary        | color.text.onSelectedPrimary, color.icon.onSelectedPrimary             |
-| <ColorPreview datum={{value: 'background-selected-primary-strong'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onSelectedPrimaryStrong">Aa</Text></ColorPreview> | color.background.selected.primary.strong | color.text.onSelectedPrimaryStrong, color.icon.onSelectedPrimaryStrong |
+| <ColorPreviewWithMode color="background-selected-primary-strong" pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreviewWithMode>   | color.background.selected.primary.strong | color.text.onSelectedPrimaryStrong, color.icon.onSelectedPrimaryStrong |
+
+export const ColorPreviewWithMode = ({ color, ...rest }) => {
+  // need to check theme to overridde what grommet does by default
+  // by setting text color based on light/dark mode
+  const theme = useContext(ThemeContext);
+  const mode = theme.dark ? 'dark' : 'light';
+
+  return (
+    <ColorPreview
+      background={{
+        color: color,
+        dark: mode === 'light' ? false : true
+      }}
+      {...rest}
+    />
+  );
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
fix the color pairing table that shows the background with text on it 

prior to change grommet was setting the incorrect text color based on dark/light mode
<img width="546" height="219" alt="Screenshot 2025-10-23 at 4 05 08 PM" src="https://github.com/user-attachments/assets/b095bb7e-8ca8-40fa-9e62-f944a3eff3cf" />

#### Where should the reviewer start?
color-pairing.mdx

#### What testing has been done on this PR?

locally
In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
locally 
#### Any background context you want to provide?
text color was coming through incorrectly on the example
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
