### PR TITLE
Workaround lint in aries core

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-__dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-__rootDir="$(CDPATH= cd "$($__dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 echo "..Running design token checks"
 pnpm --filter hpe-design-tokens run test
 pnpm --filter hpe-design-tokens run paddingY:verify
@@ -13,11 +10,7 @@ echo "..Running aries-site checks"
 echo "....Linting checks for aries-site"
 pnpm --filter aries-site run lint-fix
 
-# TODO: aries-core pulls in an eslint v9 version
-# that doesn't work with the eslintrc.js from the root.
-# It works with eslint v8 used elsewhere in the repo
-
-# echo "..Running aries-core checks"
-# pnpm --filter aries-core run lint-fix
+echo "..Running aries-core checks"
+pnpm --filter aries-core run lint-fix
 
 echo "Pre-commit checks completed."

--- a/aries-core/src/stories/codeBlocks.stories.js
+++ b/aries-core/src/stories/codeBlocks.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 /* eslint-disable max-len */
+// eslint-disable-next-line import/no-unresolved
 import { CodeBlockExample } from 'aries-site/src/examples/templates/code-blocks/CodeBlocks';
 
 const meta = {

--- a/aries-core/src/stories/dashboards.stories.js
+++ b/aries-core/src/stories/dashboards.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { DashboardExample } from 'aries-site/src/examples/templates/dashboards/DashboardExample';

--- a/aries-core/src/stories/dataTableCustomization.stories.js
+++ b/aries-core/src/stories/dataTableCustomization.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { ColumnSettingsExample } from 'aries-site/src/examples/templates/table-customization/components/ColumnSettingsExample';

--- a/aries-core/src/stories/emptyState.stories.js
+++ b/aries-core/src/stories/emptyState.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { ActionEmptyState } from 'aries-site/src/examples/templates/empty-state/ActionEmptyState';

--- a/aries-core/src/stories/filtering.stories.js
+++ b/aries-core/src/stories/filtering.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { FilteringCards } from 'aries-site/src/examples/templates/filtering/FilteringCards/FilteringCards';

--- a/aries-core/src/stories/forms.stories.js
+++ b/aries-core/src/stories/forms.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { SimpleSignUpExample } from 'aries-site/src/examples/templates/forms/SimpleSignUpExample';

--- a/aries-core/src/stories/globalNotifications.stories.js
+++ b/aries-core/src/stories/globalNotifications.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { BannerContentLayoutExample } from 'aries-site/src/examples/templates/global-banner-notifications/BannerContentLayoutExample';

--- a/aries-core/src/stories/inlineNotifications.stories.js
+++ b/aries-core/src/stories/inlineNotifications.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { FormValidation } from 'aries-site/src/examples/templates/inline-notifications/InlineFormValidation';

--- a/aries-core/src/stories/lists.stories.js
+++ b/aries-core/src/stories/lists.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { ListIconIdentifierExample } from 'aries-site/src/examples/templates/list-views/ListIconIdentifierExample';

--- a/aries-core/src/stories/managingChildObjects.stories.js
+++ b/aries-core/src/stories/managingChildObjects.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { CreateCluster } from 'aries-site/src/examples/templates/forms/managing-child-objects/CreateCluster';

--- a/aries-core/src/stories/popover.stories.js
+++ b/aries-core/src/stories/popover.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { PopoverInlineExample } from 'aries-site/src/examples/templates/popover/PopoverInlineExample';

--- a/aries-core/src/stories/selector.stories.js
+++ b/aries-core/src/stories/selector.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { SimpleSelector } from 'aries-site/src/examples/templates/selector/SelectorSimple';

--- a/aries-core/src/stories/wizard.stories.js
+++ b/aries-core/src/stories/wizard.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 /* eslint-disable max-len */
 import { TwoColumnWizardExample } from 'aries-site/src/examples/templates/wizard/TwoColumnWizardExample';


### PR DESCRIPTION
As part of the `yarn` to `pnpm` migration, I temporarily disabled the husky check for lint in aries-core (due to how storybook stories were referencing things directly from aries-site source.)

This change at least re-enables the aries-core lint in husky and works around the lint complaint about how those stories are referencing examples directly from aries-site source. The longer term goal is to still move those examples into aries core and let the storybook and aries-site instead reference them from aries-core. See #5597 

Really I find this use of husky slows down my development iterations and I'd rather see the lint and test runs happen in CI. The idea is the PR can't be merged with failing CI checks. The lint issues should show up in my IDE and I can choose to address them when is convenient before merge. This is something I'd like to tee up for discussion later.
 
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
