### PR TITLE
DS Storybook - sort stories alphabetically

### DIFF
--- a/shared/aries-core/.storybook/preview.mjs
+++ b/shared/aries-core/.storybook/preview.mjs
@@ -40,6 +40,7 @@ export default {
     },
     options: {
       storySort: {
+        method: 'alphabetical',
         order: [
           'Welcome',
           'Components',


### PR DESCRIPTION
#### What does this PR do?
Fix order of stories, previously the data stories were at the bottom of the components section of stories. This PR sorts the stories alphabetically within their folders.

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5867

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
