### PR TITLE
DS Storybook - fix shipping forms example accessibility error

### DIFF
--- a/apps/docs/src/examples/templates/forms/Shipping/ShippingInfomation.js
+++ b/apps/docs/src/examples/templates/forms/Shipping/ShippingInfomation.js
@@ -63,7 +63,7 @@ export const ShippingInfomation = ({ name }) => (
       name="zipcode"
       label="ZIP code"
     >
-      <TextInput id={`state-shipping-${name}`} name="zipcode" />
+      <TextInput id={`zipcode-${name}`} name="zipcode" />
     </FormField>
     <FormField
       contentProps={{ width: 'medium' }}


### PR DESCRIPTION
This pull request makes a minor fix to the `ShippingInfomation` form component. The change corrects the `id` attribute for the ZIP code input field to ensure it matches the field's purpose.

- Changed the `TextInput` id from `state-shipping-${name}` to `zipcode-${name}` in `ShippingInfomation.js` to correctly reflect the input's purpose.<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

#### What are the relevant issues?
related to https://github.com/grommet/hpe-design-system/issues/5864
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
