### PR TITLE
layer content to button

### DIFF
--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -69,9 +69,9 @@ Using the design system Button Component will ensure your button looks like a bu
 
 #### Action label conventions
 
-If a layer contains footer actions, the primary action should be labeled using verb + noun format (e.g., "Apply filters").
+In a set of actions, the primary button should be labeled using the verb + noun format (e.g., "Apply filters").
 
-The noun may be omitted from actions labels beyond the primary action if the action is clear and unambiguous (e.g. "Reset" instead of "Reset filters").
+The noun may be omitted from labels beyond the primary button if the action is clear and unambiguous (e.g. "Reset" instead of "Reset filters").
 
 When in doubt, follow the verb + noun convention to ensure clarity.
 

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -20,6 +20,7 @@ import {
   ButtonRightAlignExample,
   ButtonStatesExample,
   ButtonSizingExample,
+  ActionLabels,
   DefaultButtonExample,
   PrimaryButtonExample,
   SecondaryButtonExample,
@@ -65,6 +66,38 @@ Using the design system Button Component will ensure your button looks like a bu
 | **Add**    | "Add" is used when an object already exists. It builds an association between that object and another object or set of objects.                                                                           | When editing a device group, use "Add device" to add an existing device to the group.                                               |
 | **New**    | "New" opens a template, or blank canvas, of a given object type to allow for user input. The object will not be added as a record in a database until a "Create" or submission action has been completed. | When starting the configuration process for a new device, use "New device" to initiate the process.                                 |
 | **Create** | "Create" is typically used for form submission, to submit user input and create an instance of an object.                                                                                                 | After completing inputs related to configuring a new device, use "Create device" to submit the data and create the object instance. |
+
+#### Action label conventions
+
+If a layer contains footer actions, the primary action should be labeled using verb + noun format (e.g., "Apply filters").
+
+The noun may be omitted from actions labels beyond the primary action if the action is clear and unambiguous (e.g. "Reset" instead of "Reset filters").
+
+When in doubt, follow the verb + noun convention to ensure clarity.
+
+<BestPracticeGroup>
+  <Example
+    height={{ min: 'xsmall' }}
+    bestPractice={{
+      type: 'do',
+      message:
+        'When secondary actions are clear and unambiguous, you can omit the noun. In this case, "filters" is not repeated for the reset action.',
+    }}
+    width="100%"
+  >
+    <ActionLabels />
+  </Example>
+  <Example
+    height={{ min: 'xsmall' }}
+    bestPractice={{
+      type: 'dont',
+      message: `Don't remove the noun from the primary action as this can cause ambiguity about what the actions refer to.`,
+    }}
+    width="100%"
+  >
+    <ActionLabels bestPractice={false} />
+  </Example>
+</BestPracticeGroup>
 
 ### Button alignment
 

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -81,7 +81,7 @@ When in doubt, follow the verb + noun convention to ensure clarity.
     bestPractice={{
       type: 'do',
       message:
-        'When secondary actions are clear and unambiguous, you can omit the noun. In this case, "filters" is not repeated for the reset action.',
+        'Use the full verb–noun phrase for the primary action, and omit the noun for subsequent actions.',
     }}
     width="100%"
   >
@@ -91,7 +91,7 @@ When in doubt, follow the verb + noun convention to ensure clarity.
     height={{ min: 'xsmall' }}
     bestPractice={{
       type: 'dont',
-      message: `Don't remove the noun from the primary action as this can cause ambiguity about what the actions refer to.`,
+      message: `Don't omit the noun from the primary action as this can cause ambiguity about what the actions refer to.`,
     }}
     width="100%"
   >

--- a/apps/docs/src/pages/components/layer.mdx
+++ b/apps/docs/src/pages/components/layer.mdx
@@ -6,7 +6,6 @@ import {
   StyleTable,
 } from '../../layouts';
 import {
-  ActionLabels,
   ActionLabelTitle,
   CenterInformational,
   ContentDrivenLayout,
@@ -228,43 +227,6 @@ confirmation—a secondary dialog that asks the user to confirm they want to dis
 | Layer contains unsaved changes                        | Close icon, Cancel button, Esc key, Save                 | <Checkmark a11yTitle="true" size="small" /> |
 | Layer includes a critical or irreversible action      | Close icon, Cancel button, Esc key                       | <Checkmark a11yTitle="true" size="small" /> |
 | Primary action is successfully completed (e.g., Save) | Automatically close or close via Save                    | Optional            |
-
-
-{/*
-MOVE THIS TO BUTTON PAGE
-
-## Action label conventions
-
-If a layer contains footer actions, the primary action should be labeled using verb + noun format (e.g., "Apply filters").
-
-The noun may be omitted from actions labels beyond the primary action if the action is clear and unambiguous (e.g. "Reset" instead of "Reset filters").
-
-When in doubt, follow the verb + noun convention to ensure clarity. See [button labeling guidance](/components/button#button-labeling) for more details.
-
-<BestPracticeGroup>
-  <Example
-    height={{ min: 'xsmall' }}
-    bestPractice={{
-      type: 'do',
-      message:
-        'When secondary actions are clear and unambiguous, you can omit the noun. In this case, "filters" is not repeated for the reset action.',
-    }}
-    width="100%"
-  >
-    <ActionLabels />
-  </Example>
-  <Example
-    height={{ min: 'xsmall' }}
-    bestPractice={{
-      type: 'dont',
-      message: `Don’t remove the noun from the primary action as this can cause ambiguity about what the actions refer to.`,
-    }}
-    width="100%"
-  >
-    <ActionLabels bestPractice={false} />
-  </Example>
-</BestPracticeGroup>
-*/}
 
 ## Accessibility
 


### PR DESCRIPTION
moving action label conventions to button page

<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6089--keen-mayer-a86c8b.netlify.app/components/button?q=butt#button-labeling)

#### What does this PR do?
Moves layer's section Action label convention to button page.
Review the content to be less layer-centric and fit into the button context.

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/5801
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
