### PR TITLE
Fix menu example links

### DIFF
--- a/apps/docs/src/components/content/HighlightPhrase.js
+++ b/apps/docs/src/components/content/HighlightPhrase.js
@@ -58,9 +58,7 @@ const formatMatchedPhrase = (matchObj, highlightProps) => {
       nextIndex = match.index + match[0].length;
       nextPhrase.push(
         <HighlightedText key={index} fade={fade} {...rest}>
-          &nbsp;
           {match.input.slice(match.index, match.index + match[0].length)}
-          &nbsp;
         </HighlightedText>,
       );
       if (index + 1 === matchObj.length) {

--- a/apps/docs/src/components/content/HighlightPhrase.js
+++ b/apps/docs/src/components/content/HighlightPhrase.js
@@ -58,7 +58,9 @@ const formatMatchedPhrase = (matchObj, highlightProps) => {
       nextIndex = match.index + match[0].length;
       nextPhrase.push(
         <HighlightedText key={index} fade={fade} {...rest}>
+          &nbsp;
           {match.input.slice(match.index, match.index + match[0].length)}
+          &nbsp;
         </HighlightedText>,
       );
       if (index + 1 === matchObj.length) {

--- a/apps/docs/src/pages/components/menu.mdx
+++ b/apps/docs/src/pages/components/menu.mdx
@@ -40,7 +40,7 @@ Use Menu within the header to organize and present application-level navigation 
 
 <Example
   docs="https://v2.grommet.io/menu?theme=hpe#props"
-  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/menu/MenuHeaderExample.js"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/menu/MenuHeaderExample.js"
   height={{ min: 'small' }}
   width="100%"
 >
@@ -54,11 +54,11 @@ In this example, actions are grouped into executing and configuration categories
 
 <Example
   code={[
-    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/menu/MenuBatchActionsExample.js',
-    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/FilterControls/FilterControls.js',
-    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/data/mockData/servers.json',
+    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/menu/MenuBatchActionsExample.js',
+    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/templates/FilterControls/FilterControls.js',
+    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/data/mockData/servers.json',
   ]}
-  github="https://github.com/grommet/hpe-design-system/blob/master/aries-site/src/examples/components/menu/MenuBatchActionsExample.js"
+  github="https://github.com/grommet/hpe-design-system/blob/master/apps/docs/src/examples/components/menu/MenuBatchActionsExample.js"
   height={{ min: 'small' }}
 >
   <MenuBatchActionsExample />
@@ -73,10 +73,10 @@ For more details on grouping and ordering, see [Organizing menu items](#organizi
 
 <Example
   code={[
-    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/components/menu/MenuRecordActionsExample.js',
-    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/data/mockData/serverGroups.json',
+    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/menu/MenuRecordActionsExample.js',
+    'https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/data/mockData/serverGroups.json',
   ]}
-  github="https://github.com/grommet/hpe-design-system/blob/master/aries-site/src/examples/components/menu/MenuRecordActionsExample.js"
+  github="https://github.com/grommet/hpe-design-system/blob/master/apps/docs/src/examples/components/menu/MenuRecordActionsExample.js"
   height={{ min: 'medium' }}
 >
   <MenuRecordActionsExample />

--- a/apps/docs/src/pages/templates/ascending-navigation.mdx
+++ b/apps/docs/src/pages/templates/ascending-navigation.mdx
@@ -8,7 +8,7 @@ import { Text } from 'grommet';
 
 <Example 
   pad='small'
-  code='https://raw.githubusercontent.com/grommet/hpe-design-system/master/aries-site/src/examples/templates/ascending-navigation/AscendingNavigationCodeExample.js'
+  code='https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/templates/ascending-navigation/AscendingNavigationCodeExample.js'
 >
   <AscendingNavigationExample />
 </Example>


### PR DESCRIPTION

[Deploy Preview](https://deploy-preview-6302--keen-mayer-a86c8b.netlify.app/components/menu)

#### What does this PR do?
Fix the menu example source code links and an ascending navigation source link. They still had the old `aries-site` in the path.

#### What are the relevant issues?

#### Where should the reviewer start?
menu.mdx

#### How should this be manually tested?
Menu component page

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
