### PR TITLE
DS storybook - Remove controls panel from patterns stories

### DIFF
--- a/shared/aries-core/src/stories/codeBlocks.stories.js
+++ b/shared/aries-core/src/stories/codeBlocks.stories.js
@@ -8,6 +8,7 @@ const meta = {
   component: CodeBlockExample,
   parameters: {
     layout: 'centered',
+    controls: { disable: true },
   },
 };
 

--- a/shared/aries-core/src/stories/dashboards.stories.js
+++ b/shared/aries-core/src/stories/dashboards.stories.js
@@ -9,6 +9,7 @@ const meta = {
   title: 'Patterns/Dashboards',
   parameters: {
     layout: 'fullscreen',
+    controls: { disable: true },
   },
 };
 

--- a/shared/aries-core/src/stories/dataTableCustomization.stories.js
+++ b/shared/aries-core/src/stories/dataTableCustomization.stories.js
@@ -8,6 +8,7 @@ const meta = {
   title: 'Patterns/DataTable Customization',
   parameters: {
     layout: 'centered',
+    controls: { disable: true },
   },
 };
 

--- a/shared/aries-core/src/stories/emptyState.stories.js
+++ b/shared/aries-core/src/stories/emptyState.stories.js
@@ -10,6 +10,9 @@ import { PageEmptyState } from 'apps/docs/src/examples/templates/empty-state/Pag
 
 const meta = {
   title: 'Patterns/Empty State',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/filtering.stories.js
+++ b/shared/aries-core/src/stories/filtering.stories.js
@@ -8,6 +8,9 @@ import { QuickFilterToolbar } from 'apps/docs/src/examples/templates/filtering/Q
 
 const meta = {
   title: 'Patterns/Filtering',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/forms.stories.js
+++ b/shared/aries-core/src/stories/forms.stories.js
@@ -16,6 +16,9 @@ import { ChangePasswordExample } from 'apps/docs/src/examples/templates/forms/Ch
 
 const meta = {
   title: 'Patterns/Forms',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/globalNotifications.stories.js
+++ b/shared/aries-core/src/stories/globalNotifications.stories.js
@@ -10,6 +10,9 @@ import { BannerNotificationWarningClose } from 'apps/docs/src/examples/templates
 
 const meta = {
   title: 'Patterns/Global Notifications',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/inlineNotifications.stories.js
+++ b/shared/aries-core/src/stories/inlineNotifications.stories.js
@@ -9,6 +9,9 @@ import { StatusUpdateExample } from 'apps/docs/src/examples/templates/inline-not
 
 const meta = {
   title: 'Patterns/Inline Notifications',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/lists.stories.js
+++ b/shared/aries-core/src/stories/lists.stories.js
@@ -11,6 +11,9 @@ import { ListScreenExample } from 'apps/docs/src/examples/templates/list-views/L
 
 const meta = {
   title: 'Patterns/Lists',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/managingChildObjects.stories.js
+++ b/shared/aries-core/src/stories/managingChildObjects.stories.js
@@ -7,6 +7,9 @@ import { EditRole } from 'apps/docs/src/examples/templates/forms/managing-child-
 
 const meta = {
   title: 'Patterns/Managing Child Objects',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/popover.stories.js
+++ b/shared/aries-core/src/stories/popover.stories.js
@@ -6,6 +6,9 @@ import { PopoverSimpleExample } from 'apps/docs/src/examples/templates/popover/P
 
 const meta = {
   title: 'Patterns/Popover',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/selector.stories.js
+++ b/shared/aries-core/src/stories/selector.stories.js
@@ -7,6 +7,9 @@ import { SupportSelector } from 'apps/docs/src/examples/templates/selector/Suppo
 
 const meta = {
   title: 'Patterns/Selector',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;

--- a/shared/aries-core/src/stories/wizard.stories.js
+++ b/shared/aries-core/src/stories/wizard.stories.js
@@ -6,6 +6,9 @@ import { WizardValidationExample } from 'apps/docs/src/examples/templates/wizard
 
 const meta = {
   title: 'Patterns/Wizard',
+  parameters: {
+    controls: { disable: true },
+  },
 };
 
 export default meta;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Removes the controls panel from the patterns stories because we don't want to expose controls for these stories

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5867

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
