### PR TITLE
Bump node version in gh actions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,7 +22,7 @@ jobs:
           version: 10
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
           cache: 'pnpm'

--- a/.github/workflows/codemod-test.yml
+++ b/.github/workflows/codemod-test.yml
@@ -13,8 +13,8 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
           cache: 'pnpm'

--- a/.github/workflows/codemod-test.yml
+++ b/.github/workflows/codemod-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '24.15.0'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/docs-unit-tests.yml
+++ b/.github/workflows/docs-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
           version: 10
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
           cache: 'pnpm'
@@ -59,7 +59,7 @@ jobs:
           version: 10
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
           cache: 'pnpm'

--- a/.github/workflows/docs-unit-tests.yml
+++ b/.github/workflows/docs-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/sync-figma-to-tokens.yml
+++ b/.github/workflows/sync-figma-to-tokens.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
 

--- a/.github/workflows/sync-figma-to-tokens.yml
+++ b/.github/workflows/sync-figma-to-tokens.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/sync-tokens-to-figma.yml
+++ b/.github/workflows/sync-tokens-to-figma.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/sync-tokens-to-figma.yml
+++ b/.github/workflows/sync-tokens-to-figma.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
 

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           version: 10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
           cache: 'pnpm'

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
           cache: 'pnpm'
       - name: Install latest dependencies
         run: pnpm install

--- a/.github/workflows/update-design-tokens-stable.yml
+++ b/.github/workflows/update-design-tokens-stable.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
 

--- a/.github/workflows/update-design-tokens-stable.yml
+++ b/.github/workflows/update-design-tokens-stable.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.19.x'
+          node-version: '24.15.0'
 
       - name: Set NPM version
         run: npm install -g npm@9.5.1

--- a/.github/workflows/update-grommet-dependencies.yml
+++ b/.github/workflows/update-grommet-dependencies.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm

--- a/.github/workflows/update-grommet-dependencies.yml
+++ b/.github/workflows/update-grommet-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
#### What does this PR do?
Node 20 is deprecated in gh actions. Bumping our scripts to use node 24 
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
