### PR TITLE
[Monorepo] Copilot instructions - Added initial instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,8 @@ pnpm workspace with four workspace roots (`apps/*`, `packages/**`, `sandbox/*`, 
 | `shared/aries-core`          | `@shared/aries-core`         | Shared React components + Storybook           |
 | `shared/hooks`               | `@shared/hooks`              | Shared React hooks (TypeScript, Vitest)       |
 | `sandbox/grommet-app`        | —                            | Prototype app for testing components/tokens   |
-| `sandbox/mcp-ui`             | —                            | Future development — do not treat as active   |
+| `sandbox/native-web`         | —                            | Prototype sandbox app (native-web)            |
+| `sandbox/tailwind-app`       | —                            | Prototype sandbox app (Tailwind)              |
 
 Shared dependency versions are managed through `pnpm-workspace.yaml` `catalog:` entries — use `catalog:` references in `package.json` instead of pinned versions for shared deps like `grommet`, `react`, `styled-components`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Monorepo Overview
 
-pnpm workspace with five workspace roots (`apps/*`, `packages/**`, `sandbox/*`, `shared/*`). Key packages:
+pnpm workspace with four workspace roots (`apps/*`, `packages/**`, `sandbox/*`, `shared/*`). Key packages:
 
 | Path                         | Package                      | Purpose                                       |
 | ---------------------------- | ---------------------------- | --------------------------------------------- |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,7 @@ pnpm workspace with five workspace roots (`apps/*`, `packages/**`, `sandbox/*`, 
 | `apps/docs`                  | `docs`                       | Next.js 15 documentation site (static export) |
 | `packages/hpe-design-tokens` | `hpe-design-tokens`          | Design tokens built with Style Dictionary v4  |
 | `packages/icons-grommet`     | `@hpe-design/icons-grommet`  | HPE icons for Grommet (Vite build)            |
+| `packages/icons-svg`         | `@hpe-design/icons-svg`      | HPE icons in raw SVG format (Vite build)      |
 | `packages/codemods`          | `hpe-design-system-codemods` | JSCodeshift transforms for migrations         |
 | `shared/aries-core`          | `@shared/aries-core`         | Shared React components + Storybook           |
 | `shared/hooks`               | `@shared/hooks`              | Shared React hooks (TypeScript, Vitest)       |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,25 @@ pnpm --filter hpe-design-tokens sync-tokens-to-figma   # JSON files → Figma
 - **Dark mode**: Implemented via `ThemeMode` component (`apps/docs/src/layouts/main/ThemeMode.js`); token files have separate `.light.json`/`.dark.json` variants.
 - Docs site uses `output: 'export'` (static HTML) in `apps/docs/next.config.mjs` — no server-side rendering at runtime.
 
+## Pull Request Conventions
+
+**Branch naming** (descriptive, kebab-case, optionally prefixed by area):
+
+```
+docs/colors-layering-update
+templates/replace-dashboard-card-image
+remove-unused-icons
+```
+
+**PR title** format: `[{project}] {subject} – {describe what changed}`
+
+- `[Docs] Colors – Moved background layering approach from tokens to foundations`
+- `[Design Tokens] Colors – Updated brand palette and spacing scale`
+- `[Icons Grommet] Library – Added new status icons`
+- `[Codemod] T-shirt – Added mod for calendar sizes`
+
+**PR description**: Complete all sections of the PR template. Link closing issues with `Closes #1234` (auto-closes on merge); use a plain link for related-but-not-closing issues.
+
 ## Versioning & Publishing
 
 - Changesets (`@changesets/cli`) manages versioning for publishable packages (`hpe-design-tokens`, `@hpe-design/icons-grommet`, `hpe-design-system-codemods`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,8 +24,8 @@ Shared dependency versions are managed through `pnpm-workspace.yaml` `catalog:` 
 pnpm install                          # install all workspace deps (run from anywhere)
 pnpm start:docs                       # dev server for docs site (Next.js)
 pnpm --filter hpe-design-tokens build # rebuild tokens (required after token file changes)
-pnpm --filter "@hpe-design/icons-grommet" storybook  # icons Storybook
-pnpm --filter "@shared/aries-core" storybook         # component Storybook
+pnpm storybook:icons-grommet                          # icons Storybook
+pnpm storybook:core                                   # component Storybook
 pnpm --filter docs test:ci            # run TestCafe e2e tests (headless)
 pnpm --filter "@shared/hooks" test    # Vitest unit tests for hooks
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ pnpm workspace with five workspace roots (`apps/*`, `packages/**`, `sandbox/*`, 
 | Path                         | Package                      | Purpose                                       |
 | ---------------------------- | ---------------------------- | --------------------------------------------- |
 | `apps/docs`                  | `docs`                       | Next.js 15 documentation site (static export) |
+| `apps/design-tokens-manager` | `design-tokens-manager`      | Vite app for browsing/managing design tokens  |
 | `packages/hpe-design-tokens` | `hpe-design-tokens`          | Design tokens built with Style Dictionary v4  |
 | `packages/icons-grommet`     | `@hpe-design/icons-grommet`  | HPE icons for Grommet (Vite build)            |
 | `packages/icons-svg`         | `@hpe-design/icons-svg`      | HPE icons in raw SVG format (Vite build)      |
@@ -23,12 +24,16 @@ Shared dependency versions are managed through `pnpm-workspace.yaml` `catalog:` 
 ```bash
 pnpm install                          # install all workspace deps (run from anywhere)
 pnpm start:docs                       # dev server for docs site (Next.js)
+pnpm start:design-tokens-manager      # dev server for design tokens manager
+pnpm start:grommet-app                # dev server for grommet sandbox app
 pnpm --filter hpe-design-tokens build # rebuild tokens (required after token file changes)
-pnpm storybook:icons-grommet                          # icons Storybook
-pnpm storybook:core                                   # component Storybook
+pnpm storybook:icons-grommet          # icons Storybook
+pnpm storybook:core                   # component Storybook (builds tokens + hooks first)
 pnpm --filter docs test:ci            # run TestCafe e2e tests (headless)
 pnpm --filter "@shared/hooks" test    # Vitest unit tests for hooks
 ```
+
+**`pnpm install` gotcha**: the `grommet` stable tarball SHA can go stale, causing an integrity check failure. Fix: `rm pnpm-lock.yaml && pnpm install`.
 
 **Pre-commit hooks** run ESLint, Prettier, and TestCafe e2e tests via Husky. TestCafe launches real browser windows — **keep browser windows in focus** or tests will stall/timeout (>2.5 min = browser is minimized).
 
@@ -44,11 +49,11 @@ Component documentation follows a strict three-part pattern:
 
 ## Design Token Architecture
 
-Tokens follow W3C Design Token Community Group format (`$type`, `$value`, `$description`). Three layers:
+Tokens follow W3C Design Token Community Group format (`$type`, `$value`, `$description`). Three layers under `packages/hpe-design-tokens/tokens/`:
 
-- `tokens/primitive/` — raw values (colors, sizes)
-- `tokens/semantic/` — contextual references (`color.light.json`, `color.dark.json`, `dimension.default.json`)
-- `tokens/component/` — component-specific tokens
+- `primitive/` — raw values (colors, sizes)
+- `semantic/` — contextual references (`color.light.json`, `color.dark.json`, `dimension.default.json`)
+- `component/` — component-specific tokens
 
 Versioned variants exist (`.v0`, `.v1`, current) for migration compatibility. The build is run via Style Dictionary: `pnpm --filter hpe-design-tokens build`. Token outputs land in `packages/hpe-design-tokens/dist/` as ESM, CJS, CSS vars, and a Grommet-compatible format.
 
@@ -88,7 +93,7 @@ remove-unused-icons
 
 ## Versioning & Publishing
 
-- Changesets (`@changesets/cli`) manages versioning for publishable packages (`hpe-design-tokens`, `@hpe-design/icons-grommet`, `hpe-design-system-codemods`).
+- Changesets (`@changesets/cli`) manages versioning for publishable packages (`hpe-design-tokens`, `@hpe-design/icons-grommet`, `@hpe-design/icons-svg`, `hpe-design-system-codemods`).
 - The `design-tokens-stable` branch tracks stable token releases.
 - `pnpm-workspace.yaml` catalogs (`grommet-stable`, `grommet-theme-hpe-v6`, `grommet-theme-hpe-v7`) allow consuming specific Grommet versions per package.
 
@@ -98,4 +103,5 @@ remove-unused-icons
 - Docs layout components (`Example`, `ContentSection`, etc.): `apps/docs/src/layouts/content/`
 - Page shell (header, theme toggle): `apps/docs/src/layouts/main/`
 - Style Dictionary build config: `packages/hpe-design-tokens/src/scripts/build-style-dictionary.js`
+- Custom SD formats/transforms: `packages/hpe-design-tokens/src/formats/` and `packages/hpe-design-tokens/src/transforms/`
 - Custom SD formats/transforms: `packages/hpe-design-tokens/src/formats/` and `src/transforms/`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,81 @@
+# HPE Design System — Copilot Instructions
+
+## Monorepo Overview
+
+pnpm workspace with five workspace roots (`apps/*`, `packages/**`, `sandbox/*`, `shared/*`). Key packages:
+
+| Path                         | Package                      | Purpose                                       |
+| ---------------------------- | ---------------------------- | --------------------------------------------- |
+| `apps/docs`                  | `docs`                       | Next.js 15 documentation site (static export) |
+| `packages/hpe-design-tokens` | `hpe-design-tokens`          | Design tokens built with Style Dictionary v4  |
+| `packages/icons-grommet`     | `@hpe-design/icons-grommet`  | HPE icons for Grommet (Vite build)            |
+| `packages/codemods`          | `hpe-design-system-codemods` | JSCodeshift transforms for migrations         |
+| `shared/aries-core`          | `@shared/aries-core`         | Shared React components + Storybook           |
+| `shared/hooks`               | `@shared/hooks`              | Shared React hooks (TypeScript, Vitest)       |
+| `sandbox/grommet-app`        | —                            | Prototype app for testing components/tokens   |
+| `sandbox/mcp-ui`             | —                            | Future development — do not treat as active   |
+
+Shared dependency versions are managed through `pnpm-workspace.yaml` `catalog:` entries — use `catalog:` references in `package.json` instead of pinned versions for shared deps like `grommet`, `react`, `styled-components`.
+
+## Essential Commands
+
+```bash
+pnpm install                          # install all workspace deps (run from anywhere)
+pnpm start:docs                       # dev server for docs site (Next.js)
+pnpm --filter hpe-design-tokens build # rebuild tokens (required after token file changes)
+pnpm --filter "@hpe-design/icons-grommet" storybook  # icons Storybook
+pnpm --filter "@shared/aries-core" storybook         # component Storybook
+pnpm --filter docs test:ci            # run TestCafe e2e tests (headless)
+pnpm --filter "@shared/hooks" test    # Vitest unit tests for hooks
+```
+
+**Pre-commit hooks** run ESLint, Prettier, and TestCafe e2e tests via Husky. TestCafe launches real browser windows — **keep browser windows in focus** or tests will stall/timeout (>2.5 min = browser is minimized).
+
+## Adding a Component Page to Docs
+
+Component documentation follows a strict three-part pattern:
+
+1. **Register in structure**: Add an entry to `apps/docs/src/data/structures/components.js` with `name`, `category`, `description`, `seoDescription`, `sections[]`, `preview`, and `relatedContent[]`.
+
+2. **Create examples**: Add a directory `apps/docs/src/examples/components/<ComponentName>/` with individual example files and an `index.js` barrel export. Each example is a named React export (e.g., `export const ButtonExample = () => <Button ... />`).
+
+3. **Write the MDX page**: Create `apps/docs/src/pages/components/<componentname>.mdx`. Import from `../../layouts` (`Example`, `BestPracticeGroup`, `AccessibilitySection`) and `../../examples`. Wrap each example in `<Example componentName="..." code="..." docs="..." figma="...">`.
+
+## Design Token Architecture
+
+Tokens follow W3C Design Token Community Group format (`$type`, `$value`, `$description`). Three layers:
+
+- `tokens/primitive/` — raw values (colors, sizes)
+- `tokens/semantic/` — contextual references (`color.light.json`, `color.dark.json`, `dimension.default.json`)
+- `tokens/component/` — component-specific tokens
+
+Versioned variants exist (`.v0`, `.v1`, current) for migration compatibility. The build is run via Style Dictionary: `pnpm --filter hpe-design-tokens build`. Token outputs land in `packages/hpe-design-tokens/dist/` as ESM, CJS, CSS vars, and a Grommet-compatible format.
+
+Figma ↔ tokens sync is bidirectional via:
+
+```bash
+pnpm --filter hpe-design-tokens sync-figma-to-tokens   # Figma → JSON files
+pnpm --filter hpe-design-tokens sync-tokens-to-figma   # JSON files → Figma
+```
+
+## UI Framework Conventions
+
+- **Always use Grommet components** (`Box`, `Button`, `Text`, etc. from `grommet`) — not custom HTML elements.
+- **Icons**: Use `@hpe-design/icons-grommet`, not `grommet-icons`. Run `npx hpe-design-system-codemods migrate-grommet-icons-to-hpe <path>` to migrate.
+- **Theming**: Extend `hpe` theme from `grommet-theme-hpe` via `deepMerge(hpe, {...})`. See `apps/docs/src/themes/aries.js`.
+- **Dark mode**: Implemented via `ThemeMode` component (`apps/docs/src/layouts/main/ThemeMode.js`); token files have separate `.light.json`/`.dark.json` variants.
+- Docs site uses `output: 'export'` (static HTML) in `apps/docs/next.config.mjs` — no server-side rendering at runtime.
+
+## Versioning & Publishing
+
+- Changesets (`@changesets/cli`) manages versioning for publishable packages (`hpe-design-tokens`, `@hpe-design/icons-grommet`, `hpe-design-system-codemods`).
+- The `design-tokens-stable` branch tracks stable token releases.
+- `pnpm-workspace.yaml` catalogs (`grommet-stable`, `grommet-theme-hpe-v6`, `grommet-theme-hpe-v7`) allow consuming specific Grommet versions per package.
+
+## Key File Locations
+
+- Site navigation/page metadata: `apps/docs/src/data/structures/`
+- Docs layout components (`Example`, `ContentSection`, etc.): `apps/docs/src/layouts/content/`
+- Page shell (header, theme toggle): `apps/docs/src/layouts/main/`
+- Style Dictionary build config: `packages/hpe-design-tokens/src/scripts/build-style-dictionary.js`
+- Custom SD formats/transforms: `packages/hpe-design-tokens/src/formats/` and `src/transforms/`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,4 +104,3 @@ remove-unused-icons
 - Page shell (header, theme toggle): `apps/docs/src/layouts/main/`
 - Style Dictionary build config: `packages/hpe-design-tokens/src/scripts/build-style-dictionary.js`
 - Custom SD formats/transforms: `packages/hpe-design-tokens/src/formats/` and `packages/hpe-design-tokens/src/transforms/`
-- Custom SD formats/transforms: `packages/hpe-design-tokens/src/formats/` and `src/transforms/`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


#### What does this PR do?

This pull request adds detailed Copilot instructions for the HPE Design System monorepo. The new `.github/copilot-instructions.md` file provides comprehensive documentation on the project structure, development workflows, design token architecture, UI conventions, and pull request guidelines, making it easier for contributors and Copilot to understand and work within the repo.

Documentation additions:

* Added `.github/copilot-instructions.md` with an overview of the monorepo structure, listing key workspace roots and packages.
* Documented essential development commands, including workspace builds, Storybook launches, and test execution.
* Provided step-by-step instructions for adding component pages to the docs site, including file locations and required patterns.

Design token and UI conventions:

* Explained the design token architecture, build process, and Figma sync commands, covering token layers and variant handling.
* Outlined UI framework conventions, theming, icon usage, and static export configuration for the docs site.

Pull request and versioning guidelines:

* Clarified branch naming, PR title/description formatting, and linking issues in PRs.
* Detailed versioning and publishing processes using Changesets and workspace catalogs.

Key file locations:

* Listed important

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
