### PR TITLE
DS Storybook - Add CheckBox story

### DIFF
--- a/shared/aries-core/src/stories/components/CheckBox.stories.tsx
+++ b/shared/aries-core/src/stories/components/CheckBox.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { CheckBox } from 'grommet';
+import {
+  labelArg,
+  a11yTitleArg,
+  disabledArg,
+  fillArg,
+  padArg,
+  reverseArg,
+} from '../utils/commonArgs';
+
+const meta = {
+  title: 'Components/CheckBox',
+  component: CheckBox,
+  argTypes: {
+    a11yTitle: a11yTitleArg,
+    checked: {
+      control: { type: 'boolean' },
+    },
+    disabled: disabledArg,
+    fill: fillArg,
+    indeterminate: {
+      control: { type: 'boolean' },
+    },
+    label: labelArg,
+    pad: padArg,
+    reverse: reverseArg,
+    toggle: {
+      control: { type: 'boolean' },
+    },
+  },
+} satisfies Meta<typeof CheckBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  name: 'CheckBox',
+  render: args => <CheckBox {...args} />,
+  args: {
+    a11yTitle: undefined,
+    checked: false,
+    disabled: false,
+    fill: false,
+    indeterminate: false,
+    label: 'CheckBox',
+    pad: undefined,
+    reverse: false,
+    toggle: false,
+  },
+} satisfies Story;

--- a/shared/aries-core/src/stories/components/Tag.stories.tsx
+++ b/shared/aries-core/src/stories/components/Tag.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Tag } from 'grommet';
 import {


### PR DESCRIPTION
https://deploy-preview-5791--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/components-checkbox--default

#### What does this PR do?
Add CheckBox story to storybook

Also added `import React from 'react';` to Tag story to avoid this error:
<img width="714" height="154" alt="Screenshot 2026-02-09 at 3 39 37 PM" src="https://github.com/user-attachments/assets/3b6c02d7-e398-42f8-9c6c-338035aabf46" />

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5710

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
