### PR TITLE
[Docs] - Inline notification - Deleting the character limit from the format section

### DIFF
--- a/aries-site/src/pages/templates/inline-notifications.mdx
+++ b/aries-site/src/pages/templates/inline-notifications.mdx
@@ -105,7 +105,6 @@ Examples of inline notifications relating to an action element:
 ## Format
 
 - Titles and messages should be brief and clear.
-- Messages should generally be no longer than 192 characters.
 - Longer messages should wrap on narrower screens; they should not be truncated.
 - Anchor links may be used to provide additional information about the
   notification. The links should immediately follow the message and should be


### PR DESCRIPTION
This was discussed during office hours yesterday. Edgar asked why the limit was there, what was the rationale. We didn't have any, so we agreed to remove it.

Deploy preview failed, so can't add the correct link.
<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-5540--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Removes a line of guidance per office hours discussion.

#### What are the relevant issues?
No, minor change.

#### Where should the reviewer start?
Format section.

#### How should this be manually tested?

#### Any background context you want to provide?
This was discussed during office hours yesterday. Edgar asked why the limit was there, what was the rationale. We didn't have any, so we agreed to remove it.

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No, only to Edgar.

#### Is this change backwards compatible or is it a breaking change?
