### PR TITLE
DS storybook - fix accessibility error on filter stories

### DIFF
--- a/apps/docs/src/examples/templates/filtering/FilteringTable/FilterServers.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringTable/FilterServers.js
@@ -58,7 +58,10 @@ const columns = [
     property: 'hardware.model',
     header: 'Model',
     render: datum => (
-      <Text a11yTitle={!datum.hardware.model ? 'No value' : undefined}>
+      <Text
+        aria-label={!datum.hardware.model ? 'No value' : undefined}
+        role={!datum.hardware.model ? 'text' : undefined}
+      >
         {datum.hardware.model || '--'}
       </Text>
     ),

--- a/apps/docs/src/examples/templates/filtering/QuickFilterToolbar.js
+++ b/apps/docs/src/examples/templates/filtering/QuickFilterToolbar.js
@@ -56,7 +56,7 @@ export const QuickFilterToolbar = () => (
   <Page>
     <PageContent>
       <ContentPane>
-        <Heading level={2} margin="none">
+        <Heading id="storage-heading" level={2} margin="none">
           Storage
         </Heading>
         <Data data={applications} properties={properties}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-5894--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/patterns-filtering--quick-filter)

#### What does this PR do?
Fixes the accessibility issues on the stories in filter:
- QuickFilterToolbar was missing `id` for the Heading
- FilterServers had an error with the empty fields 
#### What are the relevant issues?
related to https://github.com/grommet/hpe-design-system/issues/5864
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
