### PR TITLE
Selector box shadow change

### DIFF
--- a/aries-core/src/js/components/core/Selector/Selector.js
+++ b/aries-core/src/js/components/core/Selector/Selector.js
@@ -12,7 +12,7 @@ const StyledBox = styled(Box)`
   ${props =>
     props.selected &&
     `box-shadow: inset 0 0 0 ${
-      props.theme.global.edgeSize['5xsmall']
+      props.theme.global.borderSize.small
     } ${normalizeColor(props.border.color, props.theme)};
     };`}
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Add another visual indicator besides just color that the selector is selected.

NOTE: I think this is an okay solution for now but we should probably revisit at some point and explore more options because in some high contrast modes box shadows are removed.

<img width="793" height="457" alt="Screenshot 2025-10-30 at 1 58 47 PM" src="https://github.com/user-attachments/assets/1cc10728-e47f-4d61-aad0-3f52266adb34" />

#### Where should the reviewer start?

#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
