### PR TITLE
DS Storybook - Add FileInput story

### DIFF
--- a/shared/aries-core/src/stories/components/FileInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/FileInput.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { FileInput } from 'grommet';
+import { disabledArg } from '../utils/commonArgs';
+
+const meta = {
+  title: 'Components/FileInput',
+  component: FileInput,
+  argTypes: {
+    'aria-label': {
+      control: { type: 'text' },
+    },
+    disabled: disabledArg,
+    maxSize: {
+      control: { type: 'number' },
+    },
+    multiple: {
+      control: { type: 'boolean' },
+    },
+  },
+} satisfies Meta<typeof FileInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  name: 'FileInput',
+  render: args => <FileInput {...args} />,
+  args: {
+    'aria-label': 'Choose a file',
+    disabled: false,
+    maxSize: undefined,
+    multiple: false,
+  },
+} satisfies Story;


### PR DESCRIPTION
https://deploy-preview-5797--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/components-fileinput--default

#### What does this PR do?
Add FileInput story

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5710

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
