### PR TITLE
[Docs App] fix overflowing text issue

### DIFF
--- a/apps/docs/src/layouts/content/DocsLayout.js
+++ b/apps/docs/src/layouts/content/DocsLayout.js
@@ -35,6 +35,7 @@ export const DocsLayout = ({
       )}
       <Box
         fill="horizontal"
+        style={{ minWidth: 0, overflowWrap: 'break-word' }}
       >
         <SkipLinkTarget id="main" label="Main content" />
         <ContentSection pad={{ top: 'none' }}>

--- a/apps/docs/src/layouts/content/DocsLayout.js
+++ b/apps/docs/src/layouts/content/DocsLayout.js
@@ -35,7 +35,7 @@ export const DocsLayout = ({
       )}
       <Box
         fill="horizontal"
-        style={{ minWidth: 0, overflowWrap: 'break-word' }}
+        style={{ overflowWrap: 'break-word' }}
       >
         <SkipLinkTarget id="main" label="Main content" />
         <ContentSection pad={{ top: 'none' }}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- fix issue of non-wrapping text that make the page to overflow after side nav mobile is introduced.
- The current left navigation which layout is part of `DOCS-NEXT` branch and some items are now overflowing once the side nav is opened.


#### What are the relevant issues?
closes #6189 

#### Where should the reviewer start?
`DocsLayout.js`

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
