### PR TITLE
[DS Storybook] - Bugfix, background parameter for card stories

### DIFF
--- a/shared/aries-core/src/stories/filtering.stories.js
+++ b/shared/aries-core/src/stories/filtering.stories.js
@@ -17,6 +17,9 @@ export default meta;
 
 export const FilterCards = {
   render: () => <FilteringCards />,
+  parameters: {
+    background: 'background-back',
+  },
 };
 
 export const FilterTable = {

--- a/shared/aries-core/src/stories/globalNotifications.stories.js
+++ b/shared/aries-core/src/stories/globalNotifications.stories.js
@@ -19,6 +19,10 @@ export default meta;
 
 export const ContentLayout = {
   render: () => <BannerContentLayoutExample />,
+  parameters: {
+    layout: 'fullscreen',
+    background: 'background-back',
+  },
 };
 
 export const Critical = {

--- a/shared/aries-core/src/stories/inlineNotifications.stories.js
+++ b/shared/aries-core/src/stories/inlineNotifications.stories.js
@@ -30,10 +30,18 @@ export const InlineNotification = {
 
 export const PageBanner = {
   render: () => <PageBannerExample />,
+  parameters: {
+    layout: 'fullscreen',
+    background: 'background-back',
+  },
 };
 
 export const Promotion = {
   render: () => <PromotionExample />,
+  parameters: {
+    layout: 'fullscreen',
+    background: 'background-back',
+  },
 };
 
 export const StatusUpdate = {


### PR DESCRIPTION
[Deploy Preview](https://deploy-preview-5937--unrivaled-bublanina-3a9bae.netlify.app/?path=/story/patterns-filtering--filter-cards)

#### What does this PR do?
fix: add layout and background parameters for stories that use card layouts to create visual separation

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/5923

#### Where should the reviewer start?
N/A

#### How should this be manually tested?
In the deploy preview, take a look at these sections under "Patterns"
- Filtering -> Filter Cards
- Global Notifications -> Content Layout
- Inline Notifications -> Page Banner
- Inline Notifications -> Promotion

Verify that these are the only sections that need updating.

#### Any background context you want to provide?
N/A

#### Screenshots (if appropriate)
N/A

#### Should this PR be mentioned in Design System updates?
N/A

#### Is this change backwards compatible or is it a breaking change?
N/A
