### PR TITLE
[Docs - Knowledge] Skills - Add derive-prop-types skill, and tighten up extract yaml agent

### DIFF
--- a/knowledge/capabilities/docs-refactor/agents/extract-yaml.agent.md
+++ b/knowledge/capabilities/docs-refactor/agents/extract-yaml.agent.md
@@ -20,6 +20,7 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
    - `knowledge/core/data/types.ts` — the `ComponentDefinition` interface (authoritative schema)
    - `knowledge/core/data/COMPONENT_EXAMPLE.yaml` — structural reference showing the expected YAML shape
    - `apps/docs/src/examples/components/[component-name]/` — list the directory to identify all existing example files (these become `path:` references in the `examples` array)
+   - **The component's TypeScript definition** — the authoritative source for `props`. Resolve it in order: grommet at `node_modules/grommet/components/[Name]/index.d.ts` (the exported `[Name]Props` interface), then `@shared/aries-core` types, then a local app component's exported props `interface`/`type`. See `knowledge/core/skills/derive-prop-types.skill.md`.
 
 4. **Extract and map content** — translate every piece of content from the MDX into the corresponding field in the `ComponentDefinition` schema:
    - `description` — single precise sentence from the component's intro prose
@@ -33,7 +34,7 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
    - `contentGuidelines` — writing rules for text placed inside the component
    - `dosAndDonts` — paired do/dont entries, each with a `do`, `dont`, and optional `reason`. If the source MDX has no do/don't content, infer representative pairs from your knowledge of the component.
    - `accessibility` — keyboard interactions, ARIA attributes, announcements, WCAG criteria. Also look for `<AccessibilitySection title="...">` in the MDX and capture the exact `title` value as `accessibility.wcagDataFile`. Components that share their WCAG data file with a related component (e.g., Search using `TextInput`) will have a title that differs from their own component name — preserve it exactly.
-   - `props` — name, type, required, description, defaultValue for each prop
+   - `props` — **derive strictly from the component's TypeScript definition** (the `[Name]Props` interface or equivalent type), following `knowledge/core/skills/derive-prop-types.skill.md`. Emit one entry per member of that type with `name` (exact key), `type` (resolved TypeScript type), `required` (`true` only when the member is non-optional), `description` (single sentence), and `defaultValue` (only when explicit). Every documented prop MUST exist in the type; never add a prop that is not in the definition, and never carry forward a prop from the MDX, examples, or prior knowledge that the type does not declare. If no TypeScript definition can be located, emit no props and log the gap rather than inventing them.
    - `examples` — **do NOT copy raw code**; reference existing example files as relative paths:
      ```yaml
      examples:
@@ -73,6 +74,7 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
 
 - **Never copy raw React/JSX code into the YAML.** Example files must always be `path:` references pointing to files in `apps/docs/src/examples/components/`.
 - **Never fabricate information** to fill schema gaps. If a required field has no corresponding content in the MDX, omit it so the gap is visible, and note it in the DEPRECATED file. Exception: the structural/visual fields `anatomy`, `dosAndDonts`, and `usage.whenToUse` may be inferred from your knowledge of the component when absent from the source — log each inferred field in the TODO file for human review.
+- **Props are derived from the TypeScript definition, not authored by hand.** A prop may appear in the `props` array only if it exists in the component's resolved `[Name]Props` interface (or equivalent type). Never add, rename, alias, or merge props, and never include a prop that the type does not declare — even if it appears in the source MDX or example code. When the definition and the MDX disagree, the definition wins; drop the unbacked prop and log it for review. Follow `knowledge/core/skills/derive-prop-types.skill.md`.
 - **Variants are not states.** Disabled, loading, hover, focus, error, and similar transient conditions belong in `behaviors`, never in `variants`.
 - **`whenToUse` items must be task-oriented** — they describe the user's goal (e.g., "Submitting a form"), not a design rationale (e.g., "When there are 5 or more options").
 - **`description` must be a single sentence.** No markdown formatting inside the value.

--- a/knowledge/capabilities/docs-refactor/agents/extract-yaml.agent.md
+++ b/knowledge/capabilities/docs-refactor/agents/extract-yaml.agent.md
@@ -1,7 +1,7 @@
 ---
 name: extract-yaml-agent
 description: "Use when: reverse-engineering a component's existing MDX documentation into a structured YAML file. Triggered at the start of the per-component refactor workflow. Extracts MDX content into the ComponentDefinition schema, validates the YAML inline, stubs a DEPRECATED file for unmappable content, and renames the original MDX to .mdx.bak. Part of the docs refactor workflow described in knowledge/capabilities/docs-refactor/plan.md and knowledge/capabilities/docs-refactor/docs/execution.skill.md."
-argument-hint: "Component name (e.g. checkbox, menu, select). Must match the MDX file name in apps/docs/src/pages/components/."
+argument-hint: 'Component name (e.g. checkbox, menu, select). Must match the MDX file name in apps/docs/src/pages/components/.'
 tools: [read, search, edit]
 ---
 
@@ -20,7 +20,7 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
    - `knowledge/core/data/types.ts` — the `ComponentDefinition` interface (authoritative schema)
    - `knowledge/core/data/COMPONENT_EXAMPLE.yaml` — structural reference showing the expected YAML shape
    - `apps/docs/src/examples/components/[component-name]/` — list the directory to identify all existing example files (these become `path:` references in the `examples` array)
-   - **The component's TypeScript definition** — the authoritative source for `props`. Resolve it in order: grommet at `node_modules/grommet/components/[Name]/index.d.ts` (the exported `[Name]Props` interface), then `@shared/aries-core` types, then a local app component's exported props `interface`/`type`. See `knowledge/core/skills/derive-prop-types.skill.md`.
+   - **The component's TypeScript definition** — the authoritative source for `props`. Resolve it from grommet at `node_modules/grommet/components/[Name]/index.d.ts` (the exported `[Name]Props` interface). See `knowledge/core/skills/derive-prop-types.skill.md`.
 
 4. **Extract and map content** — translate every piece of content from the MDX into the corresponding field in the `ComponentDefinition` schema:
    - `description` — single precise sentence from the component's intro prose
@@ -34,11 +34,11 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
    - `contentGuidelines` — writing rules for text placed inside the component
    - `dosAndDonts` — paired do/dont entries, each with a `do`, `dont`, and optional `reason`. If the source MDX has no do/don't content, infer representative pairs from your knowledge of the component.
    - `accessibility` — keyboard interactions, ARIA attributes, announcements, WCAG criteria. Also look for `<AccessibilitySection title="...">` in the MDX and capture the exact `title` value as `accessibility.wcagDataFile`. Components that share their WCAG data file with a related component (e.g., Search using `TextInput`) will have a title that differs from their own component name — preserve it exactly.
-   - `props` — **derive strictly from the component's TypeScript definition** (the `[Name]Props` interface or equivalent type), following `knowledge/core/skills/derive-prop-types.skill.md`. Emit one entry per member of that type with `name` (exact key), `type` (resolved TypeScript type), `required` (`true` only when the member is non-optional), `description` (single sentence), and `defaultValue` (only when explicit). Every documented prop MUST exist in the type; never add a prop that is not in the definition, and never carry forward a prop from the MDX, examples, or prior knowledge that the type does not declare. If no TypeScript definition can be located, emit no props and log the gap rather than inventing them.
+   - `props` — **derive strictly from the component's TypeScript definition** (the `[Name]Props` interface or equivalent type), following `knowledge/core/skills/derive-prop-types.skill.md`. Emit one entry per member of that type with `name` (exact key), `type` (resolved TypeScript type), `required` (`true` only when the member is non-optional), `description` (single sentence), and `defaultValue` (only when explicit). Every documented prop MUST exist in the type; never add a prop that is not in the definition, and never carry forward a prop from the MDX, examples, or prior knowledge that the type does not declare. If no TypeScript definition can be located, set `props: []` (the schema requires the field) and log the gap rather than inventing them.
    - `examples` — **do NOT copy raw code**; reference existing example files as relative paths:
      ```yaml
      examples:
-       - description: "Primary button used to submit a form"
+       - description: 'Primary button used to submit a form'
          path: apps/docs/src/examples/components/button/ButtonSubmittingFormExample.js
      ```
 
@@ -62,11 +62,12 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
 9. **Log inferred fields in the TODO file** — if any fields were inferred rather than extracted from the source MDX (`anatomy`, `usage.whenToUse`, `dosAndDonts`), create or append to `apps/docs/todos/TODO-[component-name].md` with a section titled `## Inferred fields — verify before merging`. List each inferred field and recommend verifying the content against the Figma file and grommet source before the PR is merged. If nothing was inferred, skip this step.
 
 10. **Stub the DEPRECATED file** — create `apps/docs/todos/DEPRECATED-[component-name].md` with a section for each piece of unmappable content. For each entry include:
-   - The original section name or content excerpt
-   - Why it didn't map to the schema
-   - Whether it may have value worth preserving and where it could potentially live
 
-   If nothing was unmappable, create the file with a brief note confirming the review was done and no content was dropped.
+- The original section name or content excerpt
+- Why it didn't map to the schema
+- Whether it may have value worth preserving and where it could potentially live
+
+If nothing was unmappable, create the file with a brief note confirming the review was done and no content was dropped.
 
 11. **Rename the original MDX to `.bak`** — rename `apps/docs/src/pages/components/[component-name].mdx` to `apps/docs/src/pages/components/[component-name].mdx.bak`. This protects Next.js page-level imports and frontmatter so `generate-mdx-agent` can merge them back later.
 

--- a/knowledge/core/skills/derive-prop-types.skill.md
+++ b/knowledge/core/skills/derive-prop-types.skill.md
@@ -50,7 +50,7 @@ outside the type is ever added.
    `knowledge/core/data/types.ts`.
 5. Record any member whose type cannot be resolved in the gap list rather than guessing.
 
-## Failure handling
+## Failure Handling
 
 - If the grommet TypeScript definition cannot be found, emit an empty `props` array (`props: []`) and
   add a blocking gap note naming the paths searched for human review.

--- a/knowledge/core/skills/derive-prop-types.skill.md
+++ b/knowledge/core/skills/derive-prop-types.skill.md
@@ -3,7 +3,7 @@ name: derive-prop-types
 description: Derives a component's documented props strictly from its TypeScript definition, with no invented or extra props.
 inputs:
   - Component name
-  - Component's TypeScript definition (grommet `index.d.ts` `<Name>Props` interface or `@shared/aries-core` types)
+  - Component's TypeScript definition (grommet `index.d.ts` `<Name>Props` interface)
   - Target schema reference (`ComponentProp` in `knowledge/core/data/types.ts`)
 outputs:
   - `props` array whose entries map one-to-one to the TypeScript definition
@@ -17,25 +17,22 @@ Produce the `props` array for a component definition so that it is an exact refl
 the component's TypeScript type — every documented prop comes from the type, and no prop
 outside the type is ever added.
 
-## Authoritative source
+## Inputs
 
-The component's TypeScript definition is the **single source of truth** for props. Resolve it
-in this order and stop at the first match:
+- Component name
+- The component's grommet TypeScript definition (`<Name>Props` interface)
+- Target schema reference (`ComponentProp` in `knowledge/core/data/types.ts`)
 
-1. **Grommet components** — `node_modules/grommet/components/<Name>/index.d.ts`, the exported
-   `<Name>Props` interface (e.g. `ButtonProps` in `grommet/components/Button/index.d.ts`).
-2. **`@shared/aries-core` components** — the component's `.d.ts` / `.tsx` type or interface
-   under `shared/aries-core/`.
-3. **Local app components** — the exported props `interface`/`type` co-located with the
-   component source.
+## Outputs
 
-If no TypeScript definition can be located, do **not** infer props from prose, examples, or
-prior knowledge. Emit an empty `props` array (or omit the field), and record the gap for human
-review.
+- `props` array whose entries map one-to-one to the TypeScript definition
+- Gap list of props that could not be resolved to a type and need human review
 
 ## Procedure
 
-1. Resolve the authoritative TypeScript definition using the order above.
+1. Resolve the grommet TypeScript definition — the **single source of truth** for props — at
+   `node_modules/grommet/components/<Name>/index.d.ts`, the exported `<Name>Props` interface
+   (e.g. `ButtonProps` in `node_modules/grommet/components/Button/index.d.ts`).
 2. Read the exported props interface/type in full, including any extended or imported
    member types (e.g. `A11yTitleType`, `MarginType`) so each prop's type is accurate.
 3. For each member of the interface, emit one `ComponentProp` entry:
@@ -62,13 +59,12 @@ review.
 - **Never rename, alias, or merge props.** Property names must match the type exactly.
 - **Do not fabricate types, defaults, or required flags.** Optionality and types come from
   the definition, not assumption.
-- **Prefer omission over invention.** When the definition is unavailable or a member is
-  unresolved, leave it out and log the gap.
+- **Prefer explicit gaps over invention.** When the definition is unavailable, emit `props: []` and log the gap. When a member's type cannot be resolved, keep the prop and flag it in the gap list.
 
 ## Failure handling
 
-- If the TypeScript definition cannot be found, emit no props and add a blocking gap note
-  naming the paths searched.
+- If the grommet TypeScript definition cannot be found, emit an empty `props` array (`props: []`) and
+  add a blocking gap note naming the paths searched for human review.
 - If a member's type references an unresolved imported type, keep the prop but mark its type
   for review in the gap list.
 - If existing documentation lists a prop absent from the definition, drop it from `props` and
@@ -76,6 +72,6 @@ review.
 
 ## Reuse Constraints
 
-- Requires read access to the resolved TypeScript definition.
+- Requires read access to the grommet TypeScript definition.
 - Must remain deterministic for the same definition input.
-- Should not embed capability-specific paths beyond the resolution order above.
+- Should not embed capability-specific paths beyond the grommet resolution path above.

--- a/knowledge/core/skills/derive-prop-types.skill.md
+++ b/knowledge/core/skills/derive-prop-types.skill.md
@@ -1,0 +1,81 @@
+---
+name: derive-prop-types
+description: Derives a component's documented props strictly from its TypeScript definition, with no invented or extra props.
+inputs:
+  - Component name
+  - Component's TypeScript definition (grommet `index.d.ts` `<Name>Props` interface or `@shared/aries-core` types)
+  - Target schema reference (`ComponentProp` in `knowledge/core/data/types.ts`)
+outputs:
+  - `props` array whose entries map one-to-one to the TypeScript definition
+  - List of props that could not be resolved to a type and need human review
+version: 1.0.0
+---
+
+## Purpose
+
+Produce the `props` array for a component definition so that it is an exact reflection of
+the component's TypeScript type — every documented prop comes from the type, and no prop
+outside the type is ever added.
+
+## Authoritative source
+
+The component's TypeScript definition is the **single source of truth** for props. Resolve it
+in this order and stop at the first match:
+
+1. **Grommet components** — `node_modules/grommet/components/<Name>/index.d.ts`, the exported
+   `<Name>Props` interface (e.g. `ButtonProps` in `grommet/components/Button/index.d.ts`).
+2. **`@shared/aries-core` components** — the component's `.d.ts` / `.tsx` type or interface
+   under `shared/aries-core/`.
+3. **Local app components** — the exported props `interface`/`type` co-located with the
+   component source.
+
+If no TypeScript definition can be located, do **not** infer props from prose, examples, or
+prior knowledge. Emit an empty `props` array (or omit the field), and record the gap for human
+review.
+
+## Procedure
+
+1. Resolve the authoritative TypeScript definition using the order above.
+2. Read the exported props interface/type in full, including any extended or imported
+   member types (e.g. `A11yTitleType`, `MarginType`) so each prop's type is accurate.
+3. For each member of the interface, emit one `ComponentProp` entry:
+   - `name` — the exact property key from the type.
+   - `type` — the resolved TypeScript type. Normalize union literals to a readable form
+     (e.g. `'start' | 'center' | 'end'`); preserve `boolean`, `string`, `number`, and
+     object/function shapes faithfully.
+   - `required` — `true` only when the member is non-optional (no `?`); otherwise `false`.
+   - `description` — a single concise sentence describing the prop. Reuse description text
+     from the source MDX when it matches the same prop; otherwise summarize from the type
+     and JSDoc. Never invent behavior the type does not support.
+   - `defaultValue` — include only when the default is explicit in the type, JSDoc, or
+     existing documentation; otherwise omit.
+4. Validate each entry against the `ComponentProp` interface in
+   `knowledge/core/data/types.ts`.
+5. Record any member whose type cannot be resolved in the gap list rather than guessing.
+
+## Hard constraints
+
+- **Derive every prop from the TypeScript definition.** A prop may appear in `props` only if
+  it exists in the resolved interface/type.
+- **Never add props that are not in the definition.** Do not introduce props from memory,
+  from other components, from example code, or from prose in the MDX.
+- **Never rename, alias, or merge props.** Property names must match the type exactly.
+- **Do not fabricate types, defaults, or required flags.** Optionality and types come from
+  the definition, not assumption.
+- **Prefer omission over invention.** When the definition is unavailable or a member is
+  unresolved, leave it out and log the gap.
+
+## Failure handling
+
+- If the TypeScript definition cannot be found, emit no props and add a blocking gap note
+  naming the paths searched.
+- If a member's type references an unresolved imported type, keep the prop but mark its type
+  for review in the gap list.
+- If existing documentation lists a prop absent from the definition, drop it from `props` and
+  log it as a candidate for removal/verification — do not carry it forward.
+
+## Reuse constraints
+
+- Requires read access to the resolved TypeScript definition.
+- Must remain deterministic for the same definition input.
+- Should not embed capability-specific paths beyond the resolution order above.

--- a/knowledge/core/skills/derive-prop-types.skill.md
+++ b/knowledge/core/skills/derive-prop-types.skill.md
@@ -50,17 +50,6 @@ outside the type is ever added.
    `knowledge/core/data/types.ts`.
 5. Record any member whose type cannot be resolved in the gap list rather than guessing.
 
-## Hard constraints
-
-- **Derive every prop from the TypeScript definition.** A prop may appear in `props` only if
-  it exists in the resolved interface/type.
-- **Never add props that are not in the definition.** Do not introduce props from memory,
-  from other components, from example code, or from prose in the MDX.
-- **Never rename, alias, or merge props.** Property names must match the type exactly.
-- **Do not fabricate types, defaults, or required flags.** Optionality and types come from
-  the definition, not assumption.
-- **Prefer explicit gaps over invention.** When the definition is unavailable, emit `props: []` and log the gap. When a member's type cannot be resolved, keep the prop and flag it in the gap list.
-
 ## Failure handling
 
 - If the grommet TypeScript definition cannot be found, emit an empty `props` array (`props: []`) and

--- a/knowledge/core/skills/derive-prop-types.skill.md
+++ b/knowledge/core/skills/derive-prop-types.skill.md
@@ -74,7 +74,7 @@ review.
 - If existing documentation lists a prop absent from the definition, drop it from `props` and
   log it as a candidate for removal/verification — do not carry it forward.
 
-## Reuse constraints
+## Reuse Constraints
 
 - Requires read access to the resolved TypeScript definition.
 - Must remain deterministic for the same definition input.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- tighten up the `extract-yaml` agent instructions 
- create a `derive-prop-types` skill that the agent uses for props to be derived from the component's typescript definition and to not include props that are not part of that definition.

#### What are the relevant issues?
relates to #6229 

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
