### PR TITLE
fix obscured focus

### DIFF
--- a/apps/docs/src/layouts/main/Layout.js
+++ b/apps/docs/src/layouts/main/Layout.js
@@ -107,8 +107,8 @@ export const Layout = ({
         <NavProvider>
           <Grid areas={gridAreas} columns={gridColumns} rows={gridRows}>
             {/* Only render Header for non-home pages.
-                Homepage header is rendered in index.js
-                to have the same background as the hero. */}
+              Homepage header is rendered in index.js
+              to have the same background as the hero. */}
             {title && title.toLowerCase() !== 'home' && (
               <AppHeader gridArea="header" />
             )}
@@ -116,7 +116,15 @@ export const Layout = ({
               gridArea="nav"
               as="aside"
               a11yTitle="Site navigation"
-              background="background-front" />
+              background="background-front"
+              height="100vh"
+              overflow="auto"
+              style={{
+                position: 'sticky',
+                top: 0,
+                overscrollBehavior: 'contain',
+              }}
+            />
             <Main overflow="visible" gridArea="main">
               <Page>
                 {layout !== 'plain' ? (

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
@@ -18,16 +18,15 @@ export const NavContainer = ({
   open,
   setOpen,
   title,
+  overflow,
   ...rest
 }: NavContainerProps) => {
   return (
     <Box
-      pad={{ 
-        horizontal: 'xsmall', 
-        bottom: '3xsmall' 
-      }}
-      width={open ? 'small' : undefined}
       {...rest}
+      direction="column"
+      overflow="hidden"
+      width={open ? 'small' : undefined}
     >
       {header || (
         <NavHeader
@@ -37,7 +36,17 @@ export const NavContainer = ({
           setOpen={setOpen}
         />
       )}
-      {children}
+      {/* Items scroll independently of the sticky header above. pad.top
+          ensures the first item's focus ring isn't clipped by the overflow
+          boundary when scrollTop is at its floor (0). */}
+      <Box
+        overflow={overflow ?? 'auto'}
+        flex
+        pad={{ top: '3xsmall', horizontal: 'xsmall', bottom: '3xsmall' }}
+        style={{ scrollPaddingTop: '6px' }}
+      >
+        {children}
+      </Box>
     </Box>
   );
 };

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
@@ -22,11 +22,7 @@ export const NavContainer = ({
   ...rest
 }: NavContainerProps) => {
   return (
-    <Box
-      {...rest}
-      overflow="hidden"
-      width={open ? 'small' : undefined}
-    >
+    <Box {...rest} width={open ? 'small' : undefined}>
       {header || (
         <NavHeader
           title={title}
@@ -39,10 +35,9 @@ export const NavContainer = ({
           ensures the first item's focus ring isn't clipped by the overflow
           boundary when scrollTop is at its floor (0). */}
       <Box
-        overflow={overflow ?? 'auto'}
-        flex
         pad={{ top: '3xsmall', horizontal: 'xsmall', bottom: '3xsmall' }}
         style={{ scrollPaddingTop: '6px' }}
+        overflow="auto"
       >
         {children}
       </Box>

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
@@ -1,4 +1,6 @@
+import { useContext } from 'react';
 import { Box } from 'grommet';
+import { ThemeContext } from 'styled-components';
 import { NavHeader } from './NavHeader';
 
 interface NavContainerProps {
@@ -21,6 +23,7 @@ export const NavContainer = ({
   overflow,
   ...rest
 }: NavContainerProps) => {
+  const theme = useContext(ThemeContext) as any;
   return (
     <Box {...rest} width={open ? 'small' : undefined}>
       {header || (
@@ -36,7 +39,7 @@ export const NavContainer = ({
           boundary when scrollTop is at its floor (0). */}
       <Box
         pad={{ top: '3xsmall', horizontal: 'xsmall', bottom: '3xsmall' }}
-        style={{ scrollPaddingTop: '6px' }}
+        style={{ scrollPaddingTop: theme.global.edgeSize['3xsmall'] }}
         overflow="auto"
       >
         {children}

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
@@ -24,7 +24,6 @@ export const NavContainer = ({
   return (
     <Box
       {...rest}
-      direction="column"
       overflow="hidden"
       width={open ? 'small' : undefined}
     >

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Box } from 'grommet';
+import { Box, ThemeType } from 'grommet';
 import { ThemeContext } from 'styled-components';
 import { NavHeader } from './NavHeader';
 
@@ -23,7 +23,11 @@ export const NavContainer = ({
   overflow,
   ...rest
 }: NavContainerProps) => {
-  const theme = useContext(ThemeContext) as any;
+  // ThemeType only includes base grommet edgeSize keys; HPE extends it with
+  // additional sizes (e.g. '3xsmall'). The intersection adds them explicitly.
+  const theme = useContext(ThemeContext) as ThemeType & {
+    global: { edgeSize: Record<string, string> };
+  };
   return (
     <Box {...rest} width={open ? 'small' : undefined}>
       {header || (


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6184--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Fixes WCAG 2.2 SC 2.4.12 (Focus Not Obscured Enhanced) in the docs site's left sidebar navigation. Previously, keyboard-focused nav items could be partially or fully hidden behind the sticky NavHeader.

#### What are the relevant issues?
closes #5658 
#### Where should the reviewer start?
`NavContainer.tsx`
#### How should this be manually tested?
Open the docs site and focus the sidebar nav using keyboard (Tab into it)
Tab through all items no item or its focus ring should appear behind the NavHeader

#### Any background context you want to provide?
#### Screenshots (if appropriate)
none
#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 