### PR TITLE
[icons-svg] - Modified docs and added tests

### DIFF
--- a/packages/icons-svg/README.md
+++ b/packages/icons-svg/README.md
@@ -10,31 +10,43 @@ npm install @hpe-design/icons-svg
 
 ## Usage
 
-### Importing Individual SVG Icons
+### Approach 1 — Import as URL (`<img>` tag)
 
-You can import individual SVG files directly from the package:
+The simplest approach. The icon is treated as a static asset and resolves to a URL.
 
-*Note: this doesn't let you style the color as easily with CSS and you have to use something like `filter` to adjust the color* 
+> ⚠️ **`fill="currentColor"` has no effect when rendered via `<img>`.** To change the colour you must use a CSS `filter`. Use Approach 2 if you need CSS colour control.
 
 ```javascript
-// Import as a URL/path
 import addIcon from '@hpe-design/icons-svg/add.svg';
 import closeIcon from '@hpe-design/icons-svg/close.svg';
-import searchIcon from '@hpe-design/icons-svg/search.svg';
 
 // Use in your HTML
 const iconElement = `<img src="${addIcon}" alt="Add" class="icon" />`;
 ```
 
-### Loading SVG as Raw String
+### Approach 2 — Inline SVG (full CSS colour control)
 
-You can also load SVG content as raw strings for dynamic usage:
+Inject the SVG markup directly into the DOM so that `fill="currentColor"` inherits the CSS `color` property from any ancestor element.
+
+**Option A — Raw import (Vite only):**
+
+The `?raw` query suffix is a [Vite built-in](https://vite.dev/guide/assets#importing-asset-as-string) that returns the file content as a string.
 
 ```javascript
-// Using fetch to load SVG content
+// Vite only — no additional configuration required
+import addIcon from '@hpe-design/icons-svg/add.svg?raw';
+
+document.getElementById('icon-container').innerHTML = addIcon;
+```
+
+**Option B — Dynamic fetch (framework-agnostic):**
+
+```javascript
 async function loadIcon(iconName) {
-  const response = await fetch(`/node_modules/@hpe-design/icons-svg/${iconName}.svg`);
-  return await response.text();
+  // In a bundled app the icons are served from your build output.
+  // Adjust the base path to match your asset serving setup.
+  const response = await fetch(`/assets/${iconName}.svg`);
+  return response.text();
 }
 
 // Usage
@@ -43,16 +55,11 @@ loadIcon('add').then(svgContent => {
 });
 ```
 
-You can also load the svg as a raw string with a bundler setup to allow raw imports like:
-```javascript
-import addIcon from "@hpe-design/icons-svg/add.svg?raw"
-
-document.getElementById('icon-container').innerHTML = addIcon;
-```
-
 ### Styling Icons with CSS
 
-All icons use `fill="currentColor"`, making them easy to style with CSS. They can simply inherit the current foreground `color` from their parent, or you can give them a specific color:
+Most icons use `fill="currentColor"`, making them easy to style with CSS when rendered as **inline SVG** (Approach 2). The icon inherits the foreground `color` from its parent element.
+
+> **Note:** CSS `color`-based styling does not apply when icons are rendered via an `<img>` tag (Approach 1).
 
 ```css
 /* Basic icon styling */
@@ -111,17 +118,16 @@ All icons use `fill="currentColor"`, making them easy to style with CSS. They ca
   .icon {
     color: #ffffff;
   }
-  
+
   .icon-button {
     color: #cccccc;
   }
-  
+
   .icon-button:hover {
     color: #4d9fff;
   }
 }
 ```
-
 
 ## Available Icons
 
@@ -147,23 +153,9 @@ import addIcon from '@hpe-design/icons-svg/add.svg';
 const iconUrl: string = addIcon;
 ```
 
-## Webpack Configuration
+## Bundler Configuration
 
-If you're using Webpack, you might need to configure it to handle SVG imports:
-
-```javascript
-// webpack.config.js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.svg$/,
-        use: ['@svgr/webpack', 'url-loader'],
-      },
-    ],
-  },
-};
-```
+Detailed, annotated configuration examples for **Vite** and **Webpack** (including how to support both URL and raw-string imports in the same project) can be found in [`examples/bundlers/`](./examples/bundlers/).
 
 ## Browser Support
 
@@ -173,7 +165,6 @@ These SVG icons work in all modern browsers that support SVG:
 - Firefox 3+
 - Safari 3.2+
 - Edge 12+
-- Internet Explorer 9+
 
 ## Performance Tips
 

--- a/packages/icons-svg/examples/bundlers/vite.config.example.js
+++ b/packages/icons-svg/examples/bundlers/vite.config.example.js
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+/**
+ * Example Vite configuration for projects consuming @hpe-design/icons-svg.
+ *
+ * Two common SVG import strategies are shown below. Pick the one that fits
+ * your project, or use both side-by-side.
+ */
+export default defineConfig({
+  plugins: [react()],
+
+  // ─── Option A (default, no config needed) ───────────────────────────────
+  // Vite handles SVG out-of-the-box:
+  //   • `import url from './icon.svg'`       → resolves to a URL string
+  //   • `import raw from './icon.svg?raw'`   → resolves to the SVG markup
+  //
+  // No extra configuration required for these two built-in query suffixes.
+
+  // ─── Option B: treat ALL SVG imports as raw strings (no ?raw suffix) ────
+  // Uncomment the block below if you prefer `import raw from './icon.svg'`
+  // to always return the raw SVG markup instead of a URL.
+  //
+  // assetsInclude: [],  // prevent Vite treating .svg as static assets
+  // optimizeDeps: {
+  //   // If you pre-bundle dependencies, exclude the icons package so that
+  //   // individual .svg files remain resolvable at runtime.
+  //   exclude: ['@hpe-design/icons-svg'],
+  // },
+  // plugins: [
+  //   react(),
+  //   {
+  //     // Inline plugin: intercept .svg imports and return raw content
+  //     name: 'svg-raw',
+  //     transform(src, id) {
+  //       if (id.endsWith('.svg')) {
+  //         return { code: `export default ${JSON.stringify(src)}`, map: null };
+  //       }
+  //     },
+  //   },
+  // ],
+});

--- a/packages/icons-svg/examples/bundlers/webpack.config.example.js
+++ b/packages/icons-svg/examples/bundlers/webpack.config.example.js
@@ -1,0 +1,61 @@
+/**
+ * Example Webpack 5 configuration for projects consuming @hpe-design/icons-svg.
+ *
+ * Two SVG handling strategies are shown:
+ *   A) URL/DataURI — import resolves to a URL string (no CSS colour control)
+ *   B) Raw string  — import resolves to the SVG markup  (CSS colour control ✅)
+ *
+ * Install the required loader before using Option B:
+ *   npm install --save-dev raw-loader
+ */
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+  module: {
+    rules: [
+      // ── TypeScript / JavaScript ────────────────────────────────────────
+      {
+        test: /\.[jt]sx?$/,
+        exclude: /node_modules/,
+        use: 'babel-loader',
+      },
+
+      // ── Option A: SVG as URL / Data URI ───────────────────────────────
+      // `import iconUrl from '@hpe-design/icons-svg/add.svg'`
+      // → resolves to a data URL or asset URL (no CSS colour control).
+      {
+        test: /\.svg$/,
+        // Exclude packages where you want raw strings (Option B) by using
+        // a resourceQuery or separate rule with `include` / `exclude`.
+        type: 'asset/resource',
+        // Alternatively, inline small SVGs as data URIs:
+        // type: 'asset',
+        // parser: { dataUrlCondition: { maxSize: 8 * 1024 } },
+      },
+
+      // ── Option B: SVG as raw string ────────────────────────────────────
+      // Uncomment this rule (and comment out Option A above) to import SVGs
+      // as raw markup strings so `fill="currentColor"` can be styled with CSS.
+      //
+      // {
+      //   test: /\.svg$/,
+      //   use: 'raw-loader',
+      // },
+
+      // ── Option C: Use a resourceQuery to support both simultaneously ───
+      // This lets you choose per-import:
+      //   import url from './icon.svg'        → URL  (matched by Option A)
+      //   import raw from './icon.svg?raw'    → raw  (matched by this rule)
+      //
+      // {
+      //   test: /\.svg$/,
+      //   resourceQuery: /raw/,
+      //   use: 'raw-loader',
+      // },
+    ],
+  },
+
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+};

--- a/packages/icons-svg/examples/html/index.html
+++ b/packages/icons-svg/examples/html/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@hpe-design/icons-svg — HTML Examples</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #333;
+      }
+      h2 { border-bottom: 1px solid #ddd; padding-bottom: 0.5rem; }
+      .demo {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        flex-wrap: wrap;
+        margin: 1rem 0;
+      }
+      .icon-wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.25rem;
+        font-size: 0.75rem;
+        color: #666;
+      }
+
+      /* -----------------------------------------------------------------------
+         SVG icons use fill="currentColor", so setting `color` on any ancestor
+         controls the icon colour when the SVG is rendered inline.
+      ----------------------------------------------------------------------- */
+      .icon { width: 24px; height: 24px; }
+      .icon-blue  { color: #0073e7; }
+      .icon-green { color: #00c781; }
+      .icon-red   { color: #ff5757; }
+      .icon-large { width: 48px; height: 48px; }
+    </style>
+  </head>
+  <body>
+    <h1>@hpe-design/icons-svg</h1>
+    <p>HTML usage examples for HPE SVG icons.</p>
+
+    <!-- =====================================================================
+         Approach 1: <img> tag
+         Simple, but fill="currentColor" has no effect — the icon will always
+         render in its default colour. Use this only when you don't need colour
+         control via CSS.
+    ====================================================================== -->
+    <h2>Approach 1 — &lt;img&gt; tag (no CSS colour control)</h2>
+    <div class="demo">
+      <div class="icon-wrapper">
+        <img
+          src="/node_modules/@hpe-design/icons-svg/dist/add.svg"
+          alt="Add"
+          class="icon"
+        />
+        <span>add</span>
+      </div>
+      <div class="icon-wrapper">
+        <img
+          src="/node_modules/@hpe-design/icons-svg/dist/close.svg"
+          alt="Close"
+          class="icon"
+        />
+        <span>close</span>
+      </div>
+    </div>
+
+    <!-- =====================================================================
+         Approach 2: Inline SVG via fetch
+         Inject SVG markup directly into the DOM so that fill="currentColor"
+         inherits the CSS `color` property from the element or its ancestors.
+    ====================================================================== -->
+    <h2>Approach 2 — Inline SVG via fetch (full CSS colour control)</h2>
+    <div class="demo" id="inline-demo">Loading…</div>
+
+    <!-- =====================================================================
+         Approach 3: CSS mask
+         Works with a plain <div> + background-color. Useful when you need a
+         solid-colour icon without injecting SVG markup, but it doesn't support
+         multi-colour icons.
+    ====================================================================== -->
+    <h2>Approach 3 — CSS mask (solid colour, no SVG injection)</h2>
+    <style>
+      .icon-mask {
+        display: inline-block;
+        width: 24px;
+        height: 24px;
+        background-color: currentColor; /* set via `color` on the element */
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+      }
+      .icon-mask-search {
+        -webkit-mask-image: url('/node_modules/@hpe-design/icons-svg/dist/search.svg');
+        mask-image: url('/node_modules/@hpe-design/icons-svg/dist/search.svg');
+      }
+      .icon-mask-home {
+        -webkit-mask-image: url('/node_modules/@hpe-design/icons-svg/dist/home.svg');
+        mask-image: url('/node_modules/@hpe-design/icons-svg/dist/home.svg');
+      }
+    </style>
+    <div class="demo">
+      <div class="icon-wrapper">
+        <span class="icon-mask icon-mask-search icon-blue"></span>
+        <span>search (blue)</span>
+      </div>
+      <div class="icon-wrapper">
+        <span class="icon-mask icon-mask-home icon-green" style="width:32px;height:32px"></span>
+        <span>home (green, 32 px)</span>
+      </div>
+    </div>
+
+    <script>
+      // Approach 2: fetch SVG content and inject inline
+      async function loadInlineSVG(iconName) {
+        const res = await fetch(
+          `/node_modules/@hpe-design/icons-svg/dist/${iconName}.svg`,
+        );
+        return res.text();
+      }
+
+      const icons = [
+        { name: 'add',     label: 'add (blue)',   cssClass: 'icon-blue'  },
+        { name: 'close',   label: 'close (red)',  cssClass: 'icon-red'   },
+        { name: 'search',  label: 'search (green)',cssClass: 'icon-green' },
+        { name: 'settings',label: 'settings (large)', cssClass: 'icon-large icon-blue' },
+      ];
+
+      async function renderInlineIcons() {
+        const container = document.getElementById('inline-demo');
+        container.innerHTML = '';
+        for (const { name, label, cssClass } of icons) {
+          const svgContent = await loadInlineSVG(name);
+          const wrapper = document.createElement('div');
+          wrapper.className = 'icon-wrapper';
+          wrapper.innerHTML = `
+            <span class="icon ${cssClass}">${svgContent}</span>
+            <span>${label}</span>
+          `;
+          container.appendChild(wrapper);
+        }
+      }
+
+      renderInlineIcons();
+    </script>
+  </body>
+</html>

--- a/packages/icons-svg/examples/react/App.tsx
+++ b/packages/icons-svg/examples/react/App.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Approach 1: Import as URL
+// The bundler (Vite/webpack) resolves the SVG to a URL string.
+// Renders with <img>, so fill="currentColor" does NOT apply — the icon colour
+// cannot be controlled via the CSS `color` property.
+// ---------------------------------------------------------------------------
+import addIconUrl from '@hpe-design/icons-svg/add.svg';
+import closeIconUrl from '@hpe-design/icons-svg/close.svg';
+
+// ---------------------------------------------------------------------------
+// Approach 2: Import as raw string  (Vite: append `?raw`)
+// Inject the SVG markup directly into the DOM so that fill="currentColor"
+// inherits the CSS `color` of the wrapper element.
+// ---------------------------------------------------------------------------
+import searchIconRaw from '@hpe-design/icons-svg/search.svg?raw';
+import homeIconRaw from '@hpe-design/icons-svg/home.svg?raw';
+
+// ---------------------------------------------------------------------------
+// Approach 3: Look up icon filenames from the metadata object, then load
+// on-demand (useful when the icon name is only known at runtime).
+// ---------------------------------------------------------------------------
+import allIcons from '@hpe-design/icons-svg';
+
+// ─── Reusable inline-SVG component ──────────────────────────────────────────
+
+interface InlineSVGProps {
+  /** Raw SVG markup string */
+  svgContent: string;
+  /** CSS color value — controls the icon fill via currentColor */
+  color?: string;
+  /** Icon dimensions in pixels (default 24) */
+  size?: number;
+  /** Accessible label */
+  'aria-label'?: string;
+}
+
+function InlineSVG({ svgContent, color, size = 24, 'aria-label': ariaLabel }: InlineSVGProps) {
+  return (
+    <span
+      style={{ color, display: 'inline-flex', width: size, height: size }}
+      aria-label={ariaLabel}
+      aria-hidden={!ariaLabel}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: svgContent }}
+    />
+  );
+}
+
+// ─── Dynamic icon loader ────────────────────────────────────────────────────
+
+async function fetchIconRaw(iconName: string): Promise<string> {
+  // `allIcons` maps PascalCase name → kebab-case filename, e.g. 'Add' → 'add.svg'
+  const filename = allIcons[iconName];
+  if (!filename) throw new Error(`Icon "${iconName}" not found`);
+
+  // In a real app, replace the base URL with wherever @hpe-design/icons-svg is served.
+  const res = await fetch(`/node_modules/@hpe-design/icons-svg/dist/${filename}`);
+  if (!res.ok) throw new Error(`Failed to fetch icon: ${filename}`);
+  return res.text();
+}
+
+// ─── Demo app ───────────────────────────────────────────────────────────────
+
+export default function App() {
+  const [dynamicSvg, setDynamicSvg] = useState<string | null>(null);
+  const [dynamicName, setDynamicName] = useState('Settings');
+
+  const handleLoad = async () => {
+    const svg = await fetchIconRaw(dynamicName);
+    setDynamicSvg(svg);
+  };
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '2rem', maxWidth: 640 }}>
+      <h1>@hpe-design/icons-svg — React Examples</h1>
+
+      {/* ------------------------------------------------------------------ */}
+      <h2>Approach 1 — &lt;img&gt; tag (URL import, no colour control)</h2>
+      <p>Use this when colour control is not needed.</p>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <img src={addIconUrl} alt="Add" width={24} height={24} />
+        <img src={closeIconUrl} alt="Close" width={24} height={24} />
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      <h2>Approach 2 — Inline SVG (raw import, full colour control)</h2>
+      <p>
+        Import with <code>?raw</code> and inject via{' '}
+        <code>dangerouslySetInnerHTML</code>. The icon's{' '}
+        <code>fill="currentColor"</code> inherits the wrapper's CSS{' '}
+        <code>color</code>.
+      </p>
+      <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+        <InlineSVG svgContent={searchIconRaw} color="#0073e7" size={24} aria-label="Search" />
+        <InlineSVG svgContent={homeIconRaw}   color="#00c781" size={32} aria-label="Home" />
+        <InlineSVG svgContent={searchIconRaw} color="#ff5757" size={48} aria-label="Search large" />
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      <h2>Approach 3 — Dynamic fetch by icon name</h2>
+      <p>
+        Use the exported icon metadata object to resolve a name to a filename,
+        then fetch the SVG on demand. Handy when the icon is unknown at build
+        time.
+      </p>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <select
+          value={dynamicName}
+          onChange={e => { setDynamicName(e.target.value); setDynamicSvg(null); }}
+        >
+          {Object.keys(allIcons).slice(0, 20).map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+        <button onClick={handleLoad}>Load icon</button>
+        {dynamicSvg && (
+          <InlineSVG svgContent={dynamicSvg} color="#6633cc" size={32} aria-label={dynamicName} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/icons-svg/examples/react/README.md
+++ b/packages/icons-svg/examples/react/README.md
@@ -1,0 +1,30 @@
+# React Example
+
+Demonstrates three ways to use `@hpe-design/icons-svg` in a React + Vite project.
+
+## Setup
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+cd my-app
+npm install @hpe-design/icons-svg
+```
+
+Copy `App.tsx` into `src/App.tsx`, then run `npm run dev`.
+
+## Approaches
+
+| Approach      | Import style                                    | CSS colour control | Use when                                  |
+| ------------- | ----------------------------------------------- | ------------------ | ----------------------------------------- |
+| `<img>` tag   | URL (`import icon from '…/add.svg'`)            | ❌                 | Static decorative icons, no colour needed |
+| Inline SVG    | Raw string (`import icon from '…/add.svg?raw'`) | ✅                 | Coloured icons, known at build time       |
+| Dynamic fetch | Metadata object + `fetch()`                     | ✅                 | Icon name only known at runtime           |
+
+## Vite configuration
+
+The `?raw` suffix is built into Vite — no additional configuration is needed.
+For URL imports (`import icon from '…/add.svg'`) Vite also works out-of-the-box.
+
+See [`../bundlers/vite.config.example.js`](../bundlers/vite.config.example.js)
+for an explicit SVG asset configuration that can replace the `?raw` suffix with
+a global rule.

--- a/packages/icons-svg/package.json
+++ b/packages/icons-svg/package.json
@@ -22,12 +22,15 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && vite build"
+    "build": "tsc && vite build",
+    "test": "vitest --watch=false"
   },
   "devDependencies": {
+    "@types/node": "catalog:",
     "typescript": "catalog:",
     "vite": "^7.2.2",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-static-copy": "^2.3.2"
+    "vite-plugin-static-copy": "^2.3.2",
+    "vitest": "^3.0.9"
   }
 }

--- a/packages/icons-svg/src/tests/build.test.ts
+++ b/packages/icons-svg/src/tests/build.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = path.resolve(__dirname, '../../dist');
+const ICONS_DIR = path.resolve(__dirname, '../icons');
+
+const distExists = fs.existsSync(DIST_DIR);
+
+// ---------------------------------------------------------------------------
+// Guard: skip all build tests if dist/ hasn't been generated yet.
+// Run `pnpm build` before running `pnpm test` in CI, or run both together:
+//   pnpm build && pnpm test
+// ---------------------------------------------------------------------------
+describe.skipIf(!distExists)(
+  'Build output — run `pnpm build` before this suite',
+  () => {
+    let distFiles: string[];
+    let sourceIconFiles: string[];
+
+    beforeAll(() => {
+      distFiles = fs.readdirSync(DIST_DIR);
+      sourceIconFiles = fs
+        .readdirSync(ICONS_DIR)
+        .filter(f => f.endsWith('.svg'));
+    });
+
+    // -------------------------------------------------------------------------
+    // Required output files
+    // -------------------------------------------------------------------------
+    describe('Required output files', () => {
+      it('ESM bundle (hpe-icons.js) exists', () => {
+        expect(distFiles).toContain('hpe-icons.js');
+      });
+
+      it('CJS bundle (hpe-icons.cjs) exists', () => {
+        expect(distFiles).toContain('hpe-icons.cjs');
+      });
+
+      it('TypeScript declaration file (index.d.ts) exists', () => {
+        expect(distFiles).toContain('index.d.ts');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // SVG files copied to dist/
+    // -------------------------------------------------------------------------
+    describe('SVG files copied to dist/', () => {
+      it('SVG count in dist/ matches SVG count in src/icons/', () => {
+        const distSvgFiles = distFiles.filter(f => f.endsWith('.svg'));
+        expect(distSvgFiles.length).toBe(sourceIconFiles.length);
+      });
+
+      it('all source SVG filenames are present in dist/', () => {
+        const missing = sourceIconFiles.filter(f => !distFiles.includes(f));
+        expect(missing).toEqual([]);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Bundle file contents
+    // -------------------------------------------------------------------------
+    describe('Bundle file contents', () => {
+      it('ESM bundle contains export default', () => {
+        const content = fs.readFileSync(
+          path.join(DIST_DIR, 'hpe-icons.js'),
+          'utf-8',
+        );
+        expect(content).toContain('export default');
+      });
+
+      it('CJS bundle contains exports assignment', () => {
+        const content = fs.readFileSync(
+          path.join(DIST_DIR, 'hpe-icons.cjs'),
+          'utf-8',
+        );
+        const hasCjsExports =
+          content.includes('module.exports') || content.includes('exports.');
+        expect(hasCjsExports).toBe(true);
+      });
+
+      it('TypeScript declaration re-exports a default', () => {
+        const content = fs.readFileSync(
+          path.join(DIST_DIR, 'index.d.ts'),
+          'utf-8',
+        );
+        expect(content).toContain('export default');
+      });
+
+      it('ESM bundle references the expected icon names', () => {
+        const content = fs.readFileSync(
+          path.join(DIST_DIR, 'hpe-icons.js'),
+          'utf-8',
+        );
+        // Spot-check a few well-known icons that should always exist
+        expect(content).toContain('add.svg');
+        expect(content).toContain('close.svg');
+        expect(content).toContain('search.svg');
+      });
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Reminder when the build hasn't been run yet
+// ---------------------------------------------------------------------------
+describe.skipIf(distExists)('Build output — dist/ not found', () => {
+  it.todo('dist/ directory should exist — run `pnpm build` before this suite');
+});

--- a/packages/icons-svg/src/tests/icons.test.ts
+++ b/packages/icons-svg/src/tests/icons.test.ts
@@ -1,0 +1,120 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ICONS_DIR = path.resolve(__dirname, '../icons');
+
+// ---------------------------------------------------------------------------
+// Source icon file validation
+// ---------------------------------------------------------------------------
+describe('Icon source files', () => {
+  let iconFiles: string[];
+
+  beforeAll(() => {
+    iconFiles = fs.readdirSync(ICONS_DIR).filter(f => f.endsWith('.svg'));
+  });
+
+  it('contains at least 400 SVG icons', () => {
+    expect(iconFiles.length).toBeGreaterThanOrEqual(400);
+  });
+
+  it('icons directory contains only SVG files', () => {
+    const allFiles = fs.readdirSync(ICONS_DIR);
+    const nonSvg = allFiles.filter(f => !f.endsWith('.svg'));
+    expect(nonSvg).toEqual([]);
+  });
+
+  it('all filenames follow the expected naming convention (kebab-case)', () => {
+    // Allows lowercase-kebab, AI-prefixed (uppercase abbreviations), and digits
+    const invalid = iconFiles.filter(
+      f => !/^[a-zA-Z][a-zA-Z0-9-]*\.svg$/.test(f),
+    );
+    expect(invalid).toEqual([]);
+  });
+
+  it('no duplicate filenames', () => {
+    const unique = new Set(iconFiles);
+    expect(iconFiles.length).toBe(unique.size);
+  });
+
+  it('all icons have viewBox="0 0 24 24"', () => {
+    const invalid = iconFiles.filter(file => {
+      const content = fs.readFileSync(path.join(ICONS_DIR, file), 'utf-8');
+      return !content.includes('viewBox="0 0 24 24"');
+    });
+    expect(invalid).toEqual([]);
+  });
+
+  it('all icons use fill="currentColor" for CSS color support', () => {
+    const invalid = iconFiles.filter(file => {
+      const content = fs.readFileSync(path.join(ICONS_DIR, file), 'utf-8');
+      return !content.includes('fill="currentColor"');
+    });
+    expect(invalid).toEqual([]);
+  });
+
+  it('all icons declare width="24" and height="24"', () => {
+    const invalid = iconFiles.filter(file => {
+      const content = fs.readFileSync(path.join(ICONS_DIR, file), 'utf-8');
+      return (
+        !content.includes('width="24"') || !content.includes('height="24"')
+      );
+    });
+    expect(invalid).toEqual([]);
+  });
+
+  it('all icons are valid SVG markup', () => {
+    const invalid = iconFiles.filter(file => {
+      const content = fs.readFileSync(path.join(ICONS_DIR, file), 'utf-8');
+      return (
+        !content.trimStart().startsWith('<svg') || !content.includes('</svg>')
+      );
+    });
+    expect(invalid).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Icon name derivation logic (mirrors src/index.ts)
+// ---------------------------------------------------------------------------
+describe('Icon name derivation', () => {
+  const getIconName = (filename: string): string => {
+    const nameWithoutExt = filename.replace(/\.svg$/, '');
+    return nameWithoutExt.charAt(0).toUpperCase() + nameWithoutExt.slice(1);
+  };
+
+  const getIconFileName = (iconPath: string): string =>
+    iconPath.split('/').pop()!;
+
+  it('derives a capitalised name from a simple filename', () => {
+    expect(getIconName('add.svg')).toBe('Add');
+    expect(getIconName('close.svg')).toBe('Close');
+    expect(getIconName('home.svg')).toBe('Home');
+  });
+
+  it('preserves hyphenated names', () => {
+    expect(getIconName('chart-bar.svg')).toBe('Chart-bar');
+    expect(getIconName('arrow-left.svg')).toBe('Arrow-left');
+    expect(getIconName('status-critical.svg')).toBe('Status-critical');
+  });
+
+  it('preserves already-uppercase prefixes (e.g. AI-*)', () => {
+    expect(getIconName('AI-gen.svg')).toBe('AI-gen');
+    expect(getIconName('AI-systems.svg')).toBe('AI-systems');
+    expect(getIconName('AI-gen-fill.svg')).toBe('AI-gen-fill');
+  });
+
+  it('extracts filename from a full path', () => {
+    expect(getIconFileName('./icons/add.svg')).toBe('add.svg');
+    expect(getIconFileName('./icons/AI-gen.svg')).toBe('AI-gen.svg');
+  });
+
+  it('all source icons produce unique exported names', () => {
+    const iconFiles = fs.readdirSync(ICONS_DIR).filter(f => f.endsWith('.svg'));
+    const names = iconFiles.map(f => getIconName(f));
+    const unique = new Set(names);
+    expect(names.length).toBe(unique.size);
+  });
+});

--- a/packages/icons-svg/tsconfig.json
+++ b/packages/icons-svg/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/tests"]
 }

--- a/packages/icons-svg/tsconfig.test.json
+++ b/packages/icons-svg/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/tests"]
+}

--- a/packages/icons-svg/vite.config.ts
+++ b/packages/icons-svg/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import dts from 'vite-plugin-dts';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
@@ -27,5 +27,9 @@ export default defineConfig({
     },
     outDir: 'dist',
     emptyOutDir: true,
+  },
+  test: {
+    environment: 'node',
+    include: ['src/tests/**/*.test.ts'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
 
   packages/icons-svg:
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.25
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -407,6 +410,9 @@ importers:
       vite-plugin-static-copy:
         specifier: ^2.3.2
         version: 2.3.2(vite@7.2.2(@types/node@20.19.25)(jiti@1.21.7)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.9
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jsdom@26.1.0)(terser@5.44.1)
 
   sandbox/grommet-app:
     dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

This pull request significantly improves the documentation and developer experience for using `@hpe-design/icons-svg` in various environments. The README has been rewritten to clearly explain multiple integration approaches, and new example projects have been added for React, HTML, and bundler configurations. These changes make it much easier for users to understand how to import, style, and configure SVG icons for different use cases and toolchains.

**Documentation and Usage Improvements:**

* Rewrote the main `README.md` to clearly explain three main usage approaches: importing SVGs as URLs for `<img>` tags, as raw strings for inline SVG (with full CSS color control), and dynamic loading via fetch. Each approach now includes code samples and clear notes on styling and browser support. [[1]](diffhunk://#diff-70b6952ce597910e3f50cdc81653b847660299b492b5d72f0790f78655609ca7L13-R49) [[2]](diffhunk://#diff-70b6952ce597910e3f50cdc81653b847660299b492b5d72f0790f78655609ca7L46-R62) [[3]](diffhunk://#diff-70b6952ce597910e3f50cdc81653b847660299b492b5d72f0790f78655609ca7L125)
* Added a new React example (`examples/react/App.tsx` and `examples/react/README.md`) demonstrating all three approaches in a modern React+Vite setup, including a reusable inline SVG component and dynamic loading by icon name. [[1]](diffhunk://#diff-dbac397cf1ee47533687e63ec2020102c3dd2325617266343ce9055d273ea0deR1-R124) [[2]](diffhunk://#diff-39f30d7430f0474003f77c7ac06543c9f3185ca0a59141eb40583aa6ace6a2ebR1-R30)
* Added an HTML example (`examples/html/index.html`) showing how to use icons with `<img>`, inline SVG (via fetch), and as CSS masks, including live color styling and dynamic loading.

**Bundler Configuration Examples:**

* Added detailed, annotated example configuration files for both Vite (`examples/bundlers/vite.config.example.js`) and Webpack (`examples/bundlers/webpack.config.example.js`). These show how to support both URL and raw-string SVG imports, and how to customize handling for different project needs. [[1]](diffhunk://#diff-5215ff1c1193e0b15d7c88c3266bb84dfcd373a0a7d22f8187c6c568799682e5R1-R42) [[2]](diffhunk://#diff-399b90c526cead5888cdb5d25842fc7b777ad50e5328fd02ce67afd45f717b08R1-R61)
* Updated the main `README.md` to reference these new configuration examples instead of including outdated or partial webpack configuration inline.

**Other Enhancements:**

* Added `@types/node` and `vitest` as dev dependencies and introduced a `test` script in `package.json` to support future testing and improve DX.
* Removed outdated browser support notes for Internet Explorer, clarifying the focus on modern browsers.

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
