### PR TITLE
[Docs] Hide "Managing child objects" template page from docs site

### DIFF
--- a/apps/docs/_redirects
+++ b/apps/docs/_redirects
@@ -4,3 +4,4 @@ https://aries.hpe.design/* https://design-system.hpe.design/:splat 301!
 /components/layer/center-layer /components/layer 301!
 /components/layer/side-drawer-layer /components/layer 301!
 /components/layer/fullscreen-layer /components/layer 301!
+/templates/forms/managing-child-objects /templates/forms 307!

--- a/apps/docs/_redirects
+++ b/apps/docs/_redirects
@@ -5,3 +5,4 @@ https://aries.hpe.design/* https://design-system.hpe.design/:splat 301!
 /components/layer/side-drawer-layer /components/layer 301!
 /components/layer/fullscreen-layer /components/layer 301!
 /templates/forms/managing-child-objects /templates/forms 307!
+/templates/forms/managing-child-objects/* /templates/forms 307!

--- a/apps/docs/src/data/structures/templates/templates.tsx
+++ b/apps/docs/src/data/structures/templates/templates.tsx
@@ -357,6 +357,9 @@ export const templates = [
   },
   {
     name: 'Forms',
+    // 'Managing child objects' is hidden from consumers via redirect, search
+    // exclusion (searchable:false), and availability (available:false) on its
+    // entry below. The pages link must remain to satisfy structure validation.
     pages: ['Managing child objects'],
     available: true,
     cardOrder: 1,
@@ -396,7 +399,6 @@ export const templates = [
       'Where to present a form',
       'Full-page forms',
       'Avoid using multiple column layouts',
-      'Managing child objects',
     ],
     relatedContent: [
       'TextInput',
@@ -427,10 +429,14 @@ export const templates = [
     ],
   },
   {
+    // Hidden from consumers: URL redirected (see apps/docs/_redirects),
+    // excluded from search (searchable:false), and kept out of pages
+    // (available:false).
     name: 'Managing child objects',
     path: '/templates/forms/managing-child-objects',
     parentPage: 'Forms',
-    available: true,
+    available: false,
+    searchable: false,
     description: `How to show, hide, and edit details of child 
     objects related to a parent within a form context.`,
     preview: {

--- a/apps/docs/src/pages/templates/forms/index.mdx
+++ b/apps/docs/src/pages/templates/forms/index.mdx
@@ -252,11 +252,9 @@ For demonstration purposes, the character limit is 40 characters and a threshold
 ### Exceptions and how to address them
 
 - A login/registration form, which typically shows two to three required fields do not need to be annotated in any way - the form is short and the necessity of completing the fields is standard practice.
-
   - For login/registration forms, apply `required={{ indicator: false }}` to the FormFields to remove the required indicator.
 
 - Forms with minimal fields are optimal, but occasionally, capturing extra information would be highly beneficial for the user. The following are some options for addressing these cases:
-
   - Create the form the optimal way; with only the minimum required fields so that the user can focus on completing their task. Separately, in a preferences or settings dashboard, for example, provide a form that allows the user to add helpful, optional information at another time. An example of a helpful but not required field could be asking for someone's official title or role. If it is not necessary to capture this information right away on a sign-in form, offer this "role" or "title" field in profile settings.
 
 <ExampleImagePreview
@@ -315,15 +313,3 @@ or simply prevent efficient progress; all of which can lead users to abandon for
     <ColumnFormDont />
   </Example>
 </BestPracticeGroup>
-
-## Managing child objects within a form
-
-Applications often have scenarios where an object has multiple child objects, such as:
-
-- Creating an account with multiple contacts, each with their own contact detail.
-- Creating a cluster to perform a workload, dependent on setting and specifying
-  parameters for each resource composing the cluster.
-- Configuring permissions for a role, for which each permission has its own set of parameters.
-
-See [managing child objects](/templates/forms/managing-child-objects) to see how a user
-can easily show and hide a child object's detail as needed.

--- a/apps/docs/src/pages/templates/forms/managing-child-objects.mdx
+++ b/apps/docs/src/pages/templates/forms/managing-child-objects.mdx
@@ -8,6 +8,12 @@ import {
   EditRole,
 } from '../../../examples/templates/forms';
 
+{/*
+  Hidden from consumers: removed from nav, cards, and search, and its URL
+  redirects to /templates/forms (see apps/docs/_redirects). File kept, not
+  deleted. Temporary removal; revisit later.
+*/}
+
 This pattern improves productivity by focusing a user's attention solely on the current
 object of interest, and uses collapsible objects to show or hide detail as needed. The
 intent is that collapsible objects reduce noise, clutter, and cognitive overload


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6338--keen-mayer-a86c8b.netlify.app/templates/forms/managing-child-objects)

#### What does this PR do?
- Temporarily removes the Managing child objects form template from consumer-facing surfaces (pages, search, and direct URL) without deleting the page. The file and its examples are retained so the page can be refreshed later.

#### What are the relevant issues?
closes #6336 

#### Where should the reviewer start?
See following files for changes made
- templates.tsx : 
  - added asearchable: falsea and aavailable: falsea to the Managing child objects entry — excludes it from the search box and page links.
  - Kept pages: ['Managing child objects'] on the Forms entry and parentPage: 'Forms' on the child to satisfy the two-way parent/child structure validation contract.
- `_redirects`: added 307! redirect `/templates/forms/managing-child-objects` → `/templates/forms` (server-side, deployed/Netlify).
- `managing-child-objects.mdx` - added inline comment for this temporary removal
- `index.mdx`: removed the "Managing child objects within a form" section and its inline link.

**Intentionally not changed**
`whats-new.mdx` — the December 2022 changelog entry referencing Managing Child Objects is kept as a historical record. Its link redirects to `/templates/forms` like any other direct access.

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
