### PR TITLE
[Monorepo] Create knowledge store - repo refactor pr6

### DIFF
--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -11,9 +11,24 @@ This directory is the AI-first knowledge system for the HPE Design System.
 
 ## Capability Index
 
-- `docs-refactor` (status: planned)
+- `docs-refactor` (status: active)
   - Entry point: `@docs-refactor-orchestrator <component-name>`
   - Manifest: `knowledge/capabilities/docs-refactor/manifest.yaml`
+- `component-creation` (status: planned)
+  - Entry point: `@component-creation-orchestrator <component-name>`
+  - Manifest: `knowledge/capabilities/component-creation/manifest.yaml`
+- `pattern-creation` (status: planned)
+  - Entry point: `@pattern-creation-orchestrator <pattern-name>`
+  - Manifest: `knowledge/capabilities/pattern-creation/manifest.yaml`
+- `design-tokens-publishing` (status: planned)
+  - Entry point: `@design-tokens-publishing-orchestrator <token-scope>`
+  - Manifest: `knowledge/capabilities/design-tokens-publishing/manifest.yaml`
+- `package-release` (status: planned)
+  - Entry point: `@package-release-orchestrator <package-name>`
+  - Manifest: `knowledge/capabilities/package-release/manifest.yaml`
+- `alignment-audit` (status: planned)
+  - Entry point: `@alignment-audit-orchestrator <scope>`
+  - Manifest: `knowledge/capabilities/alignment-audit/manifest.yaml`
 
 ## Validation
 

--- a/knowledge/capabilities/alignment-audit/README.md
+++ b/knowledge/capabilities/alignment-audit/README.md
@@ -1,0 +1,15 @@
+# alignment-audit
+
+Status: planned
+
+## Purpose
+
+Audit component and documentation alignment against standards, schemas, and repository policy.
+
+## Entry Point
+
+- `@alignment-audit-orchestrator <scope>`
+
+## Manifest
+
+- `knowledge/capabilities/alignment-audit/manifest.yaml`

--- a/knowledge/capabilities/alignment-audit/alignment-audit-orchestrator.agent.md
+++ b/knowledge/capabilities/alignment-audit/alignment-audit-orchestrator.agent.md
@@ -2,7 +2,7 @@
 name: alignment-audit-orchestrator
 description: 'Planned capability stub. Entry point for alignment audit workflow orchestration.'
 argument-hint: 'Audit scope (for example: docs, tokens, components).'
-tools: [read, search]
+tools: [read, agent, search]
 ---
 
 This is a planned capability stub.

--- a/knowledge/capabilities/alignment-audit/alignment-audit-orchestrator.agent.md
+++ b/knowledge/capabilities/alignment-audit/alignment-audit-orchestrator.agent.md
@@ -1,0 +1,16 @@
+---
+name: alignment-audit-orchestrator
+description: 'Planned capability stub. Entry point for alignment audit workflow orchestration.'
+argument-hint: 'Audit scope (for example: docs, tokens, components).'
+tools: [read, search]
+---
+
+This is a planned capability stub.
+
+When implemented, this orchestrator should:
+
+1. Detect current audit stage.
+2. Delegate to capability-specific agents.
+3. Enforce validation and reporting gates before completion.
+
+Current behavior: report that the capability is planned and not yet implemented.

--- a/knowledge/capabilities/alignment-audit/manifest.yaml
+++ b/knowledge/capabilities/alignment-audit/manifest.yaml
@@ -1,0 +1,15 @@
+apiVersion: knowledge.hpe.com/v1
+kind: CapabilityManifest
+metadata:
+  name: alignment-audit
+  version: 1.0.0
+  status: planned
+  owner: design-system
+spec:
+  summary: Audit component and documentation alignment against standards, schemas, and repository policy.
+  entrypoint:
+    agent: alignment-audit-orchestrator
+    args: "<scope>"
+  assets:
+    agents:
+      - alignment-audit-orchestrator.agent.md

--- a/knowledge/capabilities/alignment-audit/manifest.yaml
+++ b/knowledge/capabilities/alignment-audit/manifest.yaml
@@ -11,5 +11,4 @@ spec:
     agent: alignment-audit-orchestrator
     args: "<scope>"
   assets:
-    agents:
-      - alignment-audit-orchestrator.agent.md
+    agents: []

--- a/knowledge/capabilities/alignment-audit/manifest.yaml
+++ b/knowledge/capabilities/alignment-audit/manifest.yaml
@@ -11,4 +11,5 @@ spec:
     agent: alignment-audit-orchestrator
     args: "<scope>"
   assets:
-    agents: []
+    agents:
+      - alignment-audit-orchestrator.agent.md

--- a/knowledge/capabilities/component-creation/README.md
+++ b/knowledge/capabilities/component-creation/README.md
@@ -1,0 +1,15 @@
+# component-creation
+
+Status: planned
+
+## Purpose
+
+Plan and implement a new component from proposal through initial docs and examples.
+
+## Entry Point
+
+- `@component-creation-orchestrator <component-name>`
+
+## Manifest
+
+- `knowledge/capabilities/component-creation/manifest.yaml`

--- a/knowledge/capabilities/component-creation/component-creation-orchestrator.agent.md
+++ b/knowledge/capabilities/component-creation/component-creation-orchestrator.agent.md
@@ -2,7 +2,7 @@
 name: component-creation-orchestrator
 description: 'Planned capability stub. Entry point for component creation workflow orchestration.'
 argument-hint: 'Component name (for example: segmented-control, tree-view).'
-tools: [read, search]
+tools: [read, agent, search]
 ---
 
 This is a planned capability stub.

--- a/knowledge/capabilities/component-creation/component-creation-orchestrator.agent.md
+++ b/knowledge/capabilities/component-creation/component-creation-orchestrator.agent.md
@@ -1,0 +1,16 @@
+---
+name: component-creation-orchestrator
+description: 'Planned capability stub. Entry point for component creation workflow orchestration.'
+argument-hint: 'Component name (for example: segmented-control, tree-view).'
+tools: [read, search]
+---
+
+This is a planned capability stub.
+
+When implemented, this orchestrator should:
+
+1. Detect current component work stage.
+2. Delegate to capability-specific agents.
+3. Enforce validation and review gates before completion.
+
+Current behavior: report that the capability is planned and not yet implemented.

--- a/knowledge/capabilities/component-creation/manifest.yaml
+++ b/knowledge/capabilities/component-creation/manifest.yaml
@@ -1,0 +1,15 @@
+apiVersion: knowledge.hpe.com/v1
+kind: CapabilityManifest
+metadata:
+  name: component-creation
+  version: 1.0.0
+  status: planned
+  owner: design-system
+spec:
+  summary: Plan and implement a new component from proposal to initial documentation and examples.
+  entrypoint:
+    agent: component-creation-orchestrator
+    args: "<component-name>"
+  assets:
+    agents:
+      - component-creation-orchestrator.agent.md

--- a/knowledge/capabilities/design-tokens-publishing/README.md
+++ b/knowledge/capabilities/design-tokens-publishing/README.md
@@ -1,0 +1,15 @@
+# design-tokens-publishing
+
+Status: planned
+
+## Purpose
+
+Coordinate token updates from source changes through package generation and release checks.
+
+## Entry Point
+
+- `@design-tokens-publishing-orchestrator <token-scope>`
+
+## Manifest
+
+- `knowledge/capabilities/design-tokens-publishing/manifest.yaml`

--- a/knowledge/capabilities/design-tokens-publishing/design-tokens-publishing-orchestrator.agent.md
+++ b/knowledge/capabilities/design-tokens-publishing/design-tokens-publishing-orchestrator.agent.md
@@ -2,7 +2,7 @@
 name: design-tokens-publishing-orchestrator
 description: 'Planned capability stub. Entry point for design tokens publishing workflow orchestration.'
 argument-hint: 'Token scope (for example: color, spacing, typography).'
-tools: [read, search]
+tools: [read, agent, search]
 ---
 
 This is a planned capability stub.

--- a/knowledge/capabilities/design-tokens-publishing/design-tokens-publishing-orchestrator.agent.md
+++ b/knowledge/capabilities/design-tokens-publishing/design-tokens-publishing-orchestrator.agent.md
@@ -1,0 +1,16 @@
+---
+name: design-tokens-publishing-orchestrator
+description: 'Planned capability stub. Entry point for design tokens publishing workflow orchestration.'
+argument-hint: 'Token scope (for example: color, spacing, typography).'
+tools: [read, search]
+---
+
+This is a planned capability stub.
+
+When implemented, this orchestrator should:
+
+1. Detect current publishing stage.
+2. Delegate to capability-specific agents.
+3. Enforce validation and release gates before completion.
+
+Current behavior: report that the capability is planned and not yet implemented.

--- a/knowledge/capabilities/design-tokens-publishing/manifest.yaml
+++ b/knowledge/capabilities/design-tokens-publishing/manifest.yaml
@@ -1,0 +1,15 @@
+apiVersion: knowledge.hpe.com/v1
+kind: CapabilityManifest
+metadata:
+  name: design-tokens-publishing
+  version: 1.0.0
+  status: planned
+  owner: design-system
+spec:
+  summary: Coordinate token updates from source changes through package generation and release checks.
+  entrypoint:
+    agent: design-tokens-publishing-orchestrator
+    args: "<token-scope>"
+  assets:
+    agents:
+      - design-tokens-publishing-orchestrator.agent.md

--- a/knowledge/capabilities/package-release/README.md
+++ b/knowledge/capabilities/package-release/README.md
@@ -1,0 +1,15 @@
+# package-release
+
+Status: planned
+
+## Purpose
+
+Prepare, validate, and publish design-system packages with changelog and release safeguards.
+
+## Entry Point
+
+- `@package-release-orchestrator <package-name>`
+
+## Manifest
+
+- `knowledge/capabilities/package-release/manifest.yaml`

--- a/knowledge/capabilities/package-release/manifest.yaml
+++ b/knowledge/capabilities/package-release/manifest.yaml
@@ -1,0 +1,15 @@
+apiVersion: knowledge.hpe.com/v1
+kind: CapabilityManifest
+metadata:
+  name: package-release
+  version: 1.0.0
+  status: planned
+  owner: design-system
+spec:
+  summary: Prepare, validate, and publish design-system packages with changelog and release safeguards.
+  entrypoint:
+    agent: package-release-orchestrator
+    args: "<package-name>"
+  assets:
+    agents:
+      - package-release-orchestrator.agent.md

--- a/knowledge/capabilities/package-release/package-release-orchestrator.agent.md
+++ b/knowledge/capabilities/package-release/package-release-orchestrator.agent.md
@@ -1,0 +1,16 @@
+---
+name: package-release-orchestrator
+description: 'Planned capability stub. Entry point for package release workflow orchestration.'
+argument-hint: 'Package name (for example: hpe-design-tokens).'
+tools: [read, search]
+---
+
+This is a planned capability stub.
+
+When implemented, this orchestrator should:
+
+1. Detect current release stage.
+2. Delegate to capability-specific agents.
+3. Enforce validation and release gates before completion.
+
+Current behavior: report that the capability is planned and not yet implemented.

--- a/knowledge/capabilities/package-release/package-release-orchestrator.agent.md
+++ b/knowledge/capabilities/package-release/package-release-orchestrator.agent.md
@@ -2,7 +2,7 @@
 name: package-release-orchestrator
 description: 'Planned capability stub. Entry point for package release workflow orchestration.'
 argument-hint: 'Package name (for example: hpe-design-tokens).'
-tools: [read, search]
+tools: [read, agent, search]
 ---
 
 This is a planned capability stub.

--- a/knowledge/capabilities/pattern-creation/README.md
+++ b/knowledge/capabilities/pattern-creation/README.md
@@ -1,0 +1,15 @@
+# pattern-creation
+
+Status: planned
+
+## Purpose
+
+Define and publish a reusable UI pattern with guidance, structure, and validation checks.
+
+## Entry Point
+
+- `@pattern-creation-orchestrator <pattern-name>`
+
+## Manifest
+
+- `knowledge/capabilities/pattern-creation/manifest.yaml`

--- a/knowledge/capabilities/pattern-creation/manifest.yaml
+++ b/knowledge/capabilities/pattern-creation/manifest.yaml
@@ -1,0 +1,15 @@
+apiVersion: knowledge.hpe.com/v1
+kind: CapabilityManifest
+metadata:
+  name: pattern-creation
+  version: 1.0.0
+  status: planned
+  owner: design-system
+spec:
+  summary: Define and publish a reusable UI pattern with guidance, structure, and validation checks.
+  entrypoint:
+    agent: pattern-creation-orchestrator
+    args: "<pattern-name>"
+  assets:
+    agents:
+      - pattern-creation-orchestrator.agent.md

--- a/knowledge/capabilities/pattern-creation/pattern-creation-orchestrator.agent.md
+++ b/knowledge/capabilities/pattern-creation/pattern-creation-orchestrator.agent.md
@@ -1,0 +1,16 @@
+---
+name: pattern-creation-orchestrator
+description: 'Planned capability stub. Entry point for pattern creation workflow orchestration.'
+argument-hint: 'Pattern name (for example: dashboard-layout, filter-panel).'
+tools: [read, search]
+---
+
+This is a planned capability stub.
+
+When implemented, this orchestrator should:
+
+1. Detect current pattern work stage.
+2. Delegate to capability-specific agents.
+3. Enforce validation and review gates before completion.
+
+Current behavior: report that the capability is planned and not yet implemented.

--- a/knowledge/capabilities/pattern-creation/pattern-creation-orchestrator.agent.md
+++ b/knowledge/capabilities/pattern-creation/pattern-creation-orchestrator.agent.md
@@ -2,7 +2,7 @@
 name: pattern-creation-orchestrator
 description: 'Planned capability stub. Entry point for pattern creation workflow orchestration.'
 argument-hint: 'Pattern name (for example: dashboard-layout, filter-panel).'
-tools: [read, search]
+tools: [read, agent, search]
 ---
 
 This is a planned capability stub.


### PR DESCRIPTION


#### What does this PR do?

builds on https://github.com/grommet/hpe-design-system/pull/6148

This pull request expands the capability index for the HPE Design System knowledge base by introducing several new planned capabilities. For each new capability, it adds a manifest and a README file that describes its purpose, entry point, and associated assets. Additionally, it updates the status of the existing `docs-refactor` capability from "planned" to "active".

New capabilities and documentation:

**Capability Index and Status Updates**
- Updated `knowledge/README.md` to set `docs-refactor` status to "active" and add entries for five new planned capabilities: `component-creation`, `pattern-creation`, `design-tokens-publishing`, `package-release`, and `alignment-audit`.

**New Capability: Component Creation**
- Added `component-creation` capability with a manifest (`manifest.yaml`) and README describing its purpose (planning and implementing new components), entry point, and assets. [[1]](diffhunk://#diff-37c7b8e0b3b5b2e8d916010aa8c13d055aacbb2db8de2f29d92a0f12221f67dcR1-R15) [[2]](diffhunk://#diff-28bd94897e2e95b861a44f4eee3b84a20144a73e12e94b0b8d707db8fbcd95d1R1-R15)

**New Capability: Pattern Creation**
- Added `pattern-creation` capability with a manifest and README detailing its use for defining and publishing reusable UI patterns. [[1]](diffhunk://#diff-00e9d27692d3da4d5c5cb7e9668033f20a7b19f394915f969238874b878c3cedR1-R15) [[2]](diffhunk://#diff-c07b6819e9e67fe600e0246a65cbb39b465f98e1b4e66534dae387a9d316610eR1-R15)

**New Capability: Design Tokens Publishing**
- Added `design-tokens-publishing` capability with a manifest and README for coordinating design token updates and package releases. [[1]](diffhunk://#diff-b424e1b0e6d8c54ed88fa396b96f9ea4bd5013a6b7353e8b0ad0c32e03a13ec5R1-R15) [[2]](diffhunk://#diff-b47df02297ff31e443f0f8c4804b158dc1eeb141c361deb796ef2b8a54662434R1-R15)

**New Capability: Package Release**
- Added `package-release` capability, including its manifest and README, to manage package validation and publishing. [[1]](diffhunk://#diff-6de8909d5c6b3260a40561798084435f9a5a9ac44d2764a4043167516b0d7134R1-R15) [[2]](diffhunk://#diff-37a3bb4be253163a8d22f62c799a6427cceac20e889f2d61e512e4098de97743R1-R15)

**New Capability: Alignment Audit**
- Added `alignment-audit` capability with manifest and README to audit component and documentation alignment against standards and policies. [[1]](diffhunk://#diff-0b65c6255e2886c35b2079990aeeca18f8f38762d8f4c6b10c711a346f6c4340R1-R15) [[2]](diffhunk://#diff-bf67f4aa81fb56b8e33032ad39bab7598b8fd626b020de34124ba4415975946dR1-R15)

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/6149
