### PR TITLE
Sticker sheet with hover options

### DIFF
--- a/apps/docs/src/data/structure.tsx
+++ b/apps/docs/src/data/structure.tsx
@@ -145,6 +145,14 @@ const initialStructure = [
   learn,
   templates,
   tokens,
+  // Temporary feedback page — not in navigation, not indexed by search
+  [
+    {
+      name: 'Hover Sticker Sheet',
+      path: '/hover-sticker-sheet',
+      searchable: false,
+    },
+  ],
 ].flat() as StructurePage[];
 
 export const structure = initialStructure;

--- a/apps/docs/src/examples/hover-sticker-sheet/ExampleForm.jsx
+++ b/apps/docs/src/examples/hover-sticker-sheet/ExampleForm.jsx
@@ -1,0 +1,110 @@
+/* eslint-disable */
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  CheckBox,
+  CheckBoxGroup,
+  Form,
+  FormField,
+  Notification,
+  RadioButtonGroup,
+  Select,
+  TextInput,
+} from 'grommet';
+
+const COUNTRY_OPTIONS = [
+  'United States',
+  'United Kingdom',
+  'Canada',
+  'Australia',
+  'Germany',
+  'France',
+  'Japan',
+];
+
+const CONTACT_OPTIONS = [
+  { label: 'Email', value: 'email' },
+  { label: 'Phone', value: 'phone' },
+  { label: 'Text message', value: 'text' },
+];
+
+const NOTIFICATION_OPTIONS = ['Product updates', 'Security alerts', 'Newsletter'];
+
+const DEFAULT_VALUES = {
+  firstName: '',
+  lastName: '',
+  country: '',
+  contact: 'email',
+  notifications: [],
+  twoFactor: false,
+};
+
+export const ExampleForm = () => {
+  const [formValue, setFormValue] = useState(DEFAULT_VALUES);
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <Box width={{ max: 'medium' }}>
+      <Form
+        value={formValue}
+        onChange={nextValue => setFormValue(nextValue)}
+        onSubmit={() => setSubmitted(true)}
+      >
+        <FormField name="firstName" htmlFor="firstName" label="First name" required>
+          <TextInput id="firstName" name="firstName" placeholder="Jane" />
+        </FormField>
+
+        <FormField name="lastName" htmlFor="lastName" label="Last name" required>
+          <TextInput id="lastName" name="lastName" placeholder="Smith" />
+        </FormField>
+
+        <FormField name="country" htmlFor="country" label="Country">
+          <Select
+            id="country"
+            name="country"
+            options={COUNTRY_OPTIONS}
+            placeholder="Select a country..."
+          />
+        </FormField>
+
+        <FormField name="contact" label="Preferred contact method">
+          <RadioButtonGroup name="contact" options={CONTACT_OPTIONS} />
+        </FormField>
+
+        <FormField name="notifications" label="Notifications">
+          <CheckBoxGroup name="notifications" options={NOTIFICATION_OPTIONS} />
+        </FormField>
+
+        <FormField name="twoFactor">
+          <CheckBox
+            name="twoFactor"
+            toggle
+            label="Enable two-factor authentication"
+          />
+        </FormField>
+
+        <Box direction="row" gap="small" margin={{ top: 'medium' }}>
+          <Button type="submit" primary label="Submit" />
+          <Button
+            label="Reset"
+            onClick={() => {
+              setFormValue(DEFAULT_VALUES);
+              setSubmitted(false);
+            }}
+          />
+        </Box>
+      </Form>
+
+      {submitted && (
+        <Notification
+          toast
+          title="Form submitted!"
+          message="Thank you — your response has been recorded."
+          status="normal"
+          onClose={() => setSubmitted(false)}
+        />
+      )}
+    </Box>
+  );
+};

--- a/apps/docs/src/examples/hover-sticker-sheet/InstanceConfigExample.jsx
+++ b/apps/docs/src/examples/hover-sticker-sheet/InstanceConfigExample.jsx
@@ -1,0 +1,292 @@
+/* eslint-disable */
+import React, { useState } from 'react';
+import {
+  Anchor,
+  Box,
+  Button,
+  CheckBox,
+  FormField,
+  Heading,
+  PageHeader,
+  RadioButtonGroup,
+  Select,
+  Tab,
+  Tabs,
+  Text,
+  TextInput,
+  ToggleGroup,
+} from 'grommet';
+
+const CPU_CORE_OPTIONS = [
+  { label: '4 Core', value: '4' },
+  { label: '16 Cores', value: '16' },
+  { label: '32 Cores', value: '32' },
+  { label: '48 Cores', value: '48' },
+  { label: '64 Cores', value: '64' },
+];
+
+const ARCH_OPTIONS = ['x86_64 (Intel/AMD)', 'ARM (Ampere)'];
+
+const MESSAGES = [
+  {
+    role: 'assistant',
+    text: 'Adjusting your CPU configuration, particularly the number of cores, can enhance performance. Would you like assistance with this?',
+  },
+  {
+    role: 'user',
+    text: 'Yes please. Could you recommend the core count and CPU architecture?',
+  },
+  {
+    role: 'assistant',
+    text: 'To suggest the right number of cores and best architecture, could you share more about your workloads? Are these primarily hypervisors (VMware/Hyper-V), container orchestration (Kubernetes), databases, analytics, or HPC? Do you have a budget range and any licensing considerations?',
+  },
+  {
+    role: 'user',
+    text: 'Primary workload is VMware vSphere hosting mixed Linux/Windows VMs, some line-of-business apps, a couple of medium SQL Server instances, and a small Kafka cluster. Prefer 2 sockets for resiliency.',
+  },
+  {
+    role: 'assistant',
+    text: "Got it. For dual-socket hosts running mixed virtualization and moderate DB workloads, I'd suggest:\n\nArchitecture: x86_64 (Intel Xeon or AMD EPYC). EPYC offers strong memory bandwidth and high core density\u2014good for consolidation and Kafka.\n\nCores per socket: Aim for 24\u201332 cores/socket.",
+  },
+];
+
+const NavIcon = ({ active }) => (
+  <Box
+    width="36px"
+    height="36px"
+    round="xsmall"
+    align="center"
+    justify="center"
+    background={active ? 'background-contrast' : undefined}
+  >
+    <Box
+      width="18px"
+      height="18px"
+      round="xxsmall"
+      border={{ color: 'border', side: 'all' }}
+    />
+  </Box>
+);
+
+const LeftNav = () => (
+  <Box
+    width="52px"
+    flex={false}
+    background="background-back"
+    round="small"
+    pad={{ vertical: 'small', horizontal: 'xsmall' }}
+    gap="xsmall"
+    align="center"
+  >
+    <Box
+      width="36px"
+      height="36px"
+      round="xsmall"
+      align="center"
+      justify="center"
+      gap="3px"
+      pad="xsmall"
+    >
+      <Box width="18px" height="2px" background="text-weak" />
+      <Box width="18px" height="2px" background="text-weak" />
+      <Box width="18px" height="2px" background="text-weak" />
+    </Box>
+    <Box
+      width="32px"
+      height="1px"
+      background="border-weak"
+      margin={{ vertical: 'xsmall' }}
+    />
+    <NavIcon />
+    <NavIcon active />
+    <NavIcon />
+    <NavIcon />
+    <NavIcon />
+    <NavIcon />
+    <NavIcon />
+  </Box>
+);
+
+const ChatMessage = ({ role, text }) => (
+  <Box align={role === 'user' ? 'end' : 'start'} pad={{ horizontal: 'small' }}>
+    <Box
+      background={role === 'user' ? 'background-default' : undefined}
+      pad={role === 'user' ? { horizontal: 'small', vertical: 'xsmall' } : undefined}
+      round={role === 'user' ? 'small' : undefined}
+      width={{ max: '88%' }}
+    >
+      <Text size="small">{text}</Text>
+    </Box>
+  </Box>
+);
+
+const CopilotPanel = () => (
+  <Box
+    width="300px"
+    flex={false}
+    background="background-back"
+    round="small"
+    style={{ minHeight: '540px' }}
+  >
+    <Box
+      direction="row"
+      justify="between"
+      align="center"
+      pad={{ horizontal: 'medium', vertical: 'small' }}
+      border={{ color: 'border-weak', side: 'bottom' }}
+      flex={false}
+    >
+      <Text weight="bold" size="small">
+        ✦ GreenLake Copilot
+      </Text>
+      <Button plain label="&times;" />
+    </Box>
+    <Box flex overflow="auto" gap="small" pad={{ vertical: 'small' }}>
+      {MESSAGES.map((msg, i) => (
+        <ChatMessage key={i} role={msg.role} text={msg.text} />
+      ))}
+    </Box>
+    <Box
+      pad={{ horizontal: 'small', vertical: 'xsmall' }}
+      border={{ color: 'border-weak', side: 'top' }}
+      flex={false}
+    >
+      <TextInput plain placeholder="Ask anything about HPE GreenLake..." />
+    </Box>
+  </Box>
+);
+
+export const InstanceConfigExample = () => {
+  const [cores, setCores] = useState('16');
+  const [arch, setArch] = useState('x86_64 (Intel/AMD)');
+  const [perfTier, setPerfTier] = useState('Standard');
+  const [memory, setMemory] = useState('8');
+  const [autoScaling, setAutoScaling] = useState(true);
+  const [activeTab, setActiveTab] = useState(1);
+
+  return (
+    <Box
+      direction="row"
+      border={{ color: 'border', side: 'all' }}
+      round="small"
+      pad="small"
+      gap="small"
+      style={{ minHeight: '600px' }}
+    >
+      <LeftNav />
+
+      {/* Main content */}
+      <Box flex overflow="auto">
+        <Box pad={{ top: 'small', horizontal: 'xsmall' }}>
+          <PageHeader
+            title="Instances"
+            subtitle="Production web server 01"
+            parent={<Anchor label="&#8249; Resources" />}
+            actions={
+              <Box direction="row" gap="xsmall">
+                <Button label="Cancel" />
+                <Button label="Save configuration" primary />
+              </Box>
+            }
+          />
+        </Box>
+
+        <Tabs activeIndex={activeTab} onActive={setActiveTab}>
+          <Tab title="General settings">
+            <Box pad="medium">
+              <Text color="text-weak" size="small">General settings content</Text>
+            </Box>
+          </Tab>
+
+          <Tab title="Compute and RAM">
+            <Box pad="small" gap="small">
+              {/* CPU Configuration */}
+              <Box background="background-back" pad="medium" round="small" gap="small">
+                <Heading level={3} margin="none" size="small">
+                  CPU configuration
+                </Heading>
+                <FormField name="cores" label="Virtual CPUs (vCPUs)">
+                  <RadioButtonGroup
+                    name="cores"
+                    options={CPU_CORE_OPTIONS}
+                    value={cores}
+                    onChange={e => setCores(e.target.value)}
+                  />
+                </FormField>
+                <Box direction="row" gap="medium" wrap align="start">
+                  <Box width={{ min: '200px', max: 'medium' }} flex>
+                    <FormField name="arch" htmlFor="arch" label="CPU Architecture*">
+                      <Select
+                        id="arch"
+                        name="arch"
+                        options={ARCH_OPTIONS}
+                        value={arch}
+                        onChange={({ value }) => setArch(value)}
+                      />
+                    </FormField>
+                  </Box>
+                  <Box gap="xsmall">
+                    <Text size="small" weight="bold">Performance tier</Text>
+                    <ToggleGroup
+                      options={['Standard', 'Premium']}
+                      value={perfTier}
+                      onToggle={({ value }) => setPerfTier(value)}
+                    />
+                  </Box>
+                </Box>
+              </Box>
+
+              {/* Memory */}
+              <Box background="background-back" pad="medium" round="small" gap="small">
+                <Heading level={3} margin="none" size="small">
+                  Memory (RAM)
+                </Heading>
+                <Box width={{ max: 'small' }}>
+                  <FormField
+                    name="memory"
+                    htmlFor="memory"
+                    label="Label"
+                    help="Minimum recommended: 2gb"
+                  >
+                    <TextInput
+                      id="memory"
+                      name="memory"
+                      value={memory}
+                      onChange={e => setMemory(e.target.value)}
+                    />
+                  </FormField>
+                </Box>
+                <FormField>
+                  <CheckBox
+                    toggle
+                    label="Enable auto-scaling"
+                    checked={autoScaling}
+                    onChange={e => setAutoScaling(e.target.checked)}
+                  />
+                </FormField>
+              </Box>
+            </Box>
+          </Tab>
+
+          <Tab title="Storage disks">
+            <Box pad="medium">
+              <Text color="text-weak" size="small">Storage disks content</Text>
+            </Box>
+          </Tab>
+          <Tab title="Networking">
+            <Box pad="medium">
+              <Text color="text-weak" size="small">Networking content</Text>
+            </Box>
+          </Tab>
+          <Tab title="Security policies">
+            <Box pad="medium">
+              <Text color="text-weak" size="small">Security policies content</Text>
+            </Box>
+          </Tab>
+        </Tabs>
+      </Box>
+
+      <CopilotPanel />
+    </Box>
+  );
+};

--- a/apps/docs/src/examples/hover-sticker-sheet/StickerSheet.jsx
+++ b/apps/docs/src/examples/hover-sticker-sheet/StickerSheet.jsx
@@ -1,0 +1,319 @@
+/* eslint-disable */
+import React, { useState } from 'react';
+import {
+  Box,
+  CheckBox,
+  CheckBoxGroup,
+  DateInput,
+  FileInput,
+  FormField,
+  Grid,
+  Heading,
+  RadioButton,
+  RadioButtonGroup,
+  Select,
+  SelectMultiple,
+  Text,
+  TextArea,
+  TextInput,
+} from 'grommet';
+
+// ─── Shared layout helpers ────────────────────────────────────────────────────
+
+const SectionHeading = ({ children }) => (
+  <Heading level={3} margin={{ top: 'none', bottom: 'small' }} size="small">
+    {children}
+  </Heading>
+);
+
+const ItemHeading = ({ children }) => (
+  <Heading level={4} margin={{ top: 'none', bottom: 'xsmall' }} size="xsmall">
+    {children}
+  </Heading>
+);
+
+const ItemCard = ({ title, children }) => (
+  <Box background="background-contrast" round="xsmall" pad="small" gap="xsmall">
+    <ItemHeading>{title}</ItemHeading>
+    {children}
+  </Box>
+);
+
+// Two-column layout for standalone vs in-FormField comparison
+const DualCard = ({ title, standalone, inFormField }) => (
+  <Box background="background-contrast" round="xsmall" pad="small" gap="xsmall">
+    <ItemHeading>{title}</ItemHeading>
+    <Grid columns={['1/2', '1/2']} gap="small">
+      <Box gap="xsmall">
+        <Text size="xsmall" weight="bold" color="text-weak">
+          Control only
+        </Text>
+        {standalone}
+      </Box>
+      <Box gap="xsmall">
+        <Text size="xsmall" weight="bold" color="text-weak">
+          In FormField
+        </Text>
+        {inFormField}
+      </Box>
+    </Grid>
+  </Box>
+);
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export const StickerSheet = () => {
+  // Input state
+  const [textEmpty, setTextEmpty] = useState('');
+  const [textAreaVal, setTextAreaVal] = useState('');
+  const [selectEmpty, setSelectEmpty] = useState('');
+  const [multiVal, setMultiVal] = useState([]);
+  const [dateVal, setDateVal] = useState('');
+
+  // Selection control state
+  const [checkGroupVal, setCheckGroupVal] = useState(['Design']);
+  const [radioGroupVal, setRadioGroupVal] = useState('email');
+
+  const selectOptions = ['Design', 'Development', 'Research', 'QA'];
+
+  return (
+    <Box gap="large">
+      {/* ── Text inputs ────────────────────────────────────────────── */}
+      <Box gap="small">
+        <SectionHeading>Inputs (in FormField)</SectionHeading>
+        <Grid columns={{ count: 'fill', size: ['260px', '1fr'] }} gap="small">
+          <ItemCard title="TextInput empty">
+            <FormField htmlFor="ti-empty" label="Label">
+              <TextInput
+                id="ti-empty"
+                placeholder="Placeholder text"
+                value={textEmpty}
+                onChange={e => setTextEmpty(e.target.value)}
+              />
+            </FormField>
+          </ItemCard>
+
+          <ItemCard title="TextArea empty">
+            <FormField htmlFor="ta-empty" label="Label">
+              <TextArea
+                id="ta-empty"
+                placeholder="Enter text..."
+                value={textAreaVal}
+                onChange={e => setTextAreaVal(e.target.value)}
+                rows={2}
+              />
+            </FormField>
+          </ItemCard>
+
+          <ItemCard title="Select empty">
+            <FormField htmlFor="sel-empty" label="Label">
+              <Select
+                id="sel-empty"
+                options={selectOptions}
+                placeholder="Select..."
+                value={selectEmpty}
+                onChange={({ value: v }) => setSelectEmpty(v)}
+              />
+            </FormField>
+          </ItemCard>
+
+          <ItemCard title="Select with value">
+            <FormField htmlFor="sel-filled" label="Label">
+              <Select
+                id="sel-filled"
+                options={selectOptions}
+                value="Design"
+                onChange={() => {}}
+              />
+            </FormField>
+          </ItemCard>
+
+          <ItemCard title="SelectMultiple">
+            <FormField htmlFor="sm-empty" label="Label">
+              <SelectMultiple
+                id="sm-empty"
+                options={selectOptions}
+                placeholder="Select..."
+                value={multiVal}
+                onChange={({ value: v }) => setMultiVal(v)}
+              />
+            </FormField>
+          </ItemCard>
+
+          <ItemCard title="DateInput">
+            <FormField htmlFor="di-empty" label="Label">
+              <DateInput
+                id="di-empty"
+                name="date"
+                format="mm/dd/yyyy"
+                value={dateVal}
+                onChange={({ value: v }) => setDateVal(v)}
+              />
+            </FormField>
+          </ItemCard>
+
+          <ItemCard title="FileInput">
+            <FormField label="Label">
+              <FileInput name="file" />
+            </FormField>
+          </ItemCard>
+        </Grid>
+      </Box>
+
+      {/* ── Selection controls ──────────────────────────────────────── */}
+      <Box gap="small">
+        <SectionHeading>Selection Controls</SectionHeading>
+        <Grid columns={{ count: 'fill', size: ['480px', '1fr'] }} gap="small">
+          {/* CheckBox */}
+          <DualCard
+            title="CheckBox"
+            standalone={
+              <Box gap="xsmall">
+                <CheckBox label="Unchecked" checked={false} onChange={() => {}} />
+                <CheckBox label="Checked" checked onChange={() => {}} />
+                <CheckBox label="Indeterminate" indeterminate onChange={() => {}} />
+              </Box>
+            }
+            inFormField={
+              <Box gap="xsmall">
+                <FormField>
+                  <CheckBox label="Unchecked" checked={false} onChange={() => {}} />
+                </FormField>
+                <FormField>
+                  <CheckBox label="Checked" checked onChange={() => {}} />
+                </FormField>
+                <FormField>
+                  <CheckBox label="Indeterminate" indeterminate onChange={() => {}} />
+                </FormField>
+              </Box>
+            }
+          />
+
+          {/* CheckBoxGroup */}
+          <DualCard
+            title="CheckBoxGroup"
+            standalone={
+              <CheckBoxGroup
+                options={selectOptions.slice(0, 3)}
+                value={checkGroupVal}
+                onChange={({ value: v }) => setCheckGroupVal(v)}
+              />
+            }
+            inFormField={
+              <FormField label="Preferences">
+                <CheckBoxGroup
+                  options={selectOptions.slice(0, 3)}
+                  value={checkGroupVal}
+                  onChange={({ value: v }) => setCheckGroupVal(v)}
+                />
+              </FormField>
+            }
+          />
+
+          {/* RadioButton */}
+          <DualCard
+            title="RadioButton"
+            standalone={
+              <Box gap="xsmall">
+                <RadioButton
+                  name="rb-s-1"
+                  label="Unchecked"
+                  checked={false}
+                  onChange={() => {}}
+                />
+                <RadioButton
+                  name="rb-s-2"
+                  label="Checked"
+                  checked
+                  onChange={() => {}}
+                />
+              </Box>
+            }
+            inFormField={
+              <Box gap="xsmall">
+                <FormField>
+                  <RadioButton
+                    name="rb-ff-1"
+                    label="Unchecked"
+                    checked={false}
+                    onChange={() => {}}
+                  />
+                </FormField>
+                <FormField>
+                  <RadioButton
+                    name="rb-ff-2"
+                    label="Checked"
+                    checked
+                    onChange={() => {}}
+                  />
+                </FormField>
+              </Box>
+            }
+          />
+
+          {/* RadioButtonGroup */}
+          <DualCard
+            title="RadioButtonGroup"
+            standalone={
+              <RadioButtonGroup
+                name="rbg-s"
+                options={[
+                  { label: 'Email', value: 'email' },
+                  { label: 'Phone', value: 'phone' },
+                  { label: 'Text', value: 'text' },
+                ]}
+                value={radioGroupVal}
+                onChange={e => setRadioGroupVal(e.target.value)}
+              />
+            }
+            inFormField={
+              <FormField label="Contact method">
+                <RadioButtonGroup
+                  name="rbg-ff"
+                  options={[
+                    { label: 'Email', value: 'email' },
+                    { label: 'Phone', value: 'phone' },
+                    { label: 'Text', value: 'text' },
+                  ]}
+                  value={radioGroupVal}
+                  onChange={e => setRadioGroupVal(e.target.value)}
+                />
+              </FormField>
+            }
+          />
+
+          {/* Switch */}
+          <DualCard
+            title="Switch (Toggle)"
+            standalone={
+              <Box gap="xsmall">
+                <CheckBox toggle label="Off" checked={false} onChange={() => {}} />
+                <CheckBox toggle label="On" checked onChange={() => {}} />
+              </Box>
+            }
+            inFormField={
+              <Box gap="xsmall">
+                <FormField>
+                  <CheckBox
+                    toggle
+                    label="Two-factor auth"
+                    checked={false}
+                    onChange={() => {}}
+                  />
+                </FormField>
+                <FormField>
+                  <CheckBox
+                    toggle
+                    label="Two-factor auth"
+                    checked
+                    onChange={() => {}}
+                  />
+                </FormField>
+              </Box>
+            }
+          />
+        </Grid>
+      </Box>
+    </Box>
+  );
+};

--- a/apps/docs/src/examples/hover-sticker-sheet/StickerSheet.jsx
+++ b/apps/docs/src/examples/hover-sticker-sheet/StickerSheet.jsx
@@ -9,7 +9,6 @@ import {
   FormField,
   Grid,
   Heading,
-  RadioButton,
   RadioButtonGroup,
   Select,
   SelectMultiple,
@@ -207,47 +206,6 @@ export const StickerSheet = () => {
                   onChange={({ value: v }) => setCheckGroupVal(v)}
                 />
               </FormField>
-            }
-          />
-
-          {/* RadioButton */}
-          <DualCard
-            title="RadioButton"
-            standalone={
-              <Box gap="xsmall">
-                <RadioButton
-                  name="rb-s-1"
-                  label="Unchecked"
-                  checked={false}
-                  onChange={() => {}}
-                />
-                <RadioButton
-                  name="rb-s-2"
-                  label="Checked"
-                  checked
-                  onChange={() => {}}
-                />
-              </Box>
-            }
-            inFormField={
-              <Box gap="xsmall">
-                <FormField>
-                  <RadioButton
-                    name="rb-ff-1"
-                    label="Unchecked"
-                    checked={false}
-                    onChange={() => {}}
-                  />
-                </FormField>
-                <FormField>
-                  <RadioButton
-                    name="rb-ff-2"
-                    label="Checked"
-                    checked
-                    onChange={() => {}}
-                  />
-                </FormField>
-              </Box>
             }
           />
 

--- a/apps/docs/src/examples/hover-sticker-sheet/WizardExample.jsx
+++ b/apps/docs/src/examples/hover-sticker-sheet/WizardExample.jsx
@@ -1,0 +1,304 @@
+/* eslint-disable */
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  CheckBox,
+  FormField,
+  Heading,
+  RadioButtonGroup,
+  Select,
+  SelectMultiple,
+  Text,
+  TextInput,
+} from 'grommet';
+
+const SOURCE_CLUSTERS = [
+  'vSphere Cluster A',
+  'vSphere Cluster B',
+  'vSphere Cluster C',
+];
+const TARGET_CLUSTERS = ['Target Cluster East', 'Target Cluster West'];
+const DATASTORES = [
+  'SSD Datastore 01',
+  'SSD Datastore 02',
+  'HDD Datastore 01',
+];
+const VMS = [
+  'web-server-01',
+  'web-server-02',
+  'db-primary-01',
+  'db-replica-01',
+  'kafka-broker-01',
+  'kafka-broker-02',
+];
+const SCHEDULE_OPTIONS = [
+  { label: 'Immediate', value: 'immediate' },
+  { label: 'Scheduled', value: 'scheduled' },
+];
+const STEP_LABELS = [
+  'Source environment',
+  'Target configuration',
+  'Migration options',
+  'Review',
+];
+const TOTAL_STEPS = 4;
+
+const StepIndicator = ({ step }) => (
+  <Box direction="row" align="center">
+    {STEP_LABELS.map((label, i) => {
+      const n = i + 1;
+      const isActive = n === step;
+      const isDone = n < step;
+      return (
+        <React.Fragment key={n}>
+          <Box direction="row" align="center" gap="xsmall" flex={false}>
+            <Box
+              width="28px"
+              height="28px"
+              round="full"
+              flex={false}
+              align="center"
+              justify="center"
+              background={
+                isDone ? 'status-ok' : isActive ? 'brand' : 'background-contrast'
+              }
+            >
+              <Text
+                size="xsmall"
+                weight="bold"
+                color={isActive || isDone ? 'white' : 'text-weak'}
+              >
+                {n}
+              </Text>
+            </Box>
+            <Text
+              size="small"
+              color={isActive ? 'text' : 'text-weak'}
+              weight={isActive ? 'bold' : 'normal'}
+            >
+              {label}
+            </Text>
+          </Box>
+          {n < TOTAL_STEPS && (
+            <Box
+              flex
+              height="2px"
+              background="border-weak"
+              margin={{ horizontal: 'xsmall' }}
+            />
+          )}
+        </React.Fragment>
+      );
+    })}
+  </Box>
+);
+
+const ReviewRow = ({ label, value }) => (
+  <Box
+    direction="row"
+    gap="small"
+    border={{ side: 'bottom', color: 'border-weak' }}
+    pad={{ vertical: 'xsmall' }}
+  >
+    <Text size="small" color="text-weak" width="160px" flex={false}>
+      {label}
+    </Text>
+    <Text size="small">{value || '\u2014'}</Text>
+  </Box>
+);
+
+export const WizardExample = () => {
+  const [step, setStep] = useState(1);
+  const [sourceCluster, setSourceCluster] = useState('');
+  const [selectedVMs, setSelectedVMs] = useState([]);
+  const [liveMigration, setLiveMigration] = useState(false);
+  const [targetCluster, setTargetCluster] = useState('');
+  const [datastore, setDatastore] = useState('');
+  const [sourceNetwork, setSourceNetwork] = useState('');
+  const [targetNetwork, setTargetNetwork] = useState('');
+  const [schedule, setSchedule] = useState('immediate');
+  const [bandwidth, setBandwidth] = useState('');
+  const [retryOnFailure, setRetryOnFailure] = useState(true);
+
+  const renderStep = () => {
+    if (step === 1) {
+      return (
+        <Box gap="xsmall">
+          <FormField name="sourceCluster" htmlFor="sourceCluster" label="Source cluster">
+            <Select
+              id="sourceCluster"
+              name="sourceCluster"
+              options={SOURCE_CLUSTERS}
+              placeholder="Select cluster..."
+              value={sourceCluster}
+              onChange={({ value }) => setSourceCluster(value)}
+            />
+          </FormField>
+          <FormField name="selectedVMs" htmlFor="selectedVMs" label="Virtual machines to migrate">
+            <SelectMultiple
+              id="selectedVMs"
+              name="selectedVMs"
+              options={VMS}
+              placeholder="Select VMs..."
+              value={selectedVMs}
+              onChange={({ value }) => setSelectedVMs(value)}
+            />
+          </FormField>
+          <FormField>
+            <CheckBox
+              toggle
+              label="Enable live migration (zero downtime)"
+              checked={liveMigration}
+              onChange={e => setLiveMigration(e.target.checked)}
+            />
+          </FormField>
+        </Box>
+      );
+    }
+
+    if (step === 2) {
+      return (
+        <Box gap="xsmall">
+          <FormField name="targetCluster" htmlFor="targetCluster" label="Target cluster">
+            <Select
+              id="targetCluster"
+              name="targetCluster"
+              options={TARGET_CLUSTERS}
+              placeholder="Select cluster..."
+              value={targetCluster}
+              onChange={({ value }) => setTargetCluster(value)}
+            />
+          </FormField>
+          <FormField name="datastore" htmlFor="datastore" label="Target datastore">
+            <Select
+              id="datastore"
+              name="datastore"
+              options={DATASTORES}
+              placeholder="Select datastore..."
+              value={datastore}
+              onChange={({ value }) => setDatastore(value)}
+            />
+          </FormField>
+          <FormField name="sourceNetwork" htmlFor="sourceNetwork" label="Source network">
+            <TextInput
+              id="sourceNetwork"
+              name="sourceNetwork"
+              placeholder="e.g. VLAN-100"
+              value={sourceNetwork}
+              onChange={e => setSourceNetwork(e.target.value)}
+            />
+          </FormField>
+          <FormField name="targetNetwork" htmlFor="targetNetwork" label="Target network">
+            <TextInput
+              id="targetNetwork"
+              name="targetNetwork"
+              placeholder="e.g. VLAN-200"
+              value={targetNetwork}
+              onChange={e => setTargetNetwork(e.target.value)}
+            />
+          </FormField>
+        </Box>
+      );
+    }
+
+    if (step === 3) {
+      return (
+        <Box gap="xsmall">
+          <FormField name="schedule" label="Migration schedule">
+            <RadioButtonGroup
+              name="schedule"
+              options={SCHEDULE_OPTIONS}
+              value={schedule}
+              onChange={e => setSchedule(e.target.value)}
+            />
+          </FormField>
+          <FormField name="bandwidth" htmlFor="bandwidth" label="Max bandwidth (Mbps)">
+            <TextInput
+              id="bandwidth"
+              name="bandwidth"
+              placeholder="e.g. 500"
+              value={bandwidth}
+              onChange={e => setBandwidth(e.target.value)}
+            />
+          </FormField>
+          <FormField>
+            <CheckBox
+              label="Retry on failure"
+              checked={retryOnFailure}
+              onChange={e => setRetryOnFailure(e.target.checked)}
+            />
+          </FormField>
+        </Box>
+      );
+    }
+
+    // Step 4 \u2014 Review
+    return (
+      <Box gap="medium">
+        <Box gap="none">
+          <Text size="small" weight="bold" color="text-weak" margin={{ bottom: 'xsmall' }}>SOURCE</Text>
+          <ReviewRow label="Cluster" value={sourceCluster} />
+          <ReviewRow label="Virtual machines" value={selectedVMs.length ? selectedVMs.join(', ') : undefined} />
+          <ReviewRow label="Live migration" value={liveMigration ? 'Enabled' : 'Disabled'} />
+        </Box>
+        <Box gap="none">
+          <Text size="small" weight="bold" color="text-weak" margin={{ bottom: 'xsmall' }}>TARGET</Text>
+          <ReviewRow label="Cluster" value={targetCluster} />
+          <ReviewRow label="Datastore" value={datastore} />
+          <ReviewRow
+            label="Network mapping"
+            value={sourceNetwork && targetNetwork ? `${sourceNetwork} \u2192 ${targetNetwork}` : undefined}
+          />
+        </Box>
+        <Box gap="none">
+          <Text size="small" weight="bold" color="text-weak" margin={{ bottom: 'xsmall' }}>OPTIONS</Text>
+          <ReviewRow label="Schedule" value={schedule === 'immediate' ? 'Immediate' : 'Scheduled'} />
+          <ReviewRow label="Max bandwidth" value={bandwidth ? `${bandwidth} Mbps` : undefined} />
+          <ReviewRow label="Retry on failure" value={retryOnFailure ? 'Enabled' : 'Disabled'} />
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box
+      fill="horizontal"
+      style={{ minHeight: '600px' }}
+      border={{ color: 'border-default', side: 'all' }}
+      round="small"
+      overflow="hidden"
+    >
+      {/* Step indicator — pinned to top, fully inside the border */}
+      <Box
+        pad={{ horizontal: 'medium', top: 'medium', bottom: 'small' }}
+        flex={false}
+      >
+        <StepIndicator step={step} />
+      </Box>
+
+      {/* Form content — centered in the remaining space */}
+      <Box flex align="center" justify="center" pad={{ horizontal: 'medium', bottom: 'medium' }}>
+        <Box width={{ max: 'medium' }} fill="horizontal" gap="medium">
+          <Heading level={3} margin="none" size="small">
+            {STEP_LABELS[step - 1]}
+          </Heading>
+          {renderStep()}
+          <Box direction="row" justify="between" margin={{ top: 'small' }}>
+            <Button label="Cancel" onClick={() => setStep(1)} />
+            <Box direction="row" gap="small">
+              {step > 1 && (
+                <Button label="Back" onClick={() => setStep(s => s - 1)} />
+              )}
+              {step < TOTAL_STEPS ? (
+                <Button label="Next" primary onClick={() => setStep(s => s + 1)} />
+              ) : (
+                <Button label="Start migration" primary />
+              )}
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -326,3 +326,63 @@ export const option7Theme = deepMerge(option2Theme, {
     },
   },
 });
+
+// ─── Option 8 helpers ────────────────────────────────────────────────────────
+
+// Like Option 5: unchecked checkbox border = border-strong at rest.
+// On hover the border stays border-strong (no change) and the control
+// background fills with background-hover instead.
+const checkBorderStrongBgHover = props => {
+  const base =
+    typeof hpe.checkBox?.check?.extend === 'function'
+      ? hpe.checkBox.check.extend(props)
+      : hpe.checkBox?.check?.extend ?? '';
+  const { checked, indeterminate, disabled } = props;
+  const borderStrongColor = resolveColor('border-strong', props.theme);
+  const bgHoverColor = resolveColor('background-hover', props.theme);
+
+  if (!checked && !indeterminate && !disabled) {
+    return `${base}
+border-color: ${borderStrongColor};
+&:hover { background: ${bgHoverColor}; border-color: ${borderStrongColor}; }`;
+  }
+  if (indeterminate && !disabled) {
+    return `${base}\n&:hover { border-color: rgba(0, 0, 0, 0); }`;
+  }
+  return base;
+};
+
+// RadioButton extend: unchecked border = border-strong at rest and on hover.
+// On hover the circle fills with background-hover.
+const radiobuttonExtendOption8 = props => {
+  const borderStrongColor = resolveColor('border-strong', props.theme);
+  const bgHoverColor = resolveColor('background-hover', props.theme);
+  return `
+& input:not([disabled]):not(:checked) + div,
+& input:not([disabled]):not(:checked) + span {
+  border-color: ${borderStrongColor};
+}
+&:hover input:not([disabled]):not(:checked) + div,
+&:hover input:not([disabled]):not(:checked) + span {
+  background: ${bgHoverColor};
+  border-color: ${borderStrongColor};
+}`;
+};
+
+// Option 8: identical to Option 5 but hover feedback on selection controls is
+// a background fill (background-hover) rather than a border colour change.
+// Border stays border-strong at rest and on hover.
+export const option8Theme = deepMerge(hpe, {
+  checkBox: {
+    check: { extend: checkBorderStrongBgHover },
+  },
+  radioButton: {
+    extend: radiobuttonExtendOption8,
+  },
+  formField: {
+    extend: formFieldWithHoverBorder,
+  },
+  fileInput: {
+    hover: { border: { color: 'border-strong' } },
+  },
+});

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -386,3 +386,23 @@ export const option8Theme = deepMerge(hpe, {
     hover: { border: { color: 'border-strong' } },
   },
 });
+
+// ─── Focus 3px ───────────────────────────────────────────────────────────
+
+// Identical to the current HPE theme for hover states. The outer ring of the
+// focus indicator is increased from 2px to 3px. Both the regular (outline)
+// and inset variants are updated so behaviour is consistent across all inputs.
+export const focus3pxTheme = deepMerge(hpe, {
+  global: {
+    focus: {
+      outline: {
+        size: '3px',
+      },
+      inset: {
+        outline: {
+          size: '3px',
+        },
+      },
+    },
+  },
+});

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -184,7 +184,38 @@ const formFieldOption4Extend = props => {
 }`;
 };
 
+// Darken the checked control fill when any part of the row label is hovered,
+// not just when the pointer is directly over the control square/circle.
+const checkboxExtendOption4 = props => {
+  const checkedHoverBg = resolveColor(
+    'background-selected-primary-strong-hover',
+    props.theme,
+  );
+  return `${checkboxExtend(props)}
+  &:hover input:checked:not([disabled]) + div {
+    background: ${checkedHoverBg};
+  }`;
+};
+
+const radiobuttonExtendOption4 = props => {
+  const checkedHoverBg = resolveColor(
+    'background-selected-primary-strong-hover',
+    props.theme,
+  );
+  return `${radiobuttonExtend(props)}
+  &:hover input:checked:not([disabled]) + div,
+  &:hover input:checked:not([disabled]) + span {
+    background: ${checkedHoverBg};
+  }`;
+};
+
 export const option4Theme = deepMerge(option2Theme, {
+  checkBox: {
+    extend: checkboxExtendOption4,
+  },
+  radioButton: {
+    extend: radiobuttonExtendOption4,
+  },
   formField: {
     extend: formFieldOption4Extend,
   },

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -160,3 +160,32 @@ export const option3Theme = deepMerge(hpe, {
   },
   radioButton: { extend: radiobuttonExtendOption3 },
 });
+
+// ─── Option 4 helpers ────────────────────────────────────────────────────────
+
+// Like Option 2, but suppress the row-level background fill for group items.
+//
+// The fill does NOT come from checkBox.hover.background — that token is already
+// transparent in the hpe theme. It comes from hpe's formField.extend, which
+// injects this CSS for checkbox/radio groups inside a FormField:
+//
+//   [role="group"], [role="radiogroup"] {
+//     label { &:hover:not([disabled]) { background: rgba(0,0,0,.04); } }
+//   }
+//
+// Fix: append an override rule with equal specificity, placed after the base
+// CSS so the cascade suppresses the fill.
+const formFieldOption4Extend = props => {
+  const base = formFieldWithHoverBorder(props);
+  return `${base}
+[class*="ContentBox"] [role="group"] label:hover:not([disabled]),
+[class*="ContentBox"] [role="radiogroup"] label:hover:not([disabled]) {
+  background: transparent;
+}`;
+};
+
+export const option4Theme = deepMerge(option2Theme, {
+  formField: {
+    extend: formFieldOption4Extend,
+  },
+});

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -220,3 +220,102 @@ export const option4Theme = deepMerge(option2Theme, {
     extend: formFieldOption4Extend,
   },
 });
+
+// ─── Option 5 helpers ────────────────────────────────────────────────────────
+
+// Check (square div) extend: unchecked border = border-strong at rest, reverts
+// to border-default on hover. Checked / indeterminate / disabled are unchanged.
+const checkBorderStrongDefaultHover = props => {
+  const base =
+    typeof hpe.checkBox?.check?.extend === 'function'
+      ? hpe.checkBox.check.extend(props)
+      : hpe.checkBox?.check?.extend ?? '';
+  const { checked, indeterminate, disabled } = props;
+  const borderStrongColor = resolveColor('border-strong', props.theme);
+  const borderDefaultColor = resolveColor('border-default', props.theme);
+
+  if (!checked && !indeterminate && !disabled) {
+    return `${base}
+border-color: ${borderStrongColor};
+&:hover { background: transparent; border-color: ${borderDefaultColor}; }`;
+  }
+  if (indeterminate && !disabled) {
+    return `${base}\n&:hover { border-color: rgba(0, 0, 0, 0); }`;
+  }
+  return base;
+};
+
+// RadioButton extend: unchecked border = border-strong at rest, border-default
+// on hover. Checked radio border is left at its default appearance.
+const radiobuttonExtendOption5 = props => {
+  const borderStrongColor = resolveColor('border-strong', props.theme);
+  const borderDefaultColor = resolveColor('border-default', props.theme);
+  return `
+& input:not([disabled]):not(:checked) + div,
+& input:not([disabled]):not(:checked) + span {
+  border-color: ${borderStrongColor};
+}
+&:hover input:not([disabled]):not(:checked) + div,
+&:hover input:not([disabled]):not(:checked) + span {
+  border-color: ${borderDefaultColor};
+}`;
+};
+
+// Option 5: selection-control borders only — border-strong at rest, border-default
+// on hover. All other form inputs are unchanged.
+export const option5Theme = deepMerge(hpe, {
+  checkBox: {
+    check: { extend: checkBorderStrongDefaultHover },
+  },
+  radioButton: {
+    extend: radiobuttonExtendOption5,
+  },
+});
+
+// ─── Option 6 helpers ────────────────────────────────────────────────────────
+
+// FormField extend: ContentBox border = border-strong at rest, border-default on
+// hover for all non-selection-control fields (checkbox/radio FormField wrappers
+// are excluded to avoid double-bordering the control square/circle).
+const formFieldBorderStrongDefaultHover = props => {
+  const base =
+    typeof hpe.formField?.extend === 'function'
+      ? hpe.formField.extend(props)
+      : hpe.formField?.extend ?? '';
+  const { theme } = props;
+  const borderStrongColor = resolveColor('border-strong', theme);
+  const borderDefaultColor = resolveColor('border-default', theme);
+  return `${base}
+[class*="ContentBox"]:not(:has(input[type="checkbox"], input[type="radio"])) { border-color: ${borderStrongColor}; }
+&:hover:not(:focus-within) [class*="ContentBox"]:not(:has(input[type="checkbox"], input[type="radio"])) { border-color: ${borderDefaultColor}; }`;
+};
+
+// Option 6: all form inputs use border-strong at rest; hover lightens to
+// border-default. Builds on Option 5's selection-control changes.
+export const option6Theme = deepMerge(hpe, {
+  checkBox: {
+    check: { extend: checkBorderStrongDefaultHover },
+  },
+  radioButton: {
+    extend: radiobuttonExtendOption5,
+  },
+  formField: {
+    extend: formFieldBorderStrongDefaultHover,
+  },
+  fileInput: {
+    hover: { border: { color: 'border-default' } },
+  },
+});
+
+// ─── Option 7 helpers ────────────────────────────────────────────────────────
+
+// Option 7: override border-default to base.color.grey.600 (#7D8A92) — a darker
+// grey that meets 3:1 contrast — so every resting border is automatically
+// accessible. Hover continues to darken to border-strong, exactly as Option 2.
+export const option7Theme = deepMerge(option2Theme, {
+  global: {
+    colors: {
+      'border-default': { light: '#7D8A92', dark: '#7D8A92' },
+    },
+  },
+});

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -1,0 +1,116 @@
+/* eslint-disable */
+import { hpe } from 'grommet-theme-hpe';
+import { deepMerge } from 'grommet/utils';
+
+// Current: unchanged HPE theme
+export const currentTheme = hpe;
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+// Resolve a design-token color name to its current-mode hex/string value.
+const resolveColor = (token, theme) => {
+  const color = theme?.global?.colors?.[token];
+  if (color && typeof color === 'object') {
+    return color[theme.dark ? 'dark' : 'light'];
+  }
+  return color || token;
+};
+
+// ─── Option 1 helpers ────────────────────────────────────────────────────────
+
+// Remove hover background fill from the unchecked checkbox square only.
+// For checked / indeterminate / disabled states the original CSS is preserved.
+const checkNoUncheckedFill = props => {
+  const base =
+    typeof hpe.checkBox?.check?.extend === 'function'
+      ? hpe.checkBox.check.extend(props)
+      : hpe.checkBox?.check?.extend ?? '';
+  const { checked, indeterminate, disabled } = props;
+  if (!checked && !indeterminate && !disabled) {
+    return `${base}\n&:hover { background: transparent; }`;
+  }
+  // Grommet's base checkBox.hover.border applies a border colour on hover even
+  // for filled (indeterminate/checked) states. The HPE check.extend sets
+  // border-color: transparent statically but doesn't override the hover rule.
+  // Append a hover border reset so only the background fill changes on hover.
+  if (indeterminate && !disabled) {
+    return `${base}\n&:hover { border-color: rgba(0, 0, 0, 0); }`;
+  }
+  return base;
+};
+
+// Override checkBox.extend for the container (StyledCheckBoxContainer = label).
+// The HPE theme's checkBox.extend returns a css-tagged template array which
+// styled-components handles correctly when used directly, but breaks when
+// composed via string interpolation (array.toString() produces garbled CSS with
+// commas that causes the closing `}` to escape the scoped rule, turning the
+// hover selector into a global classless rule that fires on any ancestor hover).
+//
+// Fix: write the CSS directly as a plain string, replicating the HPE extend's
+// content (font-weight, transparent label border, toggle-knob position) and
+// adding the hover border rule for unchecked state only.
+const checkboxExtend = props => {
+  const borderStrongColor = resolveColor('border-strong', props.theme);
+  return `
+    font-weight: 400;
+    width: auto;
+    border: ${hpe.checkBox?.border?.width ?? '1px'} solid rgba(0, 0, 0, 0);
+    & input:checked + span[class*=CheckBoxToggle] > span[class*=CheckBoxKnob] {
+      left: 25px;
+    }
+    &:hover input:not([disabled]):not(:checked):not(:indeterminate) + div {
+      border-color: ${borderStrongColor};
+    }
+  `;
+};
+
+// For RadioButton: the base HPE theme already darkens the border on hover for
+// ALL states via radioButton.hover.border.color. Cancel that for the checked
+// (selected) state so only unselected radio buttons get border darkening.
+const radiobuttonExtend = props => {
+  const borderDefault = resolveColor('border-default', props.theme);
+  return `
+&:hover input:checked + div,
+&:hover input:checked + span {
+  border-color: ${borderDefault};
+}`;
+};
+
+const option1Override = {
+  checkBox: {
+    check: { extend: checkNoUncheckedFill },
+    extend: checkboxExtend,
+  },
+  radioButton: {
+    extend: radiobuttonExtend,
+  },
+};
+
+export const option1Theme = deepMerge(hpe, option1Override);
+
+// ─── Option 2 helpers ────────────────────────────────────────────────────────
+
+// Compose with the existing formField.extend and append a hover border rule.
+// The border lives on FormFieldContentBox (class contains "ContentBox").
+// Exclude FormFields whose ContentBox contains a checkbox or radio input so
+// that selection-control FormFields don't get the container border treatment.
+const formFieldWithHoverBorder = props => {
+  const base =
+    typeof hpe.formField?.extend === 'function'
+      ? hpe.formField.extend(props)
+      : hpe.formField?.extend ?? '';
+  const { theme } = props;
+  const borderStrongColor = resolveColor('border-strong', theme);
+  return `${base}
+&:hover:not(:focus-within) [class*="ContentBox"]:not(:has(input[type="checkbox"], input[type="radio"])) { border-color: ${borderStrongColor}; }`;
+};
+
+export const option2Theme = deepMerge(hpe, {
+  ...option1Override,
+  fileInput: {
+    hover: { border: { color: 'border-strong' } },
+  },
+  formField: {
+    extend: formFieldWithHoverBorder,
+  },
+});

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -261,14 +261,21 @@ const radiobuttonExtendOption5 = props => {
 }`;
 };
 
-// Option 5: selection-control borders only — border-strong at rest, border-default
-// on hover. All other form inputs are unchanged.
+// Option 5: selection-control borders — border-strong at rest, border-default on
+// hover. Text/select/textarea inputs get a darker border (border-strong) on hover,
+// matching Option 2's field behaviour.
 export const option5Theme = deepMerge(hpe, {
   checkBox: {
     check: { extend: checkBorderStrongDefaultHover },
   },
   radioButton: {
     extend: radiobuttonExtendOption5,
+  },
+  formField: {
+    extend: formFieldWithHoverBorder,
+  },
+  fileInput: {
+    hover: { border: { color: 'border-strong' } },
   },
 });
 

--- a/apps/docs/src/examples/hover-sticker-sheet/themes.js
+++ b/apps/docs/src/examples/hover-sticker-sheet/themes.js
@@ -114,3 +114,49 @@ export const option2Theme = deepMerge(hpe, {
     extend: formFieldWithHoverBorder,
   },
 });
+
+// ─── Option 3 helpers ────────────────────────────────────────────────────────
+
+// Like Option 1 but unchecked checkboxes get background-hover fill on hover
+// in addition to the darker border.
+const checkWithHoverFill = props => {
+  const base =
+    typeof hpe.checkBox?.check?.extend === 'function'
+      ? hpe.checkBox.check.extend(props)
+      : hpe.checkBox?.check?.extend ?? '';
+  const { checked, indeterminate, disabled } = props;
+  if (!checked && !indeterminate && !disabled) {
+    const bgHoverColor = resolveColor('background-hover', props.theme);
+    return `${base}\n&:hover { background: ${bgHoverColor}; }`;
+  }
+  if (indeterminate && !disabled) {
+    return `${base}\n&:hover { border-color: rgba(0, 0, 0, 0); }`;
+  }
+  return base;
+};
+
+// Unchecked radio buttons get background-hover fill + border-strong on hover.
+// Checked radio buttons keep their default border (no darkening).
+const radiobuttonExtendOption3 = props => {
+  const borderDefault = resolveColor('border-default', props.theme);
+  const borderStrongColor = resolveColor('border-strong', props.theme);
+  const bgHoverColor = resolveColor('background-hover', props.theme);
+  return `
+&:hover input:not([disabled]):not(:checked) + div,
+&:hover input:not([disabled]):not(:checked) + span {
+  background: ${bgHoverColor};
+  border-color: ${borderStrongColor};
+}
+&:hover input:checked + div,
+&:hover input:checked + span {
+  border-color: ${borderDefault};
+}`;
+};
+
+export const option3Theme = deepMerge(hpe, {
+  checkBox: {
+    check: { extend: checkWithHoverFill },
+    extend: checkboxExtend,
+  },
+  radioButton: { extend: radiobuttonExtendOption3 },
+});

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -7,7 +7,6 @@ import {
   Grommet,
   Heading,
   PageContent,
-  RadioButton,
   Text,
   TextInput,
   ToggleGroup,
@@ -26,12 +25,12 @@ const DESCRIPTIONS = {
   Current: [
     'Unchecked checkboxes show a background fill on hover.',
     'Form input borders do not change on hover.',
-    'RadioButton border darkens on hover (unchecked and checked).',
+    'RadioButtonGroup border darkens on hover (unchecked and checked).',
   ],
   'Option 1': [
     'No background fill on unchecked checkbox hover.',
     'Checkbox border darkens on hover for unchecked state only.',
-    'RadioButton border darkens on hover for unchecked state only.',
+    'RadioButtonGroup border darkens on hover for unchecked state only.',
   ],
   'Option 2': [
     'All inputs get a darker border on hover.',
@@ -99,12 +98,6 @@ const HoverStickerSheet = () => {
               <Box direction="row" gap="large" align="center" wrap>
                 <CheckBox
                   label="Checkbox"
-                  checked={false}
-                  onChange={() => {}}
-                />
-                <RadioButton
-                  name="preview-rb"
-                  label="Radio button"
                   checked={false}
                   onChange={() => {}}
                 />

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -7,11 +7,12 @@ import {
   Grommet,
   Heading,
   PageContent,
+  RadioButton,
   Text,
   TextInput,
   ToggleGroup,
 } from 'grommet';
-import { currentTheme, option1Theme, option2Theme } from '../examples/hover-sticker-sheet/themes';
+import { currentTheme, option1Theme, option2Theme, option3Theme } from '../examples/hover-sticker-sheet/themes';
 import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
 import { ExampleForm } from '../examples/hover-sticker-sheet/ExampleForm';
 
@@ -19,6 +20,7 @@ const THEMES = {
   Current: currentTheme,
   'Option 1': option1Theme,
   'Option 2': option2Theme,
+  'Option 3': option3Theme,
 };
 
 const DESCRIPTIONS = {
@@ -34,6 +36,10 @@ const DESCRIPTIONS = {
   ],
   'Option 2': [
     'All inputs get a darker border on hover.',
+  ],
+  'Option 3': [
+    'Unchecked checkbox and radio button get a background fill (background-hover) and a darker border on hover.',
+    'Other form inputs are unchanged on hover.',
   ],
 };
 
@@ -77,7 +83,7 @@ const HoverStickerSheet = () => {
           <Box gap="small">
             <Text weight="bold">Hover option:</Text>
             <ToggleGroup
-              options={['Current', 'Option 1', 'Option 2']}
+              options={['Current', 'Option 1', 'Option 2', 'Option 3']}
               value={option}
               onToggle={({ value }) => setOption(value)}
             />
@@ -98,6 +104,12 @@ const HoverStickerSheet = () => {
               <Box direction="row" gap="large" align="center" wrap>
                 <CheckBox
                   label="Checkbox"
+                  checked={false}
+                  onChange={() => {}}
+                />
+                <RadioButton
+                  name="preview-rb"
+                  label="Radio button"
                   checked={false}
                   onChange={() => {}}
                 />

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -1,0 +1,141 @@
+/* eslint-disable */
+import React, { useState } from 'react';
+import {
+  Box,
+  CheckBox,
+  FormField,
+  Grommet,
+  Heading,
+  PageContent,
+  RadioButton,
+  RadioButtonGroup,
+  Text,
+  TextInput,
+} from 'grommet';
+import { currentTheme, option1Theme, option2Theme } from '../examples/hover-sticker-sheet/themes';
+import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
+import { ExampleForm } from '../examples/hover-sticker-sheet/ExampleForm';
+
+const THEMES = {
+  Current: currentTheme,
+  'Option 1': option1Theme,
+  'Option 2': option2Theme,
+};
+
+const DESCRIPTIONS = {
+  Current: [
+    'Unchecked checkboxes show a background fill on hover.',
+    'Form input borders do not change on hover.',
+    'RadioButton border darkens on hover (unchecked and checked).',
+  ],
+  'Option 1': [
+    'No background fill on unchecked checkbox hover.',
+    'Checkbox border darkens on hover for unchecked state only.',
+    'RadioButton border darkens on hover for unchecked state only.',
+  ],
+  'Option 2': [
+    'All inputs get a darker border on hover.',
+  ],
+};
+
+const HoverStickerSheet = () => {
+  const [option, setOption] = useState('Current');
+  const [darkMode, setDarkMode] = useState(false);
+
+  return (
+    <Grommet
+      theme={THEMES[option]}
+      themeMode={darkMode ? 'dark' : 'light'}
+      style={{ width: '100%' }}
+    >
+      <PageContent>
+        <Box pad={{ vertical: 'large' }} gap="xlarge">
+          {/* ── Page header ───────────────────────────────────────── */}
+          <Box
+            direction="row"
+            justify="between"
+            align="center"
+            wrap
+            gap="small"
+          >
+            <Box gap="xsmall">
+              <Heading level={1} margin="none">
+                Hover State Feedback
+              </Heading>
+              <Text size="large" color="text-weak">
+                Switch between options and hover over components to compare behavior.
+              </Text>
+            </Box>
+            <CheckBox
+              toggle
+              label="Dark mode"
+              checked={darkMode}
+              onChange={e => setDarkMode(e.target.checked)}
+            />
+          </Box>
+
+          {/* ── Option selector ───────────────────────────────────── */}
+          <Box gap="small">
+            <Text weight="bold">Hover option:</Text>
+            <RadioButtonGroup
+              name="hover-option"
+              direction="row"
+              options={['Current', 'Option 1', 'Option 2']}
+              value={option}
+              onChange={e => setOption(e.target.value)}
+            />
+            <Box
+              background="background-contrast"
+              pad="medium"
+              round="small"
+              gap="medium"
+            >
+              <Box gap="xsmall">
+                {DESCRIPTIONS[option].map(item => (
+                  <Box key={item} direction="row" gap="xsmall">
+                    <Text>•</Text>
+                    <Text>{item}</Text>
+                  </Box>
+                ))}
+              </Box>
+              <Box direction="row" gap="large" align="center" wrap>
+                <CheckBox
+                  label="Checkbox"
+                  checked={false}
+                  onChange={() => {}}
+                />
+                <RadioButton
+                  name="preview-rb"
+                  label="Radio button"
+                  checked={false}
+                  onChange={() => {}}
+                />
+                <Box width={{ min: '180px' }}>
+                  <FormField>
+                    <TextInput placeholder="Text input" />
+                  </FormField>
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+
+          {/* ── Sticker sheet ─────────────────────────────────────── */}
+          <StickerSheet />
+
+          {/* ── Example form ──────────────────────────────────────── */}
+          <Box gap="small">
+            <Heading level={2} margin="none">
+              Example Form
+            </Heading>
+            <Text color="text-weak">
+              A realistic form to experience hover states in context.
+            </Text>
+            <ExampleForm />
+          </Box>
+        </Box>
+      </PageContent>
+    </Grommet>
+  );
+};
+
+export default HoverStickerSheet;

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -8,9 +8,9 @@ import {
   Heading,
   PageContent,
   RadioButton,
-  RadioButtonGroup,
   Text,
   TextInput,
+  ToggleGroup,
 } from 'grommet';
 import { currentTheme, option1Theme, option2Theme } from '../examples/hover-sticker-sheet/themes';
 import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
@@ -77,12 +77,10 @@ const HoverStickerSheet = () => {
           {/* ── Option selector ───────────────────────────────────── */}
           <Box gap="small">
             <Text weight="bold">Hover option:</Text>
-            <RadioButtonGroup
-              name="hover-option"
-              direction="row"
+            <ToggleGroup
               options={['Current', 'Option 1', 'Option 2']}
               value={option}
-              onChange={e => setOption(e.target.value)}
+              onToggle={({ value }) => setOption(value)}
             />
             <Box
               background="background-contrast"

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -12,7 +12,7 @@ import {
   TextInput,
   ToggleGroup,
 } from 'grommet';
-import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme, option5Theme, option6Theme, option7Theme } from '../examples/hover-sticker-sheet/themes';
+import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme, option5Theme, option6Theme, option7Theme, option8Theme } from '../examples/hover-sticker-sheet/themes';
 import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
 import { ExampleForm } from '../examples/hover-sticker-sheet/ExampleForm';
 import { WizardExample } from '../examples/hover-sticker-sheet/WizardExample';
@@ -27,6 +27,7 @@ const THEMES = {
   'Option 5': option5Theme,
   'Option 6': option6Theme,
   'Option 7': option7Theme,
+  'Option 8': option8Theme,
 };
 
 const DESCRIPTIONS = {
@@ -65,6 +66,11 @@ const DESCRIPTIONS = {
     'border-default is redefined to base.color.grey.600 (#7D8A92) — meets 3:1 contrast.',
     'Hover continues to darken to border-strong, as in Option 2.',
     'All inputs benefit automatically without per-component overrides.',
+  ],
+  'Option 8': [
+    'Like Option 5: checkbox and radio control borders use border-strong at rest (3:1 contrast fix).',
+    'On hover the border stays border-strong (no change); the control background fills with background-hover instead.',
+    'Text inputs, selects, and other field inputs get a darker border (border-strong) on hover.',
   ],
 };
 
@@ -108,7 +114,7 @@ const HoverStickerSheet = () => {
           <Box gap="small">
             <Text weight="bold">Hover option:</Text>
             <ToggleGroup
-              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Option 7']}
+              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Option 7', 'Option 8']}
               value={option}
               onToggle={({ value }) => setOption(value)}
             />

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -12,7 +12,7 @@ import {
   TextInput,
   ToggleGroup,
 } from 'grommet';
-import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme } from '../examples/hover-sticker-sheet/themes';
+import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme, option5Theme, option6Theme, option7Theme } from '../examples/hover-sticker-sheet/themes';
 import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
 import { ExampleForm } from '../examples/hover-sticker-sheet/ExampleForm';
 import { WizardExample } from '../examples/hover-sticker-sheet/WizardExample';
@@ -24,6 +24,9 @@ const THEMES = {
   'Option 2': option2Theme,
   'Option 3': option3Theme,
   'Option 4': option4Theme,
+  'Option 5': option5Theme,
+  'Option 6': option6Theme,
+  'Option 7': option7Theme,
 };
 
 const DESCRIPTIONS = {
@@ -48,6 +51,20 @@ const DESCRIPTIONS = {
     'Like Option 2: all inputs get a darker border on hover.',
     'Row-level background fill is suppressed for items inside a CheckboxGroup or RadioButtonGroup.',
     'Checkbox and radio controls look the same on hover whether standalone or inside a group.',
+  ],
+  'Option 5': [
+    'Checkbox and radio control borders use border-strong at rest (3:1 contrast fix).',
+    'On hover those borders lighten to border-default.',
+    'All other form inputs are unchanged.',
+  ],
+  'Option 6': [
+    'All form input borders (text, select, checkbox, radio) use border-strong at rest (3:1 contrast fix).',
+    'On hover all borders lighten to border-default.',
+  ],
+  'Option 7': [
+    'border-default is redefined to base.color.grey.600 (#7D8A92) — meets 3:1 contrast.',
+    'Hover continues to darken to border-strong, as in Option 2.',
+    'All inputs benefit automatically without per-component overrides.',
   ],
 };
 
@@ -91,7 +108,7 @@ const HoverStickerSheet = () => {
           <Box gap="small">
             <Text weight="bold">Hover option:</Text>
             <ToggleGroup
-              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4']}
+              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Option 7']}
               value={option}
               onToggle={({ value }) => setOption(value)}
             />

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -12,15 +12,18 @@ import {
   TextInput,
   ToggleGroup,
 } from 'grommet';
-import { currentTheme, option1Theme, option2Theme, option3Theme } from '../examples/hover-sticker-sheet/themes';
+import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme } from '../examples/hover-sticker-sheet/themes';
 import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
 import { ExampleForm } from '../examples/hover-sticker-sheet/ExampleForm';
+import { WizardExample } from '../examples/hover-sticker-sheet/WizardExample';
+import { InstanceConfigExample } from '../examples/hover-sticker-sheet/InstanceConfigExample';
 
 const THEMES = {
   Current: currentTheme,
   'Option 1': option1Theme,
   'Option 2': option2Theme,
   'Option 3': option3Theme,
+  'Option 4': option4Theme,
 };
 
 const DESCRIPTIONS = {
@@ -41,6 +44,11 @@ const DESCRIPTIONS = {
     'Unchecked checkbox and radio button get a background fill (background-hover) and a darker border on hover.',
     'Other form inputs are unchanged on hover.',
   ],
+  'Option 4': [
+    'Like Option 2: all inputs get a darker border on hover.',
+    'Row-level background fill is suppressed for items inside a CheckboxGroup or RadioButtonGroup.',
+    'Checkbox and radio controls look the same on hover whether standalone or inside a group.',
+  ],
 };
 
 const HoverStickerSheet = () => {
@@ -54,7 +62,7 @@ const HoverStickerSheet = () => {
       style={{ width: '100%' }}
     >
       <PageContent>
-        <Box pad={{ vertical: 'large' }} gap="xlarge">
+        <Box pad={{ vertical: 'large' }} gap="64px">
           {/* ── Page header ───────────────────────────────────────── */}
           <Box
             direction="row"
@@ -83,7 +91,7 @@ const HoverStickerSheet = () => {
           <Box gap="small">
             <Text weight="bold">Hover option:</Text>
             <ToggleGroup
-              options={['Current', 'Option 1', 'Option 2', 'Option 3']}
+              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4']}
               value={option}
               onToggle={({ value }) => setOption(value)}
             />
@@ -133,7 +141,33 @@ const HoverStickerSheet = () => {
             <Text color="text-weak">
               A realistic form to experience hover states in context.
             </Text>
-            <ExampleForm />
+            <Box background="background-back" pad="medium" round="small">
+              <ExampleForm />
+            </Box>
+          </Box>
+
+          {/* ── VM Migration Wizard ───────────────────────────────── */}
+          <Box gap="small">
+            <Heading level={2} margin="none">
+              VM Migration Wizard
+            </Heading>
+            <Text color="text-weak">
+              A multi-step form with selects, text inputs, radio buttons and
+              toggles across 3 input steps.
+            </Text>
+            <WizardExample />
+          </Box>
+
+          {/* ── Instance Configuration ────────────────────────────── */}
+          <Box gap="small">
+            <Heading level={2} margin="none">
+              Instance Configuration
+            </Heading>
+            <Text color="text-weak">
+              A detail page with PageHeader, tabs, and a decorative Copilot
+              panel — a dense layout to test hover in context.
+            </Text>
+            <InstanceConfigExample />
           </Box>
         </Box>
       </PageContent>

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -12,7 +12,7 @@ import {
   TextInput,
   ToggleGroup,
 } from 'grommet';
-import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme, option5Theme, option6Theme, option7Theme, option8Theme } from '../examples/hover-sticker-sheet/themes';
+import { currentTheme, option1Theme, option2Theme, option3Theme, option4Theme, option5Theme, option6Theme, option7Theme, option8Theme, focus3pxTheme } from '../examples/hover-sticker-sheet/themes';
 import { StickerSheet } from '../examples/hover-sticker-sheet/StickerSheet';
 import { ExampleForm } from '../examples/hover-sticker-sheet/ExampleForm';
 import { WizardExample } from '../examples/hover-sticker-sheet/WizardExample';
@@ -28,6 +28,7 @@ const THEMES = {
   'Option 6': option6Theme,
   'Option 7': option7Theme,
   'Option 8': option8Theme,
+  'Focus 3px': focus3pxTheme,
 };
 
 const DESCRIPTIONS = {
@@ -72,6 +73,11 @@ const DESCRIPTIONS = {
     'On hover the border stays border-strong (no change); the control background fills with background-hover instead.',
     'Text inputs, selects, and other field inputs get a darker border (border-strong) on hover.',
   ],
+  'Focus 3px': [
+    'Hover states are identical to Current.',
+    'The outer ring of the focus indicator is increased to 3px (from the default 2px).',
+    'Tab through interactive elements to compare focus ring thickness.',
+  ],
 };
 
 const HoverStickerSheet = () => {
@@ -114,7 +120,7 @@ const HoverStickerSheet = () => {
           <Box gap="small">
             <Text weight="bold">Hover option:</Text>
             <ToggleGroup
-              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Option 7', 'Option 8']}
+              options={['Current', 'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Option 7', 'Option 8', 'Focus 3px']}
               value={option}
               onToggle={({ value }) => setOption(value)}
             />

--- a/apps/docs/src/pages/hover-sticker-sheet.js
+++ b/apps/docs/src/pages/hover-sticker-sheet.js
@@ -55,7 +55,7 @@ const DESCRIPTIONS = {
   'Option 5': [
     'Checkbox and radio control borders use border-strong at rest (3:1 contrast fix).',
     'On hover those borders lighten to border-default.',
-    'All other form inputs are unchanged.',
+    'Text inputs, selects, and other field inputs get a darker border (border-strong) on hover.',
   ],
   'Option 6': [
     'All form input borders (text, select, checkbox, radio) use border-strong at rest (3:1 contrast fix).',


### PR DESCRIPTION
This is a theme styling sticker sheet to review form inputs hover styling options.

<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6180--keen-mayer-a86c8b.netlify.app/hover-sticker-sheet)

#### What does this PR do?
Adds a hover-state sticker sheet for collecting team feedback on form component hover styling options.

#### Where should the reviewer start?
Run the docs dev server and visit the sticker sheet. Switch between Current / Option 1 / Option 2, toggle dark mode, and hover over each component.

#### Any background context you want to provide?
Three options are presented: Current (unchanged HPE theme), Option 1 (no background fill on unchecked checkbox hover; border darkens instead), Option 2 (all form inputs get a darker border on hover). The page is a throwaway feedback tool.

#### Is this change backwards compatible or is it a breaking change?
N/A: this PR will not be merged.