### PR TITLE
Docs - update forms example

### DIFF
--- a/apps/docs/src/examples/templates/forms/SingleFormFieldExample.js
+++ b/apps/docs/src/examples/templates/forms/SingleFormFieldExample.js
@@ -45,8 +45,8 @@ export const SingleFormFieldExample = () => {
           </Heading>
         </Header>
         <Text>
-          Are you sure you want to delete this cluster? Doing so will erase all
-          the data.
+          This will permanently delete the cluster 
+          and all its associated data.
         </Text>
         <Box
           // Padding used to prevent focus from being cutoff
@@ -76,7 +76,7 @@ export const SingleFormFieldExample = () => {
               direction="row"
             >
               <Button label="Cancel" />
-              <Button label="Delete cluster" primary type="submit" />
+              <Button label="Delete" primary type="submit" />
             </Box>
           </Form>
         </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6273--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Updates the **"Single required FormField"** example to match the rules presented under the [first Dos and Donts ](https://design-system.hpe.design/templates/double-confirmation?q=confirm#dos-and-do-nots) for double confirmation.
It states "Don't add unnecessary instructions or phrasing that causes doubt about what will happen or questions the user’s intent.", which is contradictory to the current live example under forms.

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
This was brought up by Marina, from GLP team.

#### Screenshots (if appropriate)
BEFORE
<img width="436" height="381" alt="Screenshot 2026-06-08 at 16 40 41" src="https://github.com/user-attachments/assets/c8801279-9d58-4ea2-9fa0-8425420eb5ba" />
AFTER
<img width="434" height="385" alt="Screenshot 2026-06-08 at 16 41 06" src="https://github.com/user-attachments/assets/1d67e9ed-d754-48d6-92a4-92275ee4b1dd" />


#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
