### PR TITLE
DS - storybook - fix Data accessibility error on story

### DIFF
--- a/shared/aries-core/src/stories/components/data/Data.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/Data.stories.tsx
@@ -72,7 +72,6 @@ const columns: DataTableProps<Datum>['columns'] = [
     render: ({ name }) => (
       <Text
         aria-label={!name ? 'No value' : undefined}
-        as="span"
         role={!name ? 'text' : undefined}
       >
         {name || '--'}
@@ -85,7 +84,6 @@ const columns: DataTableProps<Datum>['columns'] = [
     render: ({ location }) => (
       <Text
         aria-label={!location ? 'No value' : undefined}
-        as="span"
         role={!location ? 'text' : undefined}
       >
         {location || '--'}
@@ -101,7 +99,6 @@ const columns: DataTableProps<Datum>['columns'] = [
       return (
         <Text
           aria-label={!value ? 'No value' : undefined}
-          as="span"
           role={!value ? 'text' : undefined}
           truncate
         >


### PR DESCRIPTION
This pull request improves the accessibility of the `DataTable` component stories by refining how missing or empty values are rendered in table cells. The main changes involve updating the `Text` component props to provide better semantic meaning and assistive technology support.

Accessibility improvements in table cell rendering:

* Updated the `Text` components in the `name`, `location`, and `date` column renderers to use `as="span"` for correct semantic markup and set `role="text"` when displaying placeholder values, improving screen reader support. [[1]](diffhunk://#diff-9ac82867e24ff23b159830470f729a1670cf68ecc4ded831d92697664fcfc555L73-R77) [[2]](diffhunk://#diff-9ac82867e24ff23b159830470f729a1670cf68ecc4ded831d92697664fcfc555L82-R90) [[3]](diffhunk://#diff-9ac82867e24ff23b159830470f729a1670cf68ecc4ded831d92697664fcfc555L94-R107)
* Ensured that the fallback value `'--'` for missing data is wrapped in a `Text` component with `aria-label="No value"`, `as="span"`, and `role="text"` for consistent accessibility.<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

#### What are the relevant issues?
related to https://github.com/grommet/hpe-design-system/issues/5864
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
