### PR TITLE
add another template for PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,44 @@
+<!--- Provide a general summary of the PR in the Title above -->
+
+<!--- Insert the PR's # for the deploy preview's URL -->
+
+[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)
+
+#### What does this PR do?
+
+#### Where should the reviewer start?
+
+#### What testing has been done on this PR?
+
+In addition to the feature you are implementing, have you checked the following:
+
+**General UX Checks**
+
+- [ ] Small, medium, and large screen sizes
+- [ ] Cross-browsers (FireFox, Chrome, and Safari)
+- [ ] Light & dark modes
+- [ ] All hyperlinks route properly
+
+**Accessibility Checks**
+
+- [ ] Keyboard interactions
+- [ ] Screen reader experience
+- [ ] Run WAVE accessibility plugin (Chrome)
+
+**Code Quality Checks**
+
+- [ ] Console is free of warnings and errors
+- [ ] Passes E2E commit checks
+- [ ] Visual snapshots are reasonable
+
+#### How should this be manually tested?
+
+#### Any background context you want to provide?
+
+#### What are the relevant issues?
+
+#### Screenshots (if appropriate)
+
+#### Should this PR be mentioned in Design System updates?
+
+#### Is this change backwards compatible or is it a breaking change?

--- a/.github/PULL_REQUEST_TEMPLATE/doc-content.md
+++ b/.github/PULL_REQUEST_TEMPLATE/doc-content.md
@@ -1,0 +1,21 @@
+<!--- Provide a general summary of the content change in the Title above -->
+
+#### What content is being changed or added?
+
+#### Why is this change needed?
+
+#### Where should the reviewer focus?
+
+- Specify pages, sections, or components affected.
+
+#### Screenshots / Examples (if applicable)
+
+- Include before/after screenshots or links if helpful.
+
+#### Additional context
+
+- Any background, references, or notes for reviewers.
+
+#### Are there related PRs or issues?
+
+- Link any relevant PRs, issues, or design tickets.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
n/a

#### What does this PR do?
This PR is a test for if we can have multiple PR templates.
#### Where should the reviewer start?
Pull_request_template folder
#### What testing has been done on this PR?

In addition to the feature you are implementing, have you checked the following:

**General UX Checks**
- [ ] Small, medium, and large screen sizes
- [ ] Cross-browsers (FireFox, Chrome, and Safari)
- [ ] Light & dark modes
- [ ] All hyperlinks route properly

**Accessibility Checks**
- [ ] Keyboard interactions
- [ ] Screen reader experience
- [ ] Run WAVE accessibility plugin (Chrome)

**Code Quality Checks**
- [ ] Console is free of warnings and errors
- [ ] Passes E2E commit checks
- [ ] Visual snapshots are reasonable

#### How should this be manually tested?
A PR should be made to see if it works 
#### Any background context you want to provide?
Having a template geared towards content changes would provide flexibility for designers to put up PRs and be more specific about content changes. 
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
