### PR TITLE
DS storybook - Set addons panel to default to the right side of the screen

### DIFF
--- a/shared/aries-core/.storybook/manager.js
+++ b/shared/aries-core/.storybook/manager.js
@@ -1,0 +1,5 @@
+import { addons } from 'storybook/manager-api';
+
+addons.setConfig({
+  panelPosition: 'right',
+});


### PR DESCRIPTION
https://deploy-preview-5759--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/components-anchor--default

#### What does this PR do?
Change configuration of the addons panel in storybook to be on the right side instead of the bottom by default

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
