### PR TITLE
[hpe-design-tokens] Cleaned up typescript and eslint errors

### DIFF
--- a/packages/hpe-design-tokens/src/tests/token_export.test.ts
+++ b/packages/hpe-design-tokens/src/tests/token_export.test.ts
@@ -359,4 +359,261 @@ describe('tokenFilesFromLocalVariables', () => {
       },
     });
   });
+
+  it('merges boxShadow properties by step index', () => {
+    const localVariablesResponse: ApiGetLocalVariablesResponse = {
+      status: 200,
+      error: false,
+      meta: {
+        variableCollections: {
+          'VariableCollectionId:1:1': {
+            id: 'VariableCollectionId:1:1',
+            name: 'component',
+            modes: [{ modeId: '1:0', name: 'mode1' }],
+            defaultModeId: '1:0',
+            remote: false,
+            hiddenFromPublishing: false,
+          },
+        },
+        variables: {
+          'VariableID:2:1': {
+            id: 'VariableID:2:1',
+            name: 'panel/boxShadow/1/offsetX',
+            key: 'variable_key1',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'FLOAT',
+            valuesByMode: {
+              '1:0': 1,
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:2:2': {
+            id: 'VariableID:2:2',
+            name: 'panel/boxShadow/1/offsetY',
+            key: 'variable_key2',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'FLOAT',
+            valuesByMode: {
+              '1:0': 2,
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:2:3': {
+            id: 'VariableID:2:3',
+            name: 'panel/boxShadow/1/color',
+            key: 'variable_key3',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'COLOR',
+            valuesByMode: {
+              '1:0': { r: 0, g: 0, b: 0, a: 1 },
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:2:4': {
+            id: 'VariableID:2:4',
+            name: 'panel/boxShadow/2/offsetX',
+            key: 'variable_key4',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'FLOAT',
+            valuesByMode: {
+              '1:0': 3,
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:2:5': {
+            id: 'VariableID:2:5',
+            name: 'panel/boxShadow/2/blur',
+            key: 'variable_key5',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'FLOAT',
+            valuesByMode: {
+              '1:0': 4,
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:2:6': {
+            id: 'VariableID:2:6',
+            name: 'panel/boxShadow/2/color',
+            key: 'variable_key6',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'COLOR',
+            valuesByMode: {
+              '1:0': { r: 1, g: 1, b: 1, a: 1 },
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+        },
+      },
+    };
+
+    const tokenFiles = tokenFilesFromLocalVariables(localVariablesResponse);
+
+    expect(tokenFiles['component.mode1.json']).toEqual({
+      panel: {
+        boxShadow: {
+          $type: 'shadow',
+          $value: [
+            {
+              offsetX: 1,
+              offsetY: 2,
+              color: '#000000',
+            },
+            {
+              offsetX: 3,
+              blur: 4,
+              color: '#ffffff',
+            },
+          ],
+          $description: '',
+          $extensions: {
+            'com.figma': {
+              hiddenFromPublishing: false,
+              scopes: ['ALL_SCOPES'],
+              codeSyntax: {},
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('merges outline properties and preserves extensions across modes', () => {
+    const localVariablesResponse: ApiGetLocalVariablesResponse = {
+      status: 200,
+      error: false,
+      meta: {
+        variableCollections: {
+          'VariableCollectionId:1:1': {
+            id: 'VariableCollectionId:1:1',
+            name: 'component',
+            modes: [
+              { modeId: '1:0', name: 'mode1' },
+              { modeId: '1:1', name: 'mode2' },
+            ],
+            defaultModeId: '1:0',
+            remote: false,
+            hiddenFromPublishing: false,
+          },
+        },
+        variables: {
+          'VariableID:3:1': {
+            id: 'VariableID:3:1',
+            name: 'focusIndicator/outline/width',
+            key: 'variable_key7',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'FLOAT',
+            valuesByMode: {
+              '1:0': 1,
+              '1:1': 2,
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:3:2': {
+            id: 'VariableID:3:2',
+            name: 'focusIndicator/outline/style',
+            key: 'variable_key8',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'STRING',
+            valuesByMode: {
+              '1:0': 'solid',
+              '1:1': 'dashed',
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:3:3': {
+            id: 'VariableID:3:3',
+            name: 'focusIndicator/outline/color',
+            key: 'variable_key9',
+            variableCollectionId: 'VariableCollectionId:1:1',
+            resolvedType: 'COLOR',
+            valuesByMode: {
+              '1:0': { r: 0, g: 0, b: 0, a: 1 },
+              '1:1': { r: 1, g: 1, b: 1, a: 1 },
+            },
+            remote: false,
+            description: '',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+        },
+      },
+    };
+
+    const tokenFiles = tokenFilesFromLocalVariables(localVariablesResponse);
+
+    expect(tokenFiles['component.mode1.json']).toEqual({
+      focusIndicator: {
+        outline: {
+          $type: 'border',
+          $value: {
+            width: 1,
+            style: 'solid',
+            color: '#000000',
+          },
+          $description: '',
+          $extensions: {
+            'com.figma': {
+              hiddenFromPublishing: true,
+              scopes: [],
+              codeSyntax: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(tokenFiles['component.mode2.json']).toEqual({
+      focusIndicator: {
+        outline: {
+          $type: 'border',
+          $value: {
+            width: 2,
+            style: 'dashed',
+            color: '#ffffff',
+          },
+          $description: '',
+          $extensions: {
+            'com.figma': {
+              hiddenFromPublishing: true,
+              scopes: [],
+              codeSyntax: {},
+            },
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/hpe-design-tokens/src/token_export.ts
+++ b/packages/hpe-design-tokens/src/token_export.ts
@@ -1,6 +1,7 @@
+/* eslint-disable max-len */
 import { rgbToHex } from './color.js';
 import { ApiGetLocalVariablesResponse, Variable } from './figma_api.js';
-import { Token, TokensFile } from './token_types.js';
+import { ExportShadowToken, Token, TokensFile } from './token_types.js';
 import { access, isReference } from './utils.js';
 
 /**
@@ -12,6 +13,8 @@ const interactions = ['hover', 'focus', 'active'];
  */
 const prominences = ['xweak', 'weak', 'default', 'strong', 'xstrong'];
 const exceptionColors = ['color/focus/support', 'color/transparent'];
+
+type ShadowsByMode = Record<string, Record<string, ExportShadowToken>>;
 
 function tokenTypeFromVariable(variable: Variable) {
   if (variable.resolvedType === 'STRING' && variable.name.includes('fontStack'))
@@ -64,7 +67,9 @@ function tokenValueFromVariable(
         aliasedName = temp.join('/');
       }
       return `{${aliasedName.replace(/\//g, '.')}}`;
-    } else if ('r' in value) {
+    }
+
+    if ('r' in value) {
       return rgbToHex(value);
     }
 
@@ -81,7 +86,7 @@ export function tokenFilesFromLocalVariables(
   const localVariableCollections =
     localVariablesResponse.meta.variableCollections;
   const localVariables = localVariablesResponse.meta.variables;
-  const shadows: { [key: string]: any } = {};
+  const shadows: ShadowsByMode = {};
 
   Object.values(localVariables).forEach(variable => {
     // Skip remote variables because we only want to generate tokens for local variables
@@ -97,7 +102,7 @@ export function tokenFilesFromLocalVariables(
         tokenFiles[fileName] = {};
       }
 
-      let obj: any = tokenFiles[fileName];
+      let obj = tokenFiles[fileName] as Record<string, unknown>;
 
       // specific to "outline" but not something like "outlineOffset"
       if (/outline\//.test(variable.name)) {
@@ -106,8 +111,8 @@ export function tokenFilesFromLocalVariables(
         const property = parts[parts.length - 1];
 
         keyPath.forEach(groupName => {
-          obj[groupName] = obj[groupName] || {};
-          obj = obj[groupName];
+          obj[groupName] = (obj[groupName] as Record<string, unknown>) || {};
+          obj = obj[groupName] as Record<string, unknown>;
         });
         const token = {
           $type: 'border',
@@ -127,11 +132,14 @@ export function tokenFilesFromLocalVariables(
             },
           },
         };
-        const outline = access(keyPath.join('.'), tokenFiles[fileName]);
+        const outline = access<Record<string, unknown>>(
+          keyPath.join('.'),
+          tokenFiles[fileName] as Record<string, unknown>,
+        );
         if (Object.keys(outline).length === 0) {
           Object.assign(obj, token);
         } else {
-          const partialOutline = outline.$value;
+          const partialOutline = outline.$value as Record<string, unknown>;
           partialOutline[property] = tokenValueFromVariable(
             variable,
             mode.modeId,
@@ -144,8 +152,8 @@ export function tokenFilesFromLocalVariables(
         const property = parts[parts.length - 1];
 
         keyPath.forEach(groupName => {
-          obj[groupName] = obj[groupName] || {};
-          obj = obj[groupName];
+          obj[groupName] = (obj[groupName] as Record<string, unknown>) || {};
+          obj = obj[groupName] as Record<string, unknown>;
         });
 
         let value = tokenValueFromVariable(
@@ -179,16 +187,21 @@ export function tokenFilesFromLocalVariables(
         };
 
         // if there isn't anything in the shadow yet, create the initial value array
-        const boxShadow = access(keyPath.join('.'), tokenFiles[fileName]);
+        const boxShadow = access<Record<string, unknown>>(
+          keyPath.join('.'),
+          tokenFiles[fileName] as Record<string, unknown>,
+        );
         if (Object.keys(boxShadow).length === 0) {
           Object.assign(obj, token);
           // if not a string reference
-        } else if (typeof boxShadow.$value === 'object') {
+        } else if (Array.isArray(boxShadow.$value)) {
           const index =
             parseInt(parts[parts.length - 3], 10) >= 0
               ? parseInt(parts[parts.length - 3], 10)
               : 0;
-          const partialShadow = boxShadow.$value[index];
+          const partialShadow =
+            (boxShadow.$value[index] as Record<string, unknown>) || {};
+          boxShadow.$value[index] = partialShadow;
           partialShadow[property] = tokenValueFromVariable(
             variable,
             mode.modeId,
@@ -267,12 +280,11 @@ export function tokenFilesFromLocalVariables(
         }
 
         adjustedName.split('/').forEach(groupName => {
-          obj[groupName] = obj[groupName] || {};
-          obj = obj[groupName];
+          obj[groupName] = (obj[groupName] as Record<string, unknown>) || {};
+          obj = obj[groupName] as Record<string, unknown>;
         });
 
-        let token: Token;
-        token = {
+        const token: Token = {
           $type: tokenTypeFromVariable(variable),
           $value: tokenValueFromVariable(variable, mode.modeId, localVariables),
           $description: variable.description,

--- a/packages/hpe-design-tokens/src/token_export.ts
+++ b/packages/hpe-design-tokens/src/token_export.ts
@@ -148,8 +148,12 @@ export function tokenFilesFromLocalVariables(
         }
       } else if (variable.name.includes('boxShadow')) {
         const parts = variable.name.split('/');
-        const keyPath = parts.slice(0, parts.indexOf('boxShadow') + 1);
+        const boxShadowIndex = parts.indexOf('boxShadow');
+        const keyPath = parts.slice(0, boxShadowIndex + 1);
         const property = parts[parts.length - 1];
+        const parsedStep = parseInt(parts[boxShadowIndex + 1], 10);
+        const stepIndex =
+          Number.isInteger(parsedStep) && parsedStep > 0 ? parsedStep - 1 : 0;
 
         keyPath.forEach(groupName => {
           obj[groupName] = (obj[groupName] as Record<string, unknown>) || {};
@@ -192,16 +196,23 @@ export function tokenFilesFromLocalVariables(
           tokenFiles[fileName] as Record<string, unknown>,
         );
         if (Object.keys(boxShadow).length === 0) {
-          Object.assign(obj, token);
+          if (typeof token.$value === 'string') {
+            Object.assign(obj, token);
+          } else {
+            const initialValues: Array<Record<string, unknown>> = [];
+            initialValues[stepIndex] = {
+              [property]: value,
+            };
+            Object.assign(obj, {
+              ...token,
+              $value: initialValues,
+            });
+          }
           // if not a string reference
         } else if (Array.isArray(boxShadow.$value)) {
-          const index =
-            parseInt(parts[parts.length - 3], 10) >= 0
-              ? parseInt(parts[parts.length - 3], 10)
-              : 0;
           const partialShadow =
-            (boxShadow.$value[index] as Record<string, unknown>) || {};
-          boxShadow.$value[index] = partialShadow;
+            (boxShadow.$value[stepIndex] as Record<string, unknown>) || {};
+          boxShadow.$value[stepIndex] = partialShadow;
           partialShadow[property] = tokenValueFromVariable(
             variable,
             mode.modeId,

--- a/packages/hpe-design-tokens/src/token_types.ts
+++ b/packages/hpe-design-tokens/src/token_types.ts
@@ -41,6 +41,21 @@ export interface Token {
   };
 }
 
+export type FigmaTokenExtensions = {
+  'com.figma': {
+    hiddenFromPublishing: boolean;
+    scopes: VariableScope[];
+    codeSyntax: VariableCodeSyntax;
+  };
+};
+
+export type ExportShadowToken = {
+  $type: 'shadow';
+  $value: Array<Record<string, unknown>>;
+  $description: string;
+  $extensions: FigmaTokenExtensions;
+};
+
 export type TokenOrTokenGroup =
   | Token
   | ({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->

#### What does this PR do?

Just some project hygiene. 

This pull request enhances the handling and export of design tokens, particularly improving how `boxShadow` and `outline` properties are merged and structured when exporting from local variables. It also introduces new types for better type safety and clarity. The most important changes are summarized below.

### Improved Handling of Shadow and Outline Tokens

* The logic for merging `boxShadow` properties by step index was rewritten to ensure that multiple shadow steps are correctly grouped into an array, with each step's properties (like `offsetX`, `offsetY`, `blur`, `color`) merged into the appropriate index. This ensures that the exported tokens accurately represent multi-step shadows. [[1]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119R1-R4) [[2]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L143-R160) [[3]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L182-R215)
* The merging logic for `outline` properties was improved to combine properties (such as `width`, `style`, and `color`) into a single `$value` object for each mode, preserving extensions and ensuring mode-specific values are correctly exported. [[1]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L109-R115) [[2]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L130-R142) [[3]](diffhunk://#diff-809f5af95750cbdd824a02ca4a1d1445f6dbef9a7fc1a21a4e25bf8bc1ce11a6R362-R618)

### Type Safety and Refactoring

* Introduced new types: `ShadowsByMode`, `FigmaTokenExtensions`, and `ExportShadowToken`, which clarify the structure of exported shadow tokens and their Figma-specific extensions. [[1]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119R17-R18) [[2]](diffhunk://#diff-c64f12e0609f23870aa2db335930945d8f84df134e28fae2eac8a1283d3ca68aR44-R58)
* Updated the code to use these new types, improving type safety and readability throughout the token export logic. [[1]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L84-R89) [[2]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L100-R105) [[3]](diffhunk://#diff-2aaa35e5e88b3d7943508fa58383930f55eef2ad89e16b6ec76e4529400ba119L270-R298)

### Test Coverage

* Added unit tests to verify correct merging of `boxShadow` and `outline` properties, including handling of multiple steps and different modes, ensuring the new logic works as expected.

These changes collectively improve the reliability and maintainability of the design token export functionality, especially for complex shadow and outline scenarios.

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
