### PR TITLE
Remove background color from Meter example

### DIFF
--- a/aries-site/src/examples/components/meter/MeterExample.js
+++ b/aries-site/src/examples/components/meter/MeterExample.js
@@ -9,7 +9,6 @@ export const MeterExample = () => {
       <Stack anchor="center">
         <Meter
           type="circle"
-          background="light-2"
           value={meterValue}
           size="xsmall"
         />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-5644--keen-mayer-a86c8b.netlify.app/components/all-components)

#### What does this PR do?
Remove the background color from the meter examlpe on the all components page. Instead of setting the color through the background prop we should allow the hpe theme to manage the background color (PR coming soon for handling this in the theme).

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
