### PR TITLE
Updated icon details

### DIFF
--- a/apps/docs/src/examples/cardPreviews/status-indicator.js
+++ b/apps/docs/src/examples/cardPreviews/status-indicator.js
@@ -6,7 +6,7 @@ import {
   StatusWarning,
   StatusCritical,
   StatusUnknown,
-  Info,
+  StatusInfo,
 } from '@hpe-design/icons-grommet';
 
 import { Box } from 'grommet';
@@ -26,7 +26,7 @@ export const StatusBox = ({ toast }) => (
   <Box direction="row" gap="xlarge" pad={{ bottom: 'medium' }}>
     <Box align="center">
       <StatusGood color="icon-ok" />
-      Normal
+      Ok
     </Box>
     <Box align="center">
       <StatusWarning color="icon-warning" />
@@ -43,7 +43,7 @@ export const StatusBox = ({ toast }) => (
       Unknown
     </Box>
     <Box align="center">
-      <Info color="icon-info" />
+      <StatusInfo color="icon-info" />
       Info
     </Box>
   </Box>


### PR DESCRIPTION
https://deploy-preview-6390--keen-mayer-a86c8b.netlify.app/templates/status-indicator#icons-and-shapes

**Change 1**
Replaced  `Info` with  `StatusInfo` icon as the copy and other examples are all status related.

**Change 2**
Modified copy from "normal" to "ok" to match icon semantic naming convention




Previous example uses the [Info](https://hpe-design-icons-grommet.netlify.app/?path=/story/icons-hpe-icons-for-grommet--default&args=iconName:Info;size:xxlarge) icon incorrectly

<img width="548" height="80" alt="image" src="https://github.com/user-attachments/assets/ba31d39c-753f-449c-b019-92c7fca95ced" />

Updated to use the correct semantic icon [StatusInfo](https://hpe-design-icons-grommet.netlify.app/?path=/story/icons-hpe-icons-for-grommet--default&args=iconName:StatusInfo;size:xxlarge)

<img width="459" height="87" alt="image" src="https://github.com/user-attachments/assets/c0366228-2add-4fa3-9833-3c20731644ac" />

