### PR TITLE
undo workaround for prior bug

### DIFF
--- a/apps/docs/src/examples/tokens/SpecialtyBackgrounds.js
+++ b/apps/docs/src/examples/tokens/SpecialtyBackgrounds.js
@@ -6,17 +6,17 @@ export const SpecialtyBackgrounds = () => {
   return (
     <Box align="center" gap="xlarge">
       <Box
-        background={{ color: 'background-primary-strong', dark: false }}
+        background={{ color: 'background-primary-strong' }}
         pad="medium"
         round="xlarge"
         gap="medium"
       >
-        <Text color="text-onStrong" size="large" weight={500}>
+        <Text color="text-onPrimaryStrong" size="large" weight={500}>
           color.background.primary.strong
         </Text>
         <Box gap="xsmall">
           <Box direction="row" gap="xsmall">
-            <Text color="text-onStrong" weight={500}>
+            <Text color="text-onPrimaryStrong" weight={500}>
               Aa
             </Text>
             <Text color="text-onPrimaryStrong">color.text.onPrimaryStrong</Text>

--- a/apps/docs/src/pages/foundation/color-pairing.mdx
+++ b/apps/docs/src/pages/foundation/color-pairing.mdx
@@ -87,24 +87,7 @@ Refer to this table below for examples of background colors paired with "on" col
 | <ColorPreview datum={{value: 'background-ok'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onOk">Aa</Text></ColorPreview>                                         | color.background.ok                      | color.text.onWarning, color.text.onWarning.strong                      |
 | <ColorPreview datum={{value: 'background-info'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onInfo">Aa</Text></ColorPreview>                                     | color.background.info                    | color.text.onInfo, color.text.onInfo.strong                            |
 | <ColorPreview datum={{value: 'background-unknown'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onUnknown">Aa</Text></ColorPreview>                               | color.background.unknown                 | color.text.onUnknown, color.text.onUnknown.strong                      |
-| <ColorPreviewWithMode color="background-primary-strong" pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreviewWithMode>             | color.background.primary.strong          | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |
-| <ColorPreviewWithMode color="background-primary-xstrong" pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreviewWithMode>            | color.background.primary.xstrong         | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |        
+| <ColorPreview datum={{value: 'background-primary-strong'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreview>             | color.background.primary.strong          | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |
+| <ColorPreview datum={{value: 'background-primary-xstrong'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreview>            | color.background.primary.xstrong         | color.text.onPrimaryStrong, color.icon.onPrimaryStrong                 |        
 | <ColorPreview datum={{value: 'background-selected-primary'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onSelectedPrimary">Aa</Text></ColorPreview>              | color.background.selected.primary        | color.text.onSelectedPrimary, color.icon.onSelectedPrimary             |
-| <ColorPreviewWithMode color="background-selected-primary-strong" pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreviewWithMode>   | color.background.selected.primary.strong | color.text.onSelectedPrimaryStrong, color.icon.onSelectedPrimaryStrong |
-
-export const ColorPreviewWithMode = ({ color, ...rest }) => {
-  // need to check theme to overridde what grommet does by default
-  // by setting text color based on light/dark mode
-  const theme = useContext(ThemeContext);
-  const mode = theme.dark ? 'dark' : 'light';
-
-  return (
-    <ColorPreview
-      background={{
-        color: color,
-        dark: mode === 'light' ? false : true
-      }}
-      {...rest}
-    />
-  );
-};
+| <ColorPreview datum={{value: 'background-selected-primary-strong'}} pad={{vertical: 'xsmall', horizontal: 'medium'}}><Text size="large" color="text-onPrimaryStrong">Aa</Text></ColorPreview>   | color.background.selected.primary.strong | color.text.onSelectedPrimaryStrong, color.icon.onSelectedPrimaryStrong |


### PR DESCRIPTION
<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6159--keen-mayer-a86c8b.netlify.app/foundation/color-pairing)

#### What does this PR do?
This PR reverts old code that was in placed to do a workaround for the color pairing page.  
The old code was in place prior to this fix
https://github.com/grommet/grommet-theme-hpe/pull/563 
#### What are the relevant issues?
brought up in slack
#### Where should the reviewer start?
color-pairing.mdx
#### How should this be manually tested?
locally run the site 
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible