### PR TITLE
fix hpe icon reference

### DIFF
--- a/sandbox/grommet-app/src/themes/theme.jsx
+++ b/sandbox/grommet-app/src/themes/theme.jsx
@@ -1181,14 +1181,14 @@ const buildTheme = (tokens, flags) => {
       // TO DO add cta-primary variant
       'cta-primary': {
         ...buttonKindTheme.primary,
-        icon: <Hpe />,
+        icon: <Element />,
         reverse: true,
         extend: '',
       },
       // TO DO add cta-alternate variant
       'cta-alternate': {
         ...buttonKindTheme.secondary,
-        icon: <Hpe color="icon-brand" />,
+        icon: <Element color="icon-brand" />,
         reverse: true,
       },
       ...buttonKindTheme,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR fixes a spot in grommet-app that import Element from @hpe icons but was still point to the Hpe icon.
#### What are the relevant issues?
none ran into a build issue
#### Where should the reviewer start?
theme.jsx
#### How should this be manually tested?
run grommet app
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
