### PR TITLE
Try using the new gh action token

### DIFF
--- a/.github/workflows/update-design-tokens-stable.yml
+++ b/.github/workflows/update-design-tokens-stable.yml
@@ -35,7 +35,7 @@ jobs:
           pnpm release-stable
         working-directory: design-tokens
         env:
-          GH_TOKEN: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ACTION_ACCESS_TOKEN_NEW }}
       # If stable is successfully update, push the same updates to Figma
       - name: Sync tokens to Figma file
         run: pnpm sync-tokens-to-figma


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Created a new token under the `GH_ACTION_ACCESS_TOKEN_NEW` namespace to avoid deleting the current `GH_ACTION_ACCESS_TOKEN`. Point script to use new token

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
