### PR TITLE
[Codemod] Icons – Added Element icon transforms and Share icon warning

### DIFF
--- a/packages/codemods/transforms/migrate-grommet-icons-to-hpe.js
+++ b/packages/codemods/transforms/migrate-grommet-icons-to-hpe.js
@@ -196,7 +196,6 @@ const DEPRECATED_ICONS = new Set([
   'Heroku',
   'Horton',
   'Hp',
-  'Hpe',
   'HpeLabs',
   'Hpi',
   'Instagram',
@@ -336,15 +335,6 @@ module.exports = function transformer(file, api, options) {
             );
           }
 
-          if (iconName === 'Share' || iconName === 'share') {
-            console.warn(
-              `⚠️  Warning: Please verify if "Share" is the correct usage
-                 in this case,
-                 or consider using "NewWindow" ` +
-                'as an alternative if applicable.',
-            );
-          }
-
           // Check if icon needs to be remapped
           const newName = ICON_MAPPING[iconName] || iconName;
 
@@ -394,6 +384,14 @@ module.exports = function transformer(file, api, options) {
           if (specifier.type === 'ImportSpecifier') {
             const importedName = specifier.imported.name;
             const localName = specifier.local.name;
+
+            // Special warning for Share icon
+            if (importedName === 'Share') {
+              console.warn(
+                `⚠️  Warning: Please verify if "Share" is the correct usage in this case, or consider using "NewWindow" as an alternative if applicable.`,
+              );
+            }
+            ``;
 
             // Check if icon is deprecated
             if (DEPRECATED_ICONS.has(importedName)) {


### PR DESCRIPTION
…rom share icon

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR adds the new Element icon to the existing codemod to transform

also adds a warning about the share icon
<img width="847" height="438" alt="Screenshot 2025-12-02 at 9 57 43 AM" src="https://github.com/user-attachments/assets/54a4b8ee-5a20-4fe0-8aea-f0e8acc59491" />

#### What are the relevant issues?
on dev board 
#### Where should the reviewer start?
migrate-grommet-icons-to-hpe.js
#### How should this be manually tested?
run the codemod
#### Any background context you want to provide?
the new Element icon was added to the icons package
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
sure
#### Is this change backwards compatible or is it a breaking change?
backwards compatible