### PR TITLE
[Docs] Made the description column smaller and swapped description and value…

### DIFF
--- a/apps/docs/src/components/content/design-tokens/DesignTokensTable.js
+++ b/apps/docs/src/components/content/design-tokens/DesignTokensTable.js
@@ -89,8 +89,11 @@ const getTokenColumn = (property, header) => ({
 const descriptionColumn = {
   property: 'description',
   header: 'Description',
-  size: 'large',
-  render: datum => <Text>{datum.description || '--'}</Text>,
+  render: datum => (
+    <Box width={{ max: 'medium' }}>
+      <Text>{datum.description || '--'}</Text>
+    </Box>
+  ),
 };
 
 const formatTokenValue = value => {
@@ -153,8 +156,8 @@ export const DesignTokensTable = ({
     return [
       previewColumn,
       ...dynamicTokenColumns,
-      descriptionColumn,
       valueColumn,
+      descriptionColumn,
     ];
   }, [tokenTypeColumns]);
 


### PR DESCRIPTION

[Deploy Preview](https://deploy-preview-6286--keen-mayer-a86c8b.netlify.app/design-tokens/all-design-tokens?token=semantic%2Fcolor&tokenTypes=docs&mode=light)

#### What does this PR do?
Currently the "All tokens" page has a table that often scrolls in 2 directions. When working with some tokens it's very useful to see the value (right-most column). However the description column comes before it and has a fixed size of `large`. It almost always forces the value column to not be visible and making the window larger is no help (the page content is not full so it doesn't get wider). In many cases there is no description or a short description so you end up with a bunch of empty whitespace and still have to scroll horizontally to see the content. This makes it very difficult to use in practice. As a general rule, we try to avoid scrolling in 2 directions.

This change moves the "Output value" column left of the "Description", The value column is typically pretty short and is often what I'd rather see since the token name itself is often descriptive enough (or the only description.) I also changed the description to render as a max width rather than always being "large". See the example below of how this helps.

Before:
<img width="1161" height="670" alt="image" src="https://github.com/user-attachments/assets/be51788a-e3f6-4e9d-86e4-a814a8f0fa06" />

After:
<img width="1157" height="722" alt="image" src="https://github.com/user-attachments/assets/f3a5a157-522e-4068-8e4f-e868685820ce" />

Simpler set of tokens that have descriptions (after change):
<img width="1164" height="720" alt="image" src="https://github.com/user-attachments/assets/d7eced50-2341-41ed-883a-2c8afb74aa8b" />


#### What are the relevant issues?
Fixes #6200 

#### Where should the reviewer start?
DesignTokensTable.js

#### How should this be manually tested?
All design tokens page

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
Not necessary

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
