### PR TITLE
DS Storybook - Add maskedinput story

### DIFF
--- a/shared/aries-core/src/stories/components/MaskedInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/MaskedInput.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { MaskedInput } from 'grommet';
+import { iconArg } from '../utils/commonArgs';
+import { heightArg } from '../utils/commonArgs';
+
+const meta = {
+  title: 'Components/MaskedInput',
+  component: MaskedInput,
+  argTypes: {
+    dropHeight: heightArg,
+    icon: iconArg,
+    mask: {
+      control: { type: 'object' },
+    },
+    reverse: {
+      control: { type: 'boolean' },
+    },
+  },
+} satisfies Meta<typeof MaskedInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  name: 'MaskedInput',
+  render: args => <MaskedInput {...args} />,
+  args: {
+    dropHeight: undefined,
+    icon: undefined,
+    mask: [
+      {
+        regexp: /^[\w\-_.]+$/,
+        placeholder: 'example',
+      },
+      { fixed: '@' },
+      {
+        regexp: /^[\w]+$/,
+        placeholder: 'my',
+      },
+      { fixed: '.' },
+      {
+        regexp: /^[\w]+$/,
+        placeholder: 'com',
+      },
+    ],
+    reverse: false,
+  },
+} satisfies Story;


### PR DESCRIPTION
https://deploy-preview-5798--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/components-maskedinput--default

#### What does this PR do?
Add maskedInput story

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5710

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
