### PR TITLE
[Docs] Update deprecated/todo files for Agent doc restructure follow up work

### DIFF
--- a/knowledge/capabilities/docs-refactor/agents/create-todos.agent.md
+++ b/knowledge/capabilities/docs-refactor/agents/create-todos.agent.md
@@ -1,7 +1,7 @@
 ---
 name: create-todos-agent
-description: "Use when: finalizing the per-component docs refactor after the MDX has been generated and examples have been implemented. Diffs the original .mdx.bak against the new .mdx to produce structured TODO-[component].md and DEPRECATED-[component].md files, then deletes the .bak. Part of the docs refactor workflow described in knowledge/capabilities/docs-refactor/plan.md and knowledge/capabilities/docs-refactor/docs/execution.skill.md."
-argument-hint: "Component name (e.g. checkbox, menu, select). Must match a .mdx file and a .mdx.bak file in apps/docs/src/pages/components/."
+description: 'Use when: finalizing the per-component docs refactor after the MDX has been generated and examples have been implemented. Diffs the original .mdx.bak against the new .mdx to produce structured TODO-[component].md and DEPRECATED-[component].md files, then deletes the .bak. Part of the docs refactor workflow described in knowledge/capabilities/docs-refactor/plan.md and knowledge/capabilities/docs-refactor/docs/execution.skill.md.'
+argument-hint: 'Component name (e.g. checkbox, menu, select). Must match a .mdx file and a .mdx.bak file in apps/docs/src/pages/components/.'
 tools: [read, search, edit]
 ---
 
@@ -17,7 +17,7 @@ You run after `generate-mdx-agent`, `generate-examples-agent`, and `dos-donts-ag
    - `apps/docs/src/pages/components/[component-name].mdx` — the new generated page
    - `apps/docs/src/pages/components/[component-name].mdx.bak` — the original preserved page
    - `knowledge/core/data/components/[component-name].yaml` — the YAML source of truth
-   If any of these is missing, stop and report which prerequisite is absent.
+     If any of these is missing, stop and report which prerequisite is absent.
 
 3. **Read all relevant files** side by side:
    - `apps/docs/src/pages/components/[component-name].mdx`
@@ -36,44 +36,91 @@ You run after `generate-mdx-agent`, `generate-examples-agent`, and `dos-donts-ag
 
 5. **Identify DEPRECATED content** — compare the `.bak` against the new `.mdx` section by section. For each piece of content in the `.bak` that does not appear in the new `.mdx`:
    - Determine whether it was intentionally restructured (map to where it now lives), dropped because it didn't fit the template, or lost accidentally.
+   - Classify each entry as one of two types: an **AI claim** (the AI reports the content was removed — it needs confirming) or an **AI decision** (the AI intentionally restructured the content — the team must agree or disagree).
    - Produce a mapping table showing original location → new location or status.
 
-6. **Write `apps/docs/todos/TODO-[component-name].md`** with the following sections:
+6. **Write `apps/docs/todos/TODO-[component-name].md`** with the following sections. Every item is a table row carrying a **Status**, **Name**, **Date**, and **Notes** field so a dev or designer can track it during PR review:
+
    ```markdown
    # TODO: [ComponentName]
 
+   > **Status values:** `Open` (initial state — needs to be looked at) · `In progress` (someone is looking into it) · `Completed` (no further action needed) · `Need follow on` (bigger than the current PR, e.g. a YAML-generation improvement) · `No action required` (evaluated, decided no action is needed).
+
+   ## Review deprecated file
+
+   <!-- Include this section ONLY when DEPRECATED-[name].md contains one or more content entries. Add the AI-claim row only if the DEPRECATED file has ≥1 AI-claim entry; add the AI-decision row only if it has ≥1 AI-decision entry. Omit the section entirely if no content was deprecated. -->
+
+   | Item                                                               | Status | Name | Date              | Notes                                               |
+   | ------------------------------------------------------------------ | ------ | ---- | ----------------- | --------------------------------------------------- |
+   | Confirm all **AI claim** entries in `DEPRECATED-[name].md`         | Open   |      | [generation date] | Set each AI-claim row to Confirmed / Not confirmed. |
+   | Agree/reject all **AI decision** entries in `DEPRECATED-[name].md` | Open   |      | [generation date] | Set each AI-decision row to Agreed / Not agreed.    |
+
    ## Missing coded examples
-   <!-- List each {/* TODO */} placeholder from Use Cases and Variants, with the use case name and a one-sentence description of what the example should demonstrate. -->
+
+   | Item | Status | Name | Date | Notes |
+   | ---- | ------ | ---- | ---- | ----- |
+
+   <!-- One row per {/* TODO */} placeholder from Use Cases and Variants: use case name + a one-sentence description of what the example should demonstrate. -->
 
    ## Missing do/don't previews
-   <!-- List each <div>{/* TODO */}</div> placeholder from Dos and Don'ts, with the message text from the surrounding <Example bestPractice> block. -->
+
+   | Item | Status | Name | Date | Notes |
+   | ---- | ------ | ---- | ---- | ----- |
+
+   <!-- One row per <div>{/* TODO */}</div> placeholder from Dos and Don'ts, with the message text from the surrounding <Example bestPractice> block. -->
 
    ## Missing props documentation
-   <!-- List any props visible in the Grommet source or existing MDX that are absent from the YAML props array. -->
+
+   | Item | Status | Name | Date | Notes |
+   | ---- | ------ | ---- | ---- | ----- |
+
+   <!-- One row per prop visible in the Grommet source or existing MDX that is absent from the YAML props array. -->
 
    ## Missing behaviors or states
-   <!-- List any behaviors or states from the original MDX not captured in behaviors.interactiveStates/applicationStates/dataStates. -->
+
+   | Item | Status | Name | Date | Notes |
+   | ---- | ------ | ---- | ---- | ----- |
+
+   <!-- One row per behavior or state from the original MDX not captured in behaviors.interactiveStates/applicationStates/dataStates. -->
 
    ## Missing visual assets
-   <!-- List anatomy diagram images or other visual assets referenced but not yet created. -->
+
+   | Item | Status | Name | Date | Notes |
+   | ---- | ------ | ---- | ---- | ----- |
+
+   <!-- One row per anatomy diagram image or other visual asset referenced but not yet created. -->
 
    ## Other gaps
-   <!-- Anything else that needs follow-up research or content. -->
-   ```
-   If a section has no items, write "None identified." — do not omit the section.
 
-7. **Write or update `apps/docs/todos/DEPRECATED-[component-name].md`** — if the file already exists (stubbed by `extract-yaml-agent`), append or update it rather than overwriting. Include:
+   | Item | Status | Name | Date | Notes |
+   | ---- | ------ | ---- | ---- | ----- |
+
+   <!-- One row per follow-up research or content item. -->
+   ```
+
+   If a section has no items, omit the table entirely and write a plain `None identified.` line under the heading — do not render an empty table. Only include the table (header + rows) when the section has at least one item. The **Review deprecated file** section is the one exception: omit it entirely when the DEPRECATED file has no content entries.
+
+7. **Write or update `apps/docs/todos/DEPRECATED-[component-name].md`** — if the file already exists (stubbed by `extract-yaml-agent`), append or update it rather than overwriting. Each entry carries a **Status**, **Name**, **Date**, and **Notes** field. The **Status** field records the confirmed/agreed state of the item:
+
    ```markdown
    # Deprecated content: [ComponentName]
 
+   Comparison of `apps/docs/src/pages/components/[component-name].mdx.bak` (original) against `apps/docs/src/pages/components/[component-name].mdx` (refactored).
+
+   > **Status values:** For an **AI claim** (content the AI reports was removed), use `Not confirmed` (initial — needs verification) or `Confirmed` (verified removed). For an **AI decision** (content the AI chose to restructure), use `Not agreed` (initial — reject or change the AI's decision) or `Agreed` (accept the AI's decision).
+
    ## Content mapping table
 
-   | Original section | Original content (excerpt) | Status | New location (if restructured) |
-   |---|---|---|---|
+   | Original section | Original content (excerpt) | Type | Status | New location (if restructured) | Name | Date | Notes |
+   | ---------------- | -------------------------- | ---- | ------ | ------------------------------ | ---- | ---- | ----- |
+
+   <!-- Type = "AI claim" or "AI decision". Set the initial Status accordingly (Not confirmed for AI claims, Not agreed for AI decisions). -->
 
    ## Notes
+
    <!-- Any additional context about why content was dropped or restructured. -->
    ```
+
    If nothing was dropped, write a confirmation note instead.
 
 8. **Delete the `.bak`** — once both TODO and DEPRECATED files have been successfully written, delete `apps/docs/src/pages/components/[component-name].mdx.bak`.
@@ -84,6 +131,8 @@ You run after `generate-mdx-agent`, `generate-examples-agent`, and `dos-donts-ag
 - **Never delete the `.bak` before** both TODO and DEPRECATED files are confirmed saved.
 - **Do not fabricate** prop names, WCAG criteria, or behavior descriptions. Only log gaps that are evidenced by comparing actual files.
 - **Preserve DEPRECATED file content** if it was already stubbed by `extract-yaml-agent`. Append new findings; do not erase existing entries.
+- **Initialize every item's tracking fields.** New TODO rows start with Status `Open`; new DEPRECATED rows start with Status `Not confirmed` (AI claims) or `Not agreed` (AI decisions). Set **Date** to the generation date and leave **Name** and **Notes** blank for the reviewers to fill in.
+- **Auto-add the deprecated-review task.** Whenever `DEPRECATED-[name].md` ends up with one or more content entries, the TODO file MUST include a `## Review deprecated file` section. Add a **Confirm AI claims** row only when the DEPRECATED file has ≥1 AI-claim entry, and an **Agree/reject AI decisions** row only when it has ≥1 AI-decision entry. Both rows use the TODO Status scale (start at `Open`).
 
 ## Output Format
 
@@ -92,15 +141,18 @@ After completing all steps, confirm with a summary:
 ```
 Created/Updated:
 - apps/docs/todos/TODO-[name].md
+  - Review deprecated file task added: [yes / no — no deprecated content]
   - Missing coded examples: [N]
   - Missing do/don't previews: [N]
   - Missing props: [N]
   - Missing behaviors/states: [N]
   - Missing visual assets: [N]
   - Other gaps: [N]
+  - All rows initialized with Status/Name/Date/Notes fields
 
 - apps/docs/todos/DEPRECATED-[name].md
   - Content mapping entries: [N] / "No dropped content found"
+  - All rows initialized with Status (confirmed/agreed)/Name/Date/Notes fields
 
 Deleted:
 - apps/docs/src/pages/components/[name].mdx.bak

--- a/knowledge/capabilities/docs-refactor/agents/extract-yaml.agent.md
+++ b/knowledge/capabilities/docs-refactor/agents/extract-yaml.agent.md
@@ -59,15 +59,22 @@ You are the first step in the per-component docs refactor pipeline. Read `knowle
 
 8. **Sync description to `components.js`** — open `apps/docs/src/data/structures/components.js` and find the entry for `[component-name]`. Update its `description` field to match the `description` value finalized in the YAML (single sentence, no markdown). If no entry exists for the component, add a note to the TODO file flagging it for manual addition.
 
-9. **Log inferred fields in the TODO file** — if any fields were inferred rather than extracted from the source MDX (`anatomy`, `usage.whenToUse`, `dosAndDonts`), create or append to `apps/docs/todos/TODO-[component-name].md` with a section titled `## Inferred fields — verify before merging`. List each inferred field and recommend verifying the content against the Figma file and grommet source before the PR is merged. If nothing was inferred, skip this step.
+9. **Log inferred fields in the TODO file** — if any fields were inferred rather than extracted from the source MDX (`anatomy`, `usage.whenToUse`, `dosAndDonts`), append a `## Inferred fields — verify before merging` section to `apps/docs/todos/TODO-[component-name].md` using the same `Item | Status | Name | Date | Notes` table format as `create-todos-agent`'s TODO sections — one row per inferred field (Status `Open`, Date today, Name and Notes blank), recommending verification against Figma and the grommet source before merge. If nothing was inferred, skip this step.
 
-10. **Stub the DEPRECATED file** — create `apps/docs/todos/DEPRECATED-[component-name].md` with a section for each piece of unmappable content. For each entry include:
+10. **Stub the DEPRECATED file** — create `apps/docs/todos/DEPRECATED-[component-name].md` using the exact template `create-todos-agent` produces (step 7 of that agent), so the stub and the final file stay consistent:
 
-- The original section name or content excerpt
-- Why it didn't map to the schema
-- Whether it may have value worth preserving and where it could potentially live
+```markdown
+# Deprecated content: [ComponentName]
 
-If nothing was unmappable, create the file with a brief note confirming the review was done and no content was dropped.
+> **Status values:** For an **AI claim** (content the AI reports was removed), use `Not confirmed` (initial — needs verification) or `Confirmed` (verified removed). For an **AI decision** (content the AI chose to restructure), use `Not agreed` (initial — reject or change the AI's decision) or `Agreed` (accept the AI's decision).
+
+## Content mapping table
+
+| Original section | Original content (excerpt) | Type | Status | New location (if restructured) | Name | Date | Notes |
+| ---------------- | -------------------------- | ---- | ------ | ------------------------------ | ---- | ---- | ----- |
+```
+
+Add one row per unmappable item: **Type** = `AI claim` or `AI decision`, initial **Status** = `Not confirmed` / `Not agreed`, **Date** = today, **Name** and **Notes** blank (note where content could live in `New location` or `Notes`). If nothing was unmappable, write a brief note confirming no content was dropped instead.
 
 11. **Rename the original MDX to `.bak`** — rename `apps/docs/src/pages/components/[component-name].mdx` to `apps/docs/src/pages/components/[component-name].mdx.bak`. This protects Next.js page-level imports and frontmatter so `generate-mdx-agent` can merge them back later.
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Update the following files to reflect new decisions on how to handle follow on work after agent doc restructure

- TODO-[comp].md
- DEPRECATED-[comp].md

#### What are the relevant issues?
#6368 

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
