### PR TITLE
[Docs] - shared responsive hooks as single source of truth for breakpoint, responsive

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-grommet:
         specifier: https://github.com/grommet/eslint-plugin-grommet/tarball/stable
-        version: https://codeload.github.com/grommet/eslint-plugin-grommet/legacy.tar.gz/refs/heads/stable(eslint@9.39.1(jiti@1.21.7))
+        version: https://github.com/grommet/eslint-plugin-grommet/tarball/stable(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-import:
         specifier: ^2.26.0
         version: 2.32.0(eslint@9.39.1(jiti@1.21.7))
@@ -278,7 +278,7 @@ importers:
         version: 2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       grommet-icons:
         specifier: catalog:grommet-stable
-        version: https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       hpe-design-tokens:
         specifier: 'catalog:'
         version: 2.2.3
@@ -360,7 +360,7 @@ importers:
     dependencies:
       jscodeshift:
         specifier: ^17.3.0
-        version: 17.3.0(@babel/preset-env@7.28.5(@babel/core@7.29.0))
+        version: 17.3.0(@babel/preset-env@7.28.5(@babel/core@7.28.5))
     devDependencies:
       vitest:
         specifier: ^3.2.4
@@ -502,13 +502,13 @@ importers:
         version: 2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       grommet-icons:
         specifier: catalog:grommet-stable
-        version: https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       grommet-theme-hpe-v5:
         specifier: npm:grommet-theme-hpe@5.8.0
-        version: grommet-theme-hpe@5.8.0(grommet-icons@https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: grommet-theme-hpe@5.8.0(grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       grommet-theme-hpe-v6:
         specifier: npm:grommet-theme-hpe@6
-        version: grommet-theme-hpe@6.5.1(grommet-icons@https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: grommet-theme-hpe@6.5.1(grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       gsap:
         specifier: ^3.12.5
         version: 3.13.0
@@ -823,6 +823,9 @@ importers:
       globals:
         specifier: 'catalog:'
         version: 17.4.0
+      grommet:
+        specifier: 'catalog:'
+        version: 2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -2430,105 +2433,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2800,28 +2787,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.7':
     resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -3228,67 +3211,56 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.2':
     resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
@@ -3664,28 +3636,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.2':
     resolution: {integrity: sha512-5av6VYZZeneiYIodwzGMlnyVakpuYZryGzFIbgu1XP8wVylZxduEzup4eP8atiMDFmIm+s4wn8GySJmYqeJC0A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.2':
     resolution: {integrity: sha512-1nO/UfdCLuT/uE/7oB3EZgTeZDCIa6nL72cFEpdegnqpJVNDI6Qb8U4g/4lfVPkmHq2lvxQ0L+n+JdgaZLhrRA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.2':
     resolution: {integrity: sha512-Ksfrb0Tx310kr+TLiUOvB/I80lyZ3lSOp6cM18zmNRT/92NB4mW8oX2Jo7K4eVEI2JWyaQUAFubDSha2Q+439A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.2':
     resolution: {integrity: sha512-IzUb5RlMUY0r1A9IuJrQ7Tbts1wWb73/zXVXT8VhewbHGoNlBKE0qUhKMED6Tv4wDF+pmbtUJmKXDthytAvLmg==}
@@ -5676,8 +5644,8 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-grommet@https://codeload.github.com/grommet/eslint-plugin-grommet/legacy.tar.gz/refs/heads/stable:
-    resolution: {gitHosted: true, integrity: sha512-FM1OCLsEKshEJMlmZZVv//gTlw6NgWiG8htF8EnZlL2drzkd1y9QRUfxEYF5LH0YfvFpWtNmYvJBD1whGiVAkA==, tarball: https://codeload.github.com/grommet/eslint-plugin-grommet/legacy.tar.gz/refs/heads/stable}
+  eslint-plugin-grommet@https://github.com/grommet/eslint-plugin-grommet/tarball/stable:
+    resolution: {tarball: https://github.com/grommet/eslint-plugin-grommet/tarball/stable}
     version: 0.2.0
     engines: {node: '>=16'}
     peerDependencies:
@@ -6229,8 +6197,8 @@ packages:
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       styled-components: '>= 5.x'
 
-  grommet-icons@https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable:
-    resolution: {gitHosted: true, integrity: sha512-Jbcz+Maa5IgX9hUZZaDAu6V3NjHUD0eehcA/Y6osOeA7b/fN5tfWMQy6/yw7p8F80UPPYTusYXUkr+L/UFNIEw==, tarball: https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable}
+  grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable:
+    resolution: {tarball: https://github.com/grommet/grommet-icons/tarball/stable}
     version: 4.14.0
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -16223,7 +16191,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-grommet@https://codeload.github.com/grommet/eslint-plugin-grommet/legacy.tar.gz/refs/heads/stable(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-grommet@https://github.com/grommet/eslint-plugin-grommet/tarball/stable(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       eslint: 9.39.1(jiti@1.21.7)
       requireindex: 1.1.0
@@ -16960,16 +16928,16 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  grommet-icons@https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  grommet-theme-hpe@5.8.0(grommet-icons@https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  grommet-theme-hpe@5.8.0(grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       grommet: 2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      grommet-icons: https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      grommet-icons: https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
       styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
@@ -16981,10 +16949,10 @@ snapshots:
       react: 19.2.3
       styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  grommet-theme-hpe@6.5.1(grommet-icons@https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  grommet-theme-hpe@6.5.1(grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(grommet@2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       grommet: 2.55.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      grommet-icons: https://codeload.github.com/grommet/grommet-icons/legacy.tar.gz/refs/heads/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      grommet-icons: https://github.com/grommet/grommet-icons/tarball/stable(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       hpe-design-tokens: 1.4.1
       react: 19.2.3
       styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -18067,7 +18035,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.29.0)):
+  jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.28.5)):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
@@ -18088,7 +18056,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
 

--- a/shared/hooks/DOCUMENTATION.md
+++ b/shared/hooks/DOCUMENTATION.md
@@ -20,9 +20,249 @@ This package is part of the HPE Design System monorepo and is available as a wor
 
 ## Available Hooks
 
-- [useInert](#useInert)
-- [useLocalStorage](#useLocalStorage)
-- [useSessionStorage](#useSessionStorage)
+- [useBreakpoint](#usebreakpoint)
+- [Responsive Predicates](#responsive-predicates)
+  - [useIsMobile](#useismobile)
+  - [useIsTabletAndUp](#useistabletandup)
+  - [useIsMobileOrTablet](#useismobileortablet)
+  - [useIsDesktop](#useisdesktop)
+  - [useIsBreakpoint](#useisbreakpoint-factory)
+- [useInert](#useinert)
+- [useLocalStorage](#uselocalstorage)
+- [useSessionStorage](#usesessionstorage)
+
+### useBreakpoint
+
+A React hook that returns the current responsive breakpoint string from Grommet's ResponsiveContext. Use this as the **single source of truth for responsive breakpoint detection** across the codebase. When you need a raw string value — for example, as an object key or in a switch statement — use this directly. For boolean responsive checks, prefer the [semantic predicate hooks](#responsive-predicates), which are built on top of this hook.
+
+#### Features
+
+- **Single source of truth**: Replaces scattered `useContext(ResponsiveContext)` calls
+- **Type-safe**: Returns a string breakpoint value
+- **Clean API**: One-liner to get the current breakpoint
+- **SSR-compatible**: Works seamlessly with server-side rendering
+
+#### Usage
+
+```typescript
+import { useBreakpoint } from '@shared/hooks';
+
+function MyComponent() {
+  const breakpoint = useBreakpoint(); // 'xsmall', 'small', 'medium', 'large', or 'xlarge'
+
+  // Good use case: raw string as an object key
+  const gridAreas = responsiveGridAreas[breakpoint] ?? defaultGridAreas;
+
+  return <Grid areas={gridAreas} />;
+}
+```
+
+#### API
+
+```typescript
+const breakpoint = useBreakpoint(): string
+```
+
+**Parameters:** none
+
+**Returns:**
+
+- `breakpoint` (string): The current Grommet breakpoint ('xsmall', 'small', 'medium', 'large', or 'xlarge')
+
+---
+
+## Responsive Predicates
+
+A suite of semantic hooks for responsive design built on top of `useBreakpoint()`. These eliminate repetitive `.includes()` checks and provide clear, self-documenting code.
+
+### useIsMobile
+
+Checks if the current breakpoint is mobile-sized (xsmall or small).
+
+#### Usage
+
+```typescript
+import { useIsMobile } from '@shared/hooks';
+
+function MyComponent() {
+  const isMobile = useIsMobile();
+
+  return isMobile ? <MobileLayout /> : <DesktopLayout />;
+}
+```
+
+#### Before vs After
+
+```javascript
+// BEFORE: Repetitive and unclear
+const breakpoint = useBreakpoint();
+const isMobile = ['xsmall', 'small'].includes(breakpoint);
+
+// AFTER: Clear intent
+const isMobile = useIsMobile();
+```
+
+#### API
+
+```typescript
+const isMobile = useIsMobile(): boolean
+```
+
+---
+
+### useIsTabletAndUp
+
+Checks if the current breakpoint is tablet or larger (medium and up). Useful for "NOT mobile" logic.
+
+#### Usage
+
+```typescript
+import { useIsTabletAndUp } from '@shared/hooks';
+
+function MyLayout() {
+  const isTabletAndUp = useIsTabletAndUp();
+
+  return (
+    <Box direction={isTabletAndUp ? 'row' : 'column'}>
+      <Sidebar />
+      <Content />
+    </Box>
+  );
+}
+```
+
+#### Before vs After
+
+```javascript
+// BEFORE: Negation logic is hard to parse
+const size = useBreakpoint();
+direction={!['xsmall', 'small'].includes(size) ? 'row' : 'column'}
+
+// AFTER: Intent is crystal clear
+const isTabletAndUp = useIsTabletAndUp();
+direction={isTabletAndUp ? 'row' : 'column'}
+```
+
+#### API
+
+```typescript
+const isTabletAndUp = useIsTabletAndUp(): boolean
+```
+
+---
+
+### useIsMobileOrTablet
+
+Checks if the current breakpoint is mobile or tablet-sized (xsmall, small, or medium). Useful for distinguishing mobile/tablet from full desktop.
+
+#### Usage
+
+```typescript
+import { useIsMobileOrTablet } from '@shared/hooks';
+
+function TextComponent({ children }) {
+  const isMobileOrTablet = useIsMobileOrTablet();
+
+  return (
+    <Paragraph size={isMobileOrTablet ? 'small' : 'medium'}>
+      {children}
+    </Paragraph>
+  );
+}
+```
+
+#### Real-World Example
+
+From `Decision.js`:
+
+```javascript
+// BEFORE
+const breakpoint = useContext(ResponsiveContext);
+const textSize = ['xsmall', 'small', 'medium'].includes(breakpoint)
+  ? 'small'
+  : 'medium';
+
+// AFTER
+const isMobileOrTablet = useIsMobileOrTablet();
+const textSize = isMobileOrTablet ? 'small' : 'medium';
+```
+
+#### API
+
+```typescript
+const isMobileOrTablet = useIsMobileOrTablet(): boolean
+```
+
+---
+
+### useIsDesktop
+
+Checks if the current breakpoint is desktop-sized (large or xlarge).
+
+#### Usage
+
+```typescript
+import { useIsDesktop } from '@shared/hooks';
+
+function DesktopFeatures() {
+  const isDesktop = useIsDesktop();
+
+  return isDesktop ? <AdvancedFeatures /> : null;
+}
+```
+
+#### API
+
+```typescript
+const isDesktop = useIsDesktop(): boolean
+```
+
+---
+
+### useIsBreakpoint (Factory)
+
+Factory hook for custom breakpoint checks. Use this when the predefined semantic hooks don't cover your use case.
+
+#### Usage
+
+```typescript
+import { useIsBreakpoint } from '@shared/hooks';
+
+function MyComponent() {
+  // Check for a specific custom breakpoint set
+  const isSmallOrMedium = useIsBreakpoint(['small', 'medium']);
+  const isLargeOnly = useIsBreakpoint(['large']);
+
+  if (isSmallOrMedium) return <SmallLayout />;
+  if (isLargeOnly) return <LargeLayout />;
+}
+```
+
+#### API
+
+```typescript
+const matches = useIsBreakpoint(breakpoints: string[]): boolean
+```
+
+**Parameters:**
+
+- `breakpoints` (string[]): Array of breakpoint strings to check against
+
+**Returns:**
+
+- `matches` (boolean): True if current breakpoint is in the provided array
+
+#### Breakpoint Reference
+
+| Breakpoint | Device Type        | Use Case        |
+| ---------- | ------------------ | --------------- |
+| `xsmall`   | Extra small phone  | 320px - 375px   |
+| `small`    | Phone/small tablet | 376px - 599px   |
+| `medium`   | Tablet             | 600px - 1023px  |
+| `large`    | Desktop            | 1024px - 1439px |
+| `xlarge`   | Large desktop      | 1440px+         |
+
+---
 
 ### useInert
 
@@ -391,11 +631,15 @@ pnpm check-types
 shared/hooks/
 ├── src/
 │   ├── index.ts              # Main entry point, exports all hooks
+│   ├── useBreakpoint.ts      # Responsive breakpoint primitive hook
 │   ├── useInert.ts           # useInert hook implementation
 │   ├── useLocalStorage.ts    # useLocalStorage hook implementation
+│   ├── useResponsive.ts      # Semantic responsive predicate hooks
 │   ├── useSessionStorage.ts  # useSessionStorage hook implementation
 │   └── __tests__/
-│       └── setup.ts          # Test environment setup
+│       ├── setup.ts          # Test environment setup
+│       ├── useBreakpoint.test.tsx # Tests for useBreakpoint
+│       └── useResponsive.test.tsx # Tests for responsive predicate hooks
 ├── __tests__/
 │   ├── useInert.test.tsx          # Tests for useInert
 │   ├── useLocalStorage.test.ts   # Tests for useLocalStorage
@@ -412,7 +656,7 @@ When adding a new hook to this package:
 
 1. Create the hook file in `src/`
 2. Export it from `src/index.ts`
-3. Add comprehensive tests in `__tests__/`
+3. Add comprehensive tests in `src/__tests__/` (for `src/` hooks) or `__tests__/` (for package-level hooks)
 4. Update this documentation
 5. Run `pnpm build` to compile
 6. Run `pnpm test` to ensure all tests pass

--- a/shared/hooks/package.json
+++ b/shared/hooks/package.json
@@ -23,6 +23,7 @@
     "eslint": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",
     "globals": "catalog:",
+    "grommet": "catalog:",
     "jsdom": "^26.1.0",
     "minimatch": "^10.0.3",
     "typescript": "catalog:",

--- a/shared/hooks/src/__tests__/useBreakpoint.test.tsx
+++ b/shared/hooks/src/__tests__/useBreakpoint.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ResponsiveContext } from 'grommet';
+import { describe, expect, it } from 'vitest';
+import { useBreakpoint } from '../useBreakpoint';
+
+const wrapper =
+  (breakpoint: string) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <ResponsiveContext.Provider value={breakpoint}>
+      {children}
+    </ResponsiveContext.Provider>
+  );
+
+describe('useBreakpoint', () => {
+  it('returns the breakpoint value provided by ResponsiveContext', () => {
+    const { result } = renderHook(() => useBreakpoint(), {
+      wrapper: wrapper('medium'),
+    });
+    expect(result.current).toBe('medium');
+  });
+
+  it('reflects a small breakpoint for mobile viewports', () => {
+    const { result } = renderHook(() => useBreakpoint(), {
+      wrapper: wrapper('small'),
+    });
+    expect(result.current).toBe('small');
+    expect(['xsmall', 'small'].includes(result.current)).toBe(true);
+  });
+});

--- a/shared/hooks/src/__tests__/useResponsive.test.tsx
+++ b/shared/hooks/src/__tests__/useResponsive.test.tsx
@@ -1,0 +1,443 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ResponsiveContext } from 'grommet';
+import { describe, expect, it } from 'vitest';
+import {
+  useIsMobile,
+  useIsTabletAndUp,
+  useIsMobileOrTablet,
+  useIsDesktop,
+  useIsBreakpoint,
+} from '../useResponsive';
+
+const wrapper =
+  (breakpoint: string) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <ResponsiveContext.Provider value={breakpoint}>
+      {children}
+    </ResponsiveContext.Provider>
+  );
+
+describe('Responsive Predicates', () => {
+  describe('useIsMobile', () => {
+    it('returns true for xsmall breakpoint', () => {
+      const { result } = renderHook(() => useIsMobile(), {
+        wrapper: wrapper('xsmall'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true for small breakpoint', () => {
+      const { result } = renderHook(() => useIsMobile(), {
+        wrapper: wrapper('small'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false for medium breakpoint', () => {
+      const { result } = renderHook(() => useIsMobile(), {
+        wrapper: wrapper('medium'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false for large breakpoint', () => {
+      const { result } = renderHook(() => useIsMobile(), {
+        wrapper: wrapper('large'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false for xlarge breakpoint', () => {
+      const { result } = renderHook(() => useIsMobile(), {
+        wrapper: wrapper('xlarge'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('covers all Grommet breakpoint sizes', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+      const mobileBreakpoints = ['xsmall', 'small'];
+
+      breakpoints.forEach(bp => {
+        const { result } = renderHook(() => useIsMobile(), {
+          wrapper: wrapper(bp),
+        });
+        expect(result.current).toBe(mobileBreakpoints.includes(bp));
+      });
+    });
+  });
+
+  describe('useIsTabletAndUp', () => {
+    it('returns false for xsmall breakpoint', () => {
+      const { result } = renderHook(() => useIsTabletAndUp(), {
+        wrapper: wrapper('xsmall'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false for small breakpoint', () => {
+      const { result } = renderHook(() => useIsTabletAndUp(), {
+        wrapper: wrapper('small'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true for medium breakpoint', () => {
+      const { result } = renderHook(() => useIsTabletAndUp(), {
+        wrapper: wrapper('medium'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true for large breakpoint', () => {
+      const { result } = renderHook(() => useIsTabletAndUp(), {
+        wrapper: wrapper('large'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true for xlarge breakpoint', () => {
+      const { result } = renderHook(() => useIsTabletAndUp(), {
+        wrapper: wrapper('xlarge'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('is the logical negation of useIsMobile', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+      breakpoints.forEach(bp => {
+        const { result: isMobile } = renderHook(() => useIsMobile(), {
+          wrapper: wrapper(bp),
+        });
+        const { result: isTabletAndUp } = renderHook(() => useIsTabletAndUp(), {
+          wrapper: wrapper(bp),
+        });
+
+        expect(isTabletAndUp.current).toBe(!isMobile.current);
+      });
+    });
+
+    it('covers all Grommet breakpoint sizes', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+      const tabletAndUpBreakpoints = ['medium', 'large', 'xlarge'];
+
+      breakpoints.forEach(bp => {
+        const { result } = renderHook(() => useIsTabletAndUp(), {
+          wrapper: wrapper(bp),
+        });
+        expect(result.current).toBe(tabletAndUpBreakpoints.includes(bp));
+      });
+    });
+  });
+
+  describe('useIsMobileOrTablet', () => {
+    it('returns true for xsmall breakpoint', () => {
+      const { result } = renderHook(() => useIsMobileOrTablet(), {
+        wrapper: wrapper('xsmall'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true for small breakpoint', () => {
+      const { result } = renderHook(() => useIsMobileOrTablet(), {
+        wrapper: wrapper('small'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true for medium breakpoint', () => {
+      const { result } = renderHook(() => useIsMobileOrTablet(), {
+        wrapper: wrapper('medium'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false for large breakpoint', () => {
+      const { result } = renderHook(() => useIsMobileOrTablet(), {
+        wrapper: wrapper('large'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false for xlarge breakpoint', () => {
+      const { result } = renderHook(() => useIsMobileOrTablet(), {
+        wrapper: wrapper('xlarge'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('covers all Grommet breakpoint sizes', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+      const mobileOrTabletBreakpoints = ['xsmall', 'small', 'medium'];
+
+      breakpoints.forEach(bp => {
+        const { result } = renderHook(() => useIsMobileOrTablet(), {
+          wrapper: wrapper(bp),
+        });
+        expect(result.current).toBe(mobileOrTabletBreakpoints.includes(bp));
+      });
+    });
+  });
+
+  describe('useIsDesktop', () => {
+    it('returns false for xsmall breakpoint', () => {
+      const { result } = renderHook(() => useIsDesktop(), {
+        wrapper: wrapper('xsmall'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false for small breakpoint', () => {
+      const { result } = renderHook(() => useIsDesktop(), {
+        wrapper: wrapper('small'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false for medium breakpoint', () => {
+      const { result } = renderHook(() => useIsDesktop(), {
+        wrapper: wrapper('medium'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true for large breakpoint', () => {
+      const { result } = renderHook(() => useIsDesktop(), {
+        wrapper: wrapper('large'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true for xlarge breakpoint', () => {
+      const { result } = renderHook(() => useIsDesktop(), {
+        wrapper: wrapper('xlarge'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('covers all Grommet breakpoint sizes', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+      const desktopBreakpoints = ['large', 'xlarge'];
+
+      breakpoints.forEach(bp => {
+        const { result } = renderHook(() => useIsDesktop(), {
+          wrapper: wrapper(bp),
+        });
+        expect(result.current).toBe(desktopBreakpoints.includes(bp));
+      });
+    });
+  });
+
+  describe('useIsBreakpoint (factory)', () => {
+    it('returns true when breakpoint is in provided array', () => {
+      const { result } = renderHook(
+        () => useIsBreakpoint(['small', 'medium']),
+        {
+          wrapper: wrapper('small'),
+        },
+      );
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when breakpoint is not in provided array', () => {
+      const { result } = renderHook(
+        () => useIsBreakpoint(['large', 'xlarge']),
+        {
+          wrapper: wrapper('small'),
+        },
+      );
+      expect(result.current).toBe(false);
+    });
+
+    it('works with custom breakpoint combinations', () => {
+      const { result } = renderHook(
+        () => useIsBreakpoint(['xsmall', 'small', 'medium']),
+        {
+          wrapper: wrapper('medium'),
+        },
+      );
+      expect(result.current).toBe(true);
+    });
+
+    it('handles empty array (always false)', () => {
+      const { result } = renderHook(() => useIsBreakpoint([]), {
+        wrapper: wrapper('small'),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it('handles single-element array', () => {
+      const { result: resultSmall } = renderHook(
+        () => useIsBreakpoint(['small']),
+        {
+          wrapper: wrapper('small'),
+        },
+      );
+      expect(resultSmall.current).toBe(true);
+
+      const { result: resultMedium } = renderHook(
+        () => useIsBreakpoint(['small']),
+        {
+          wrapper: wrapper('medium'),
+        },
+      );
+      expect(resultMedium.current).toBe(false);
+    });
+
+    it('works as wrapper for semantic predicates', () => {
+      // Verify the factory can replicate all semantic hooks
+      const testCases = [
+        {
+          name: 'useIsMobile equivalent',
+          breakpoints: ['xsmall', 'small'],
+          testPoints: [
+            { bp: 'xsmall', expected: true },
+            { bp: 'medium', expected: false },
+          ],
+        },
+        {
+          name: 'useIsDesktop equivalent',
+          breakpoints: ['large', 'xlarge'],
+          testPoints: [
+            { bp: 'large', expected: true },
+            { bp: 'small', expected: false },
+          ],
+        },
+        {
+          name: 'useIsMobileOrTablet equivalent',
+          breakpoints: ['xsmall', 'small', 'medium'],
+          testPoints: [
+            { bp: 'medium', expected: true },
+            { bp: 'large', expected: false },
+          ],
+        },
+      ];
+
+      testCases.forEach(({ name, breakpoints, testPoints }) => {
+        testPoints.forEach(({ bp, expected }) => {
+          const { result } = renderHook(() => useIsBreakpoint(breakpoints), {
+            wrapper: wrapper(bp),
+          });
+          expect(result.current).toBe(expected);
+        });
+      });
+    });
+  });
+
+  describe('Comprehensive Breakpoint Matrix', () => {
+    it('all hooks cover all breakpoint sizes consistently', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+      const expectations: Record<string, Record<string, boolean>> = {
+        useIsMobile: {
+          xsmall: true,
+          small: true,
+          medium: false,
+          large: false,
+          xlarge: false,
+        },
+        useIsTabletAndUp: {
+          xsmall: false,
+          small: false,
+          medium: true,
+          large: true,
+          xlarge: true,
+        },
+        useIsMobileOrTablet: {
+          xsmall: true,
+          small: true,
+          medium: true,
+          large: false,
+          xlarge: false,
+        },
+        useIsDesktop: {
+          xsmall: false,
+          small: false,
+          medium: false,
+          large: true,
+          xlarge: true,
+        },
+      };
+
+      breakpoints.forEach(bp => {
+        const hookResults = {
+          useIsMobile: renderHook(() => useIsMobile(), {
+            wrapper: wrapper(bp),
+          }).result.current,
+          useIsTabletAndUp: renderHook(() => useIsTabletAndUp(), {
+            wrapper: wrapper(bp),
+          }).result.current,
+          useIsMobileOrTablet: renderHook(() => useIsMobileOrTablet(), {
+            wrapper: wrapper(bp),
+          }).result.current,
+          useIsDesktop: renderHook(() => useIsDesktop(), {
+            wrapper: wrapper(bp),
+          }).result.current,
+        };
+
+        Object.entries(expectations).forEach(([hookName, expected]) => {
+          expect(hookResults[hookName as keyof typeof hookResults]).toBe(
+            expected[bp],
+          );
+        });
+      });
+    });
+
+    it('hooks are mutually exclusive where appropriate', () => {
+      const breakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+      breakpoints.forEach(bp => {
+        const isMobile = renderHook(() => useIsMobile(), {
+          wrapper: wrapper(bp),
+        }).result.current;
+        const isDesktop = renderHook(() => useIsDesktop(), {
+          wrapper: wrapper(bp),
+        }).result.current;
+
+        // Mobile and desktop should never both be true
+        expect(isMobile && isDesktop).toBe(false);
+
+        // Together they should cover all but tablet edge cases
+        const isMobileOrTablet = renderHook(() => useIsMobileOrTablet(), {
+          wrapper: wrapper(bp),
+        }).result.current;
+
+        // For all breakpoints, one of these should be true
+        expect(
+          isMobile || isDesktop || (bp === 'medium' && isMobileOrTablet),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('Edge Cases & Error Handling', () => {
+    it('handles undefined context gracefully (should not throw)', () => {
+      // This tests the hook doesn't break if ResponsiveContext is somehow undefined
+      // In practice this shouldn't happen, but good to verify
+      const { result } = renderHook(() => useIsBreakpoint(['small']), {
+        wrapper: wrapper('small'),
+      });
+      expect(result.current).toBeDefined();
+    });
+
+    it('useIsBreakpoint with all breakpoints returns true', () => {
+      const allBreakpoints = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+      const { result } = renderHook(() => useIsBreakpoint(allBreakpoints), {
+        wrapper: wrapper('medium'),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it('useIsBreakpoint with opposite breakpoints returns false', () => {
+      const { result } = renderHook(
+        () => useIsBreakpoint(['xsmall', 'small']),
+        {
+          wrapper: wrapper('large'),
+        },
+      );
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/shared/hooks/src/index.ts
+++ b/shared/hooks/src/index.ts
@@ -1,4 +1,12 @@
 // Main entry point for @shared/hooks package
+export { useBreakpoint } from './useBreakpoint';
+export {
+  useIsMobile,
+  useIsTabletAndUp,
+  useIsMobileOrTablet,
+  useIsDesktop,
+  useIsBreakpoint,
+} from './useResponsive';
 export { useInert } from './useInert';
 export { useLocalStorage } from './useLocalStorage';
 export { useSessionStorage } from './useSessionStorage';

--- a/shared/hooks/src/useBreakpoint.ts
+++ b/shared/hooks/src/useBreakpoint.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useContext } from 'react';
+import { ResponsiveContext } from 'grommet';
+
+/**
+ * Returns the current responsive breakpoint string from Grommet's
+ * ResponsiveContext ('xsmall', 'small', 'medium', 'large', or 'xlarge').
+ *
+ * Use this when you need the raw breakpoint string — for example, as an
+ * object key or a switch statement. For boolean responsive checks, prefer
+ * the semantic hooks in useResponsive (useIsMobile, useIsTabletAndUp, etc.).
+ *
+ * @example
+ * const breakpoint = useBreakpoint();
+ * const gridAreas = responsiveGridAreas[breakpoint] ?? defaultGridAreas;
+ */
+export const useBreakpoint = (): string => useContext(ResponsiveContext);

--- a/shared/hooks/src/useResponsive.ts
+++ b/shared/hooks/src/useResponsive.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useBreakpoint } from './useBreakpoint';
+
+/**
+ * Checks if the current breakpoint is mobile-sized (xsmall or small).
+ *
+ * @example
+ * const isMobile = useIsMobile();
+ * return isMobile ? <MobileLayout /> : <DesktopLayout />;
+ */
+export const useIsMobile = (): boolean =>
+  ['xsmall', 'small'].includes(useBreakpoint());
+
+/**
+ * Checks if the current breakpoint is tablet or larger (medium and up).
+ * Negation of useIsMobile() - useful for "NOT mobile" logic.
+ *
+ * @example
+ * const isTabletAndUp = useIsTabletAndUp();
+ * direction={isTabletAndUp ? 'row' : 'column'}
+ */
+export const useIsTabletAndUp = (): boolean =>
+  !['xsmall', 'small'].includes(useBreakpoint());
+
+/**
+ * Checks if the current breakpoint is mobile or tablet-sized (xsmall, small, or medium).
+ * Useful for distinguishing mobile/tablet from full desktop.
+ *
+ * @example
+ * const isMobileOrTablet = useIsMobileOrTablet();
+ * if (isMobileOrTablet) adjustSpacing();
+ */
+export const useIsMobileOrTablet = (): boolean =>
+  ['xsmall', 'small', 'medium'].includes(useBreakpoint());
+
+/**
+ * Checks if the current breakpoint is desktop-sized (large or xlarge).
+ *
+ * @example
+ * const isDesktop = useIsDesktop();
+ * if (isDesktop) showDesktopFeatures();
+ */
+export const useIsDesktop = (): boolean =>
+  ['large', 'xlarge'].includes(useBreakpoint());
+
+/**
+ * Factory hook for custom breakpoint checks.
+ * Use this when the predefined hooks don't cover your use case.
+ *
+ * @param breakpoints - Array of breakpoint strings to check against
+ * @returns true if current breakpoint is in the provided array
+ *
+ * @example
+ * // Check for a specific custom breakpoint set
+ * const isSmallOrMedium = useIsBreakpoint(['small', 'medium']);
+ */
+export const useIsBreakpoint = (breakpoints: string[]): boolean =>
+  breakpoints.includes(useBreakpoint());


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR adds a reusable responsive hook layer in the shared hooks package so responsive breakpoint logic is centralized, semantic, and test-covered.  
Scope is intentionally limited to hook implementation, exports, tests, and documentation.  
Component-level adoption is out of scope and will be handled in follow-up PRs.

**What This PR Adds**
- Base breakpoint hook:
  - useBreakpoint.ts
- Semantic responsive predicate hooks:
  - useResponsive.ts
- Package exports:
  - index.ts
- Hook test coverage:
  - useBreakpoint.test.tsx
  - useResponsive.test.tsx
- Documentation updates:
  - DOCUMENTATION.md

**New Hook API**
- useBreakpoint: returns current responsive breakpoint string from Grommet ResponsiveContext
- useIsMobile: true for xsmall/small
- useIsTabletAndUp: true for medium/large/xlarge
- useIsMobileOrTablet: true for xsmall/small/medium
- useIsDesktop: true for large/xlarge
- useIsBreakpoint: generic predicate for custom breakpoint sets

#### What are the relevant issues?
#6295 

#### Where should the reviewer start?

#### How should this be manually tested?
- Added focused tests for primitive and predicate hooks
- Verified all shared hooks tests pass

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
