### PR TITLE
DS Storybook - Added DateInput story

### DIFF
--- a/shared/aries-core/src/stories/components/DateInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/DateInput.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, DateInput } from 'grommet';
+import { reverseArg } from '../utils/commonArgs';
+
+const meta = {
+  title: 'Components/DateInput',
+  component: DateInput,
+  argTypes: {
+    format: {
+      control: { type: 'text' },
+    },
+    inline: {
+      control: { type: 'boolean' },
+    },
+    readOnlyCopy: {
+      control: { type: 'boolean' },
+    },
+    reverse: reverseArg,
+  },
+} satisfies Meta<typeof DateInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  name: 'DateInput',
+  render: args => (
+    <Box>
+      <DateInput {...args} />
+    </Box>
+  ),
+  args: {
+    format: 'mm/dd/yyyy',
+    inline: false,
+    readOnlyCopy: false,
+    reverse: false,
+  },
+} satisfies Story;


### PR DESCRIPTION
https://deploy-preview-5794--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/components-dateinput--default

#### What does this PR do?
Add DateInput story

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5710

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
