### PR TITLE
DS Storybook - fix accessibility error on selector story

### DIFF
--- a/apps/docs/src/examples/templates/selector/QuickFilter.js
+++ b/apps/docs/src/examples/templates/selector/QuickFilter.js
@@ -339,6 +339,7 @@ export const QuickFilter = () => {
                 <DataTable
                   alignSelf="start"
                   columns={columns}
+                  placeholder={result.data.length === 0 ? 'No data' : undefined}
                   verticalAlign={{ body: 'top' }}
                 />
               </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-5925--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/patterns-selector--quick-filter)

#### What does this PR do?
fixes the error on the selector story

<img width="570" height="416" alt="Screenshot 2026-03-17 at 1 44 01 PM" src="https://github.com/user-attachments/assets/1bbedf03-e88d-4083-b898-524361f3cf4e" />


#### What are the relevant issues?
related to https://github.com/grommet/hpe-design-system/issues/5864
#### Where should the reviewer start?
quick filters
#### How should this be manually tested?
run storybook
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
