### PR TITLE
[Docs] - Updates color page with accent color content

### DIFF
--- a/apps/docs/src/examples/foundation/color/ColorSwatches.js
+++ b/apps/docs/src/examples/foundation/color/ColorSwatches.js
@@ -140,6 +140,69 @@ export const BorderSwatch = () => {
   );
 };
 
+// TODO: Replace placeholder tokens with real accent color tokens
+// once they are live.
+const accentPlaceholderTokens = [
+  {
+    id: 'hpe.color.background.accent.blue.weak',
+    token: 'hpe.color.background.accent.blue.weak',
+    value: '#DBEAFE',
+  },
+  {
+    id: 'hpe.color.background.accent.blue.strong',
+    token: 'hpe.color.background.accent.blue.strong',
+    value: '#2563EB',
+  },
+  {
+    id: 'hpe.color.background.accent.purple.weak',
+    token: 'hpe.color.background.accent.purple.weak',
+    value: '#EDE9FE',
+  },
+  {
+    id: 'hpe.color.background.accent.purple.strong',
+    token: 'hpe.color.background.accent.purple.strong',
+    value: '#7C3AED',
+  },
+  {
+    id: 'hpe.color.background.accent.cyan.weak',
+    token: 'hpe.color.background.accent.cyan.weak',
+    value: '#CFFAFE',
+  },
+  {
+    id: 'hpe.color.background.accent.cyan.strong',
+    token: 'hpe.color.background.accent.cyan.strong',
+    value: '#0E7490',
+  },
+  {
+    id: 'hpe.color.border.accent.blue.weak',
+    token: 'hpe.color.border.accent.blue.weak',
+    value: '#93C5FD',
+  },
+  {
+    id: 'hpe.color.border.accent.cyan.strong',
+    token: 'hpe.color.border.accent.cyan.strong',
+    value: '#06B6D4',
+  },
+  {
+    id: 'hpe.color.border.accent.purple.weak',
+    token: 'hpe.color.border.accent.purple.weak',
+    value: '#C4B5FD',
+  },
+];
+
+export const AccentSwatch = () => (
+  <TokenSwatchList
+    background={t =>
+      t.id.startsWith('hpe.color.border.') ? 'background-front' : t.value
+    }
+    border={t =>
+      t.id.startsWith('hpe.color.border.') ? t.value : undefined
+    }
+    borderSize="small"
+    tokens={accentPlaceholderTokens}
+  />
+);
+
 export const DecorativeSwatch = () => (
   <TokenSwatchList
     tokens={filterByPrefix(useColorTokens(), 'hpe.color.decorative.')}

--- a/apps/docs/src/examples/foundation/color/ColorSwatches.js
+++ b/apps/docs/src/examples/foundation/color/ColorSwatches.js
@@ -47,6 +47,7 @@ ColorSwatch.propTypes = {
 const SwatchGroup = ({ children }) => (
   <Box
     background="background-front"
+    margin={{ bottom: 'medium' }}
     pad="medium"
     gap="medium"
     width={{ max: 'xlarge', min: 'xsmall' }}

--- a/apps/docs/src/examples/foundation/color/ColorSwatches.js
+++ b/apps/docs/src/examples/foundation/color/ColorSwatches.js
@@ -175,7 +175,7 @@ const accentPlaceholderTokens = [
   },
   {
     id: 'hpe.color.border.accent.blue.weak',
-    token: 'hpe.color.border.accent.blue.weak',
+    token: 'hpe.color.border.accent.blue.strong',
     value: '#93C5FD',
   },
   {
@@ -184,8 +184,8 @@ const accentPlaceholderTokens = [
     value: '#06B6D4',
   },
   {
-    id: 'hpe.color.border.accent.purple.weak',
-    token: 'hpe.color.border.accent.purple.weak',
+    id: 'hpe.color.border.accent.purple.strong',
+    token: 'hpe.color.border.accent.purple.strong',
     value: '#C4B5FD',
   },
 ];

--- a/apps/docs/src/pages/foundation/color.mdx
+++ b/apps/docs/src/pages/foundation/color.mdx
@@ -3,6 +3,7 @@ import {
 } from 'grommet';
 
 import { 
+  AccentSwatch,
   BackgroundSwatch,
   BorderSwatch,
   DataVisSwatch,
@@ -66,6 +67,11 @@ Text colors help create hierarchy and ensure readability. Use `color.text.defaul
 Icon colors follow text hierarchy and must remain legible at small sizes. Match an icon's color emphasis with its accompanying text.
 
 <IconSwatch />
+
+### Accent
+Accent colors carry no semantic meaning and can be used for emphasis, categorization or differentiation. Use them with restraint as overuse can create visual noise and reduce their ability to draw attention. They should occupy a small proportion of any view, with the majority of the interface relying on standard background, text, and border tokens.
+
+<AccentSwatch />
 
 ### Decorative
 Decorative colors provide brand and accent without conveying status. Limit secondary decorative hues to illustration and non‑interactive ornamentation. Avoid substituting decorative colors for status; use semantic text or foreground status design tokens instead.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6282--keen-mayer-a86c8b.netlify.app/foundation/color?q=color)

#### What does this PR do?
Adds the section "Accent" and its swatches. 
TBD: Should we leave the decorative colors?


#### What are the relevant issues?
#6136 
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
