### PR TITLE
[Docs] fix typo on status indicator page

### DIFF
--- a/aries-site/src/pages/templates/status-indicator.mdx
+++ b/aries-site/src/pages/templates/status-indicator.mdx
@@ -3,7 +3,8 @@ import { StatusBox } from '../../examples';
 import { Box } from 'grommet';
 
 ## What makes up a status indicator?
-To effectively capture the user’s attention, status indicators are compromised of four different elements:
+
+To effectively capture the user’s attention, status indicators are composed of four elements:
 
 - Colors
 - Icons


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Fix typo on status indicator page
**original text** - _To effectively capture the user’s attention, status indicators are compromised of four different elements:_
**Updated text** - _To effectively capture the user’s attention, status indicators are composed of four elements:_

#### What are the relevant issues?
closes #5755

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
