### PR TITLE
[hpe-design-tokens] Added verbose and write options to token sync CLI for easier review

### DIFF
--- a/packages/hpe-design-tokens/contracts/figma-sync-cli-contract.md
+++ b/packages/hpe-design-tokens/contracts/figma-sync-cli-contract.md
@@ -13,9 +13,9 @@ Owner: design-tokens maintainers + DX/CI owner
 
 - `--env`: target environment. Optional locally (defaults to `production`).
 - `--dry-run`: plan-only mode. No POST calls to mutate variables.
-- `--verbose-plan`: print per-stage planned variable changes as formatted JSON.
-- `--write-plan <path>`: write a JSON report containing the planned per-stage variable diff.
-- `--plan-stage <stage[,stage...]>`: optional plan-output filter; limits `--verbose-plan` and `--write-plan` output to selected stages (`primitive`, `semantic`, `component`).
+- `--verbose-plan`: print per-stage planned variable changes as formatted JSON (typically used with `--dry-run`).
+- `--write-plan <path>`: write a JSON report containing the planned per-stage variable diff. Valid in both `--dry-run` and mutating runs.
+- `--plan-stage <stage[,stage...]>`: optional plan-output filter; limits `--verbose-plan` and `--write-plan` output to selected stages (`primitive`, `semantic`, `component`) in both dry-run and mutating runs.
 - `--confirm-production`: required locally for mutating production.
 - `--config`: optional config file path.
 - `--output`: output directory for pull, or output file path for discovery reports.
@@ -54,3 +54,4 @@ Missing required values after precedence resolution must fail immediately.
 - Include `schemaVersion` in every machine-readable payload.
 - Keep human logs, but machine-readable payloads are source of truth for automation.
 - `--verbose-plan` and `--write-plan` are optional diagnostic outputs and do not change the machine-readable event schema.
+- `planned-stage-diff` is a plan artifact, not a mutation result. Use `run-summary.mutationsApplied` as the source of truth for whether writes occurred.

--- a/packages/hpe-design-tokens/contracts/figma-sync-cli-contract.md
+++ b/packages/hpe-design-tokens/contracts/figma-sync-cli-contract.md
@@ -5,7 +5,7 @@ Owner: design-tokens maintainers + DX/CI owner
 
 ## Commands
 
-- Push: `pnpm sync-tokens-to-figma -- --env=<production|test> [--dry-run] [--confirm-production] [--config <path>]`
+- Push: `pnpm sync-tokens-to-figma -- --env=<production|test> [--dry-run] [--confirm-production] [--config <path>] [--verbose-plan] [--write-plan <path>] [--plan-stage <stage[,stage...]>]`
 - Pull: `pnpm sync-figma-to-tokens -- --env=<production|test> --output <dir> [--config <path>]`
 - Discover: `pnpm sync-discover-figma-collection-keys -- --env=<production|test> [--pretty] [--output <path>] [--config <path>]`
 
@@ -13,6 +13,9 @@ Owner: design-tokens maintainers + DX/CI owner
 
 - `--env`: target environment. Optional locally (defaults to `production`).
 - `--dry-run`: plan-only mode. No POST calls to mutate variables.
+- `--verbose-plan`: print per-stage planned variable changes as formatted JSON.
+- `--write-plan <path>`: write a JSON report containing the planned per-stage variable diff.
+- `--plan-stage <stage[,stage...]>`: optional plan-output filter; limits `--verbose-plan` and `--write-plan` output to selected stages (`primitive`, `semantic`, `component`).
 - `--confirm-production`: required locally for mutating production.
 - `--config`: optional config file path.
 - `--output`: output directory for pull, or output file path for discovery reports.
@@ -50,3 +53,4 @@ Missing required values after precedence resolution must fail immediately.
 - Emit final run-summary event.
 - Include `schemaVersion` in every machine-readable payload.
 - Keep human logs, but machine-readable payloads are source of truth for automation.
+- `--verbose-plan` and `--write-plan` are optional diagnostic outputs and do not change the machine-readable event schema.

--- a/packages/hpe-design-tokens/docs/OPERATIONS.md
+++ b/packages/hpe-design-tokens/docs/OPERATIONS.md
@@ -116,11 +116,12 @@ Primary events emitted by sync scripts:
 - `stage-status`
 - `run-summary`
 
-Optional human-readable / file outputs for push dry-runs:
+Optional human-readable / file outputs for push planning diagnostics:
 
-- `--verbose-plan`: print per-stage planned variable changes as formatted JSON.
-- `--write-plan <path>`: write a `planned-stage-diff` JSON report with the per-stage payload details.
-- `--plan-stage <stage[,stage...]>`: filter plan output to one or more stages (`primitive`, `semantic`, `component`).
+- `--verbose-plan`: print per-stage planned variable changes as formatted JSON (typically used with `--dry-run`).
+- `--write-plan <path>`: write a `planned-stage-diff` JSON report with the per-stage payload details (available in both `--dry-run` and mutating runs).
+- `--plan-stage <stage[,stage...]>`: filter plan output to one or more stages (`primitive`, `semantic`, `component`) for both `--verbose-plan` and `--write-plan`.
+- `planned-stage-diff` is a plan artifact. Use the final `run-summary` event (`mutationsApplied`) to determine whether writes actually occurred.
 
 Schemas and contracts:
 

--- a/packages/hpe-design-tokens/docs/OPERATIONS.md
+++ b/packages/hpe-design-tokens/docs/OPERATIONS.md
@@ -4,17 +4,17 @@ This guide is for maintainers running sync tooling and release-oriented package 
 
 ## Command Matrix
 
-| Command | When To Use | Mutates Remote Figma | Output |
-|---|---|---|---|
-| `pnpm sync-tokens-to-figma -- --env=<production\|test> [--dry-run] [--confirm-production] [--bootstrap]` | Push local JSON tokens to Figma | Yes (unless `--dry-run`) | stage-status and run-summary events |
-| `pnpm sync-figma-to-tokens -- --env=<production\|test> --output <dir>` | Pull Figma variables to local JSON for QA or updates | No | local JSON files + run-summary |
-| `pnpm sync-discover-figma-collection-keys -- --env=<production\|test> [--pretty] [--output <path>]` | Discover canonical collection keys after bootstrap or during diagnostics | No | discovery JSON payload |
-| `pnpm test` | Validate package unit/integration behavior | No | vitest results |
-| `pnpm test:contracts` | Validate schema conformance for sync payloads | No | vitest results |
-| `pnpm build` | Rebuild token outputs | No | dist artifacts |
-| `pnpm release-stable` | Stable release flow for this package | No | release script output |
-| `pnpm paddingY:verify` | Check paddingY consistency | No | verification report |
-| `pnpm paddingY:update` | Apply paddingY update automation | No | updated token content |
+| Command                                                                                                                                                                           | When To Use                                                              | Mutates Remote Figma     | Output                                                          |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------ | --------------------------------------------------------------- |
+| `pnpm sync-tokens-to-figma -- --env=<production\|test> [--dry-run] [--confirm-production] [--bootstrap] [--verbose-plan] [--write-plan <path>] [--plan-stage <stage[,stage...]>]` | Push local JSON tokens to Figma                                          | Yes (unless `--dry-run`) | stage-status and run-summary events, optional stage diff report |
+| `pnpm sync-figma-to-tokens -- --env=<production\|test> --output <dir>`                                                                                                            | Pull Figma variables to local JSON for QA or updates                     | No                       | local JSON files + run-summary                                  |
+| `pnpm sync-discover-figma-collection-keys -- --env=<production\|test> [--pretty] [--output <path>]`                                                                               | Discover canonical collection keys after bootstrap or during diagnostics | No                       | discovery JSON payload                                          |
+| `pnpm test`                                                                                                                                                                       | Validate package unit/integration behavior                               | No                       | vitest results                                                  |
+| `pnpm test:contracts`                                                                                                                                                             | Validate schema conformance for sync payloads                            | No                       | vitest results                                                  |
+| `pnpm build`                                                                                                                                                                      | Rebuild token outputs                                                    | No                       | dist artifacts                                                  |
+| `pnpm release-stable`                                                                                                                                                             | Stable release flow for this package                                     | No                       | release script output                                           |
+| `pnpm paddingY:verify`                                                                                                                                                            | Check paddingY consistency                                               | No                       | verification report                                             |
+| `pnpm paddingY:update`                                                                                                                                                            | Apply paddingY update automation                                         | No                       | updated token content                                           |
 
 ## Recommended Day-To-Day Flow
 
@@ -29,6 +29,25 @@ pnpm --filter hpe-design-tokens test:contracts
 
 ```bash
 pnpm --filter hpe-design-tokens sync-tokens-to-figma -- --env=test --dry-run
+```
+
+To inspect the actual planned variable updates during dry-run:
+
+```bash
+pnpm --filter hpe-design-tokens sync-tokens-to-figma -- --env=test --dry-run --verbose-plan
+```
+
+To save the planned stage diff as JSON for review:
+
+```bash
+pnpm --filter hpe-design-tokens sync-tokens-to-figma -- --env=test --dry-run --write-plan contracts/generated/semantic-dry-run-plan.test.json
+```
+
+To limit plan output to specific stages:
+
+```bash
+pnpm --filter hpe-design-tokens sync-tokens-to-figma -- --env=test --dry-run --verbose-plan --plan-stage semantic
+pnpm --filter hpe-design-tokens sync-tokens-to-figma -- --env=test --dry-run --write-plan contracts/generated/plan.test.json --plan-stage semantic,component
 ```
 
 3. Apply sync in test when dry-run output is expected:
@@ -48,6 +67,7 @@ pnpm --filter hpe-design-tokens sync-figma-to-tokens -- --env=test --output toke
 Use only when collection keys are not established yet.
 
 Prerequisites:
+
 - [ ] Fresh Figma files created
 - [ ] Figma file keys added to .env
 
@@ -96,9 +116,14 @@ Primary events emitted by sync scripts:
 - `stage-status`
 - `run-summary`
 
+Optional human-readable / file outputs for push dry-runs:
+
+- `--verbose-plan`: print per-stage planned variable changes as formatted JSON.
+- `--write-plan <path>`: write a `planned-stage-diff` JSON report with the per-stage payload details.
+- `--plan-stage <stage[,stage...]>`: filter plan output to one or more stages (`primitive`, `semantic`, `component`).
+
 Schemas and contracts:
 
 - `../contracts/schemas/`
 - `../contracts/figma-sync-cli-contract.md`
 - `../contracts/figma-sync-failure-codes.md`
-

--- a/packages/hpe-design-tokens/src/scripts/sync_figma_to_tokens.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_figma_to_tokens.ts
@@ -358,15 +358,15 @@ async function main() {
   });
 
   try {
-    const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    execFileSync(
-      npxCommand,
-      ['prettier', '--write', `${outputDir}/**/*.json`],
-      { stdio: 'inherit' },
-    );
+    const prettierCommand =
+      process.platform === 'win32' ? 'prettier.cmd' : 'prettier';
+    execFileSync(prettierCommand, ['--write', `${outputDir}/**/*.json`], {
+      stdio: 'inherit',
+    });
     console.log(green('✅ JSON files have been formatted with Prettier'));
   } catch (error) {
-    console.error(`Failed to format JSON files: ${error}`);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to format JSON files with Prettier: ${message}`);
   }
 
   console.log(

--- a/packages/hpe-design-tokens/src/scripts/sync_figma_to_tokens.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_figma_to_tokens.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import * as fs from 'fs';
 import path from 'path';
+import { execFileSync } from 'child_process';
 
 import FigmaApi from '../figma_api.js';
 import {
@@ -355,6 +356,18 @@ async function main() {
     startedAt: runStartedAt,
     finishedAt: new Date().toISOString(),
   });
+
+  try {
+    const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+    execFileSync(
+      npxCommand,
+      ['prettier', '--write', `${outputDir}/**/*.json`],
+      { stdio: 'inherit' },
+    );
+    console.log(green('✅ JSON files have been formatted with Prettier'));
+  } catch (error) {
+    console.error(`Failed to format JSON files: ${error}`);
+  }
 
   console.log(
     green(`✅ Tokens files have been written to the ${outputDir} directory`),

--- a/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
@@ -33,6 +33,11 @@ import {
   normalizeAliasReference,
   readJsonFiles,
 } from '../token_import.js';
+import {
+  StagePlanReport,
+  buildStagePlanReport,
+  parsePlanStageFilterValue,
+} from '../sync_plan_report.js';
 
 // This script pushes design tokens from JSON files to Figma design files
 
@@ -191,6 +196,28 @@ function getSummaryEnvironment(argv: string[]): SyncEnvironment {
   return getCliArgValue(argv, '--env') === 'test' ? 'test' : 'production';
 }
 
+function writePlanReportFile(
+  outputPath: string,
+  report: {
+    schemaVersion: string;
+    eventType: 'planned-stage-diff';
+    runId: string;
+    environment: SyncEnvironment;
+    dryRun: boolean;
+    startedAt: string;
+    finishedAt: string;
+    stages: StagePlanReport[];
+  },
+) {
+  const absoluteOutputPath = path.isAbsolute(outputPath)
+    ? outputPath
+    : path.resolve(process.cwd(), outputPath);
+
+  fs.mkdirSync(path.dirname(absoluteOutputPath), { recursive: true });
+  fs.writeFileSync(absoluteOutputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`Wrote planned stage diff report: ${absoluteOutputPath}`);
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   const runId = makeRunId();
@@ -199,6 +226,12 @@ async function main() {
   const runErrors: SyncError[] = [];
   const summaryEnvironment = getSummaryEnvironment(argv);
   const dryRun = argv.includes('--dry-run');
+  const verbosePlan = argv.includes('--verbose-plan');
+  const writePlanPath = getCliArgValue(argv, '--write-plan');
+  const planStagesFilter = parsePlanStageFilterValue(
+    getCliArgValue(argv, '--plan-stage'),
+  );
+  const stagePlanReports: StagePlanReport[] = [];
   let config;
   const fallbackStageResults = FILE_TIERS.map(stage => ({
     stage,
@@ -447,6 +480,15 @@ async function main() {
 
       const counts = countsFromPostPayload(postVariablesPayload);
       const stageHasMutations = hasMutations(counts);
+      const stagePlanReport = stageHasMutations
+        ? buildStagePlanReport(stage, postVariablesPayload, localVariables)
+        : null;
+      const includePlanForStage =
+        !planStagesFilter || planStagesFilter.includes(stage);
+
+      if (stagePlanReport && includePlanForStage) {
+        stagePlanReports.push(stagePlanReport);
+      }
 
       if (!stageHasMutations) {
         console.log(
@@ -460,6 +502,10 @@ async function main() {
             `✅ Dry run: "${stage}" has planned updates, no mutations applied`,
           ),
         );
+
+        if (verbosePlan && stagePlanReport && includePlanForStage) {
+          console.log(JSON.stringify(stagePlanReport, null, 2));
+        }
       } else {
         const apiResp = await api.postVariables(
           fileKeys[stage],
@@ -537,6 +583,19 @@ async function main() {
         stageResults.push({ stage: remainingStage, status: 'skipped', counts });
       });
 
+      if (writePlanPath) {
+        writePlanReportFile(writePlanPath, {
+          schemaVersion: SCHEMA_VERSION,
+          eventType: 'planned-stage-diff',
+          runId,
+          environment: config.env,
+          dryRun: config.dryRun,
+          startedAt: runStartedAt,
+          finishedAt: new Date().toISOString(),
+          stages: stagePlanReports,
+        });
+      }
+
       emitRunSummary({
         runId,
         environment: config.env,
@@ -555,6 +614,19 @@ async function main() {
       throw error;
     }
   }, Promise.resolve());
+
+  if (writePlanPath) {
+    writePlanReportFile(writePlanPath, {
+      schemaVersion: SCHEMA_VERSION,
+      eventType: 'planned-stage-diff',
+      runId,
+      environment: config.env,
+      dryRun: config.dryRun,
+      startedAt: runStartedAt,
+      finishedAt: new Date().toISOString(),
+      stages: stagePlanReports,
+    });
+  }
 
   emitRunSummary({
     runId,

--- a/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
@@ -228,16 +228,42 @@ async function main() {
   const dryRun = argv.includes('--dry-run');
   const verbosePlan = argv.includes('--verbose-plan');
   const writePlanPath = getCliArgValue(argv, '--write-plan');
-  const planStagesFilter = parsePlanStageFilterValue(
-    getCliArgValue(argv, '--plan-stage'),
-  );
-  const stagePlanReports: StagePlanReport[] = [];
-  let config;
   const fallbackStageResults = FILE_TIERS.map(stage => ({
     stage,
     status: 'skipped' as const,
     counts: emptyCounts(),
   }));
+
+  let planStagesFilter: ReturnType<typeof parsePlanStageFilterValue>;
+  try {
+    planStagesFilter = parsePlanStageFilterValue(
+      getCliArgValue(argv, '--plan-stage'),
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    runErrors.push({
+      code: 'INVALID_CLI_ARGS',
+      message,
+      environment: summaryEnvironment,
+      remediation: 'Provide a valid --plan-stage value and retry.',
+    });
+    emitRunSummary({
+      runId,
+      environment: summaryEnvironment,
+      dryRun,
+      productionGuardrailPassed: false,
+      mutationsApplied: false,
+      unresolvedAliasCount: 0,
+      stages: fallbackStageResults,
+      errors: withRequiredErrorFields(runErrors, summaryEnvironment),
+      startedAt: runStartedAt,
+      finishedAt: new Date().toISOString(),
+    });
+    throw error;
+  }
+
+  const stagePlanReports: StagePlanReport[] = [];
+  let config;
 
   try {
     config = resolveFigmaSyncConfig();

--- a/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
@@ -228,6 +228,12 @@ async function main() {
   const dryRun = argv.includes('--dry-run');
   const verbosePlan = argv.includes('--verbose-plan');
   const writePlanPath = getCliArgValue(argv, '--write-plan');
+  if (writePlanPath && !dryRun) {
+    console.log(
+      // eslint-disable-next-line max-len
+      'Info: --write-plan is enabled for a mutating run. The written planned-stage-diff is a plan artifact; check run-summary.mutationsApplied to confirm applied writes.',
+    );
+  }
   const fallbackStageResults = FILE_TIERS.map(stage => ({
     stage,
     status: 'skipped' as const,

--- a/packages/hpe-design-tokens/src/sync_plan_report.ts
+++ b/packages/hpe-design-tokens/src/sync_plan_report.ts
@@ -1,0 +1,230 @@
+import {
+  ApiGetLocalVariablesResponse,
+  ApiPostVariablesPayload,
+  VariableCollection,
+  VariableMode,
+  Variable,
+} from './figma_api.js';
+import {
+  FILE_TIERS,
+  FileTier,
+  StageCounts,
+  countsFromPostPayload,
+} from './sync_events.js';
+
+type CollectionSnapshot = Pick<
+  VariableCollection,
+  'id' | 'name' | 'hiddenFromPublishing' | 'defaultModeId' | 'remote'
+> & {
+  modes: VariableMode[];
+};
+
+type VariableSnapshot = Pick<
+  Variable,
+  | 'id'
+  | 'name'
+  | 'variableCollectionId'
+  | 'resolvedType'
+  | 'description'
+  | 'hiddenFromPublishing'
+  | 'scopes'
+  | 'codeSyntax'
+>;
+
+export type StagePlanReport = {
+  stage: FileTier;
+  counts: StageCounts;
+  variableCollections: Array<{
+    action: 'CREATE' | 'UPDATE' | 'DELETE';
+    id: string | null;
+    name: string | null;
+    before: CollectionSnapshot | null;
+    changes: Record<string, unknown>;
+  }>;
+  variableModes: Array<{
+    action: 'CREATE' | 'UPDATE' | 'DELETE';
+    id: string | null;
+    name: string | null;
+    modeId: string | null;
+    collectionId: string;
+    collectionName: string | null;
+    before: VariableMode | null;
+  }>;
+  variables: Array<{
+    action: 'CREATE' | 'UPDATE' | 'DELETE';
+    id: string | null;
+    name: string | null;
+    collectionId: string | null;
+    collectionName: string | null;
+    before: VariableSnapshot | null;
+    changes: Record<string, unknown>;
+  }>;
+  variableModeValues: Array<{
+    variableId: string;
+    variableName: string | null;
+    modeId: string;
+    modeName: string | null;
+    before: unknown;
+    after: unknown;
+  }>;
+};
+
+function collectionSnapshot(
+  collection: VariableCollection | undefined,
+): CollectionSnapshot | null {
+  if (!collection) {
+    return null;
+  }
+
+  return {
+    id: collection.id,
+    name: collection.name,
+    hiddenFromPublishing: collection.hiddenFromPublishing,
+    defaultModeId: collection.defaultModeId,
+    remote: collection.remote,
+    modes: collection.modes,
+  };
+}
+
+function variableSnapshot(
+  variable: Variable | undefined,
+): VariableSnapshot | null {
+  if (!variable) {
+    return null;
+  }
+
+  return {
+    id: variable.id,
+    name: variable.name,
+    variableCollectionId: variable.variableCollectionId,
+    resolvedType: variable.resolvedType,
+    description: variable.description,
+    hiddenFromPublishing: variable.hiddenFromPublishing,
+    scopes: variable.scopes,
+    codeSyntax: variable.codeSyntax,
+  };
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+export function parsePlanStageFilterValue(
+  value: string | undefined,
+): FileTier[] | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const stages = value
+    .split(',')
+    .map(stage => stage.trim())
+    .filter(Boolean);
+
+  if (stages.length === 0) {
+    throw new Error(
+      `Invalid --plan-stage value "${value}".` +
+        ` Allowed values: ${FILE_TIERS.join(', ')}.`,
+    );
+  }
+
+  const invalidStages = stages.filter(
+    stage => !FILE_TIERS.includes(stage as FileTier),
+  );
+
+  if (invalidStages.length > 0) {
+    throw new Error(
+      `Invalid --plan-stage value "${invalidStages.join(', ')}".` +
+        ` Allowed values: ${FILE_TIERS.join(', ')}.`,
+    );
+  }
+
+  return Array.from(new Set(stages)) as FileTier[];
+}
+
+export function buildStagePlanReport(
+  stage: FileTier,
+  payload: ApiPostVariablesPayload,
+  localVariables: ApiGetLocalVariablesResponse,
+): StagePlanReport {
+  const collectionsById = localVariables.meta.variableCollections;
+  const variablesById = localVariables.meta.variables;
+  const modeById = new Map<string, VariableMode>();
+  const modeNameById = new Map<string, string>();
+
+  Object.values(collectionsById).forEach(collection => {
+    collection.modes.forEach(mode => {
+      modeById.set(mode.modeId, mode);
+      modeNameById.set(mode.modeId, `${collection.name}.${mode.name}`);
+    });
+  });
+
+  return {
+    stage,
+    counts: countsFromPostPayload(payload),
+    variableCollections: (payload.variableCollections ?? []).map(change => {
+      const before = change.id ? collectionsById[change.id] : undefined;
+      return {
+        action: change.action,
+        id: change.id ?? null,
+        name: change.name ?? before?.name ?? null,
+        before: collectionSnapshot(before),
+        changes: omitUndefined({
+          initialModeId: change.initialModeId,
+          name: change.name,
+          hiddenFromPublishing: change.hiddenFromPublishing,
+        }),
+      };
+    }),
+    variableModes: (payload.variableModes ?? []).map(change => {
+      const before = change.id ? modeById.get(change.id) : undefined;
+      const collectionId = change.variableCollectionId;
+      return {
+        action: change.action,
+        id: change.id ?? null,
+        name: change.name ?? before?.name ?? null,
+        modeId: change.id ?? null,
+        collectionId,
+        collectionName: collectionsById[collectionId]?.name ?? null,
+        before: before ?? null,
+      };
+    }),
+    variables: (payload.variables ?? []).map(change => {
+      const before = change.id ? variablesById[change.id] : undefined;
+      const collectionId =
+        change.variableCollectionId ?? before?.variableCollectionId ?? null;
+      return {
+        action: change.action,
+        id: change.id ?? null,
+        name: change.name ?? before?.name ?? null,
+        collectionId,
+        collectionName: collectionId
+          ? (collectionsById[collectionId]?.name ?? null)
+          : null,
+        before: variableSnapshot(before),
+        changes: omitUndefined({
+          name: change.name,
+          variableCollectionId: change.variableCollectionId,
+          resolvedType: change.resolvedType,
+          description: change.description,
+          hiddenFromPublishing: change.hiddenFromPublishing,
+          scopes: change.scopes,
+          codeSyntax: change.codeSyntax,
+        }),
+      };
+    }),
+    variableModeValues: (payload.variableModeValues ?? []).map(change => {
+      const variable = variablesById[change.variableId];
+      return {
+        variableId: change.variableId,
+        variableName: variable?.name ?? null,
+        modeId: change.modeId,
+        modeName: modeNameById.get(change.modeId) ?? null,
+        before: variable?.valuesByMode?.[change.modeId] ?? null,
+        after: change.value,
+      };
+    }),
+  };
+}

--- a/packages/hpe-design-tokens/src/tests/sync_plan_report.test.ts
+++ b/packages/hpe-design-tokens/src/tests/sync_plan_report.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiGetLocalVariablesResponse } from '../figma_api.js';
+import {
+  buildStagePlanReport,
+  parsePlanStageFilterValue,
+} from '../sync_plan_report.js';
+
+describe('sync_plan_report', () => {
+  it('parses optional plan stage filter values', () => {
+    expect(parsePlanStageFilterValue(undefined)).toBeNull();
+    expect(parsePlanStageFilterValue('semantic')).toEqual(['semantic']);
+    expect(parsePlanStageFilterValue('semantic,component')).toEqual([
+      'semantic',
+      'component',
+    ]);
+    expect(parsePlanStageFilterValue('semantic, semantic')).toEqual([
+      'semantic',
+    ]);
+  });
+
+  it('rejects invalid plan stage filter values', () => {
+    expect(() => parsePlanStageFilterValue('')).toThrow(
+      'Invalid --plan-stage value',
+    );
+    expect(() => parsePlanStageFilterValue('foo')).toThrow(
+      'Invalid --plan-stage value',
+    );
+  });
+
+  it('builds readable plan entries from payload and local variables', () => {
+    const localVariables = {
+      status: 200,
+      error: false,
+      meta: {
+        variableCollections: {
+          color: {
+            id: 'color',
+            key: 'collection-key',
+            name: 'color',
+            modes: [{ modeId: 'dark', name: 'dark' }],
+            defaultModeId: 'dark',
+            remote: false,
+            hiddenFromPublishing: false,
+          },
+        },
+        variables: {
+          brand: {
+            id: 'brand',
+            name: 'color/background/brand',
+            key: 'var-key',
+            variableCollectionId: 'color',
+            resolvedType: 'COLOR',
+            valuesByMode: {
+              dark: { r: 0, g: 0, b: 0, a: 1 },
+            },
+            remote: false,
+            description: 'before',
+            hiddenFromPublishing: false,
+            scopes: ['ALL_FILLS'],
+            codeSyntax: {},
+          },
+        },
+      },
+    };
+
+    const report = buildStagePlanReport(
+      'semantic',
+      {
+        variables: [
+          {
+            action: 'UPDATE',
+            id: 'brand',
+            description: 'after',
+          },
+        ],
+        variableModeValues: [
+          {
+            variableId: 'brand',
+            modeId: 'dark',
+            value: { r: 1, g: 1, b: 1, a: 1 },
+          },
+        ],
+      },
+      localVariables as ApiGetLocalVariablesResponse,
+    );
+
+    expect(report.stage).toBe('semantic');
+    expect(report.counts.variables.update).toBe(1);
+    expect(report.counts.variableModeValues.update).toBe(1);
+    expect(report.variables).toEqual([
+      {
+        action: 'UPDATE',
+        id: 'brand',
+        name: 'color/background/brand',
+        collectionId: 'color',
+        collectionName: 'color',
+        before: {
+          id: 'brand',
+          name: 'color/background/brand',
+          variableCollectionId: 'color',
+          resolvedType: 'COLOR',
+          description: 'before',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_FILLS'],
+          codeSyntax: {},
+        },
+        changes: {
+          description: 'after',
+        },
+      },
+    ]);
+    expect(report.variableModeValues).toEqual([
+      {
+        variableId: 'brand',
+        variableName: 'color/background/brand',
+        modeId: 'dark',
+        modeName: 'color.dark',
+        before: { r: 0, g: 0, b: 0, a: 1 },
+        after: { r: 1, g: 1, b: 1, a: 1 },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This pull request adds enhanced diagnostics and reporting features to the Figma token sync tooling, focusing on improved visibility into planned changes during dry runs. It introduces new CLI flags for generating and filtering detailed, human-readable and machine-readable reports of planned variable updates, and ensures these features are well-documented and tested. The most important changes are as follows:

**New Diagnostic Features for Sync CLI**  
* Added new flags to `sync-tokens-to-figma`:
  - `--verbose-plan`: prints per-stage planned variable changes as formatted JSON.
  - `--write-plan <path>`: writes a JSON report of the planned per-stage variable diff.
  - `--plan-stage <stage[,stage...]>`: filters plan output to selected stages (`primitive`, `semantic`, `component`). [[1]](diffhunk://#diff-eb6b445ad2faaad0a89c4cc4d036ac5c6ad6433ede9b7dda45e112da2ca8a322L8-R18) [[2]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R36-R40) [[3]](diffhunk://#diff-0939153fcf60d399280eb1f3d3d0172f585796075367b2a8c8fb4bbfca78adcfR1-R230)
* Implemented logic to generate, filter, and output these reports in both the CLI and as files. [[1]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R229-R234) [[2]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R483-R491) [[3]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R505-R508) [[4]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R586-R598) [[5]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R618-R630)

**Documentation Updates**  
* Updated `figma-sync-cli-contract.md` and `OPERATIONS.md` to describe the new flags, their semantics, and usage examples, including how to inspect and save planned diffs and filter by stage. [[1]](diffhunk://#diff-eb6b445ad2faaad0a89c4cc4d036ac5c6ad6433ede9b7dda45e112da2ca8a322L8-R18) [[2]](diffhunk://#diff-eb6b445ad2faaad0a89c4cc4d036ac5c6ad6433ede9b7dda45e112da2ca8a322R56) [[3]](diffhunk://#diff-45a7937d4840d5d9b99e7c6f698744006f4c989b3c2f410bd201af636fbc00a1L8-R9) [[4]](diffhunk://#diff-45a7937d4840d5d9b99e7c6f698744006f4c989b3c2f410bd201af636fbc00a1R34-R52) [[5]](diffhunk://#diff-45a7937d4840d5d9b99e7c6f698744006f4c989b3c2f410bd201af636fbc00a1R119-L104)

**Codebase Improvements**  
* Added a new module, `sync_plan_report.ts`, to encapsulate logic for building detailed plan reports and parsing stage filters.
* Updated the sync scripts to use this new module and improved error handling and output for plan reporting. [[1]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R199-R220) [[2]](diffhunk://#diff-50613a39c961730afae92e93bff70fe7138c0be82bea8e833648747bc701f496R229-R234)

**Testing Enhancements**  
* Added unit tests for the new plan report builder and stage filter parser to ensure correctness and future maintainability.

**Other Quality-of-Life Improvements**  
* The `sync_figma_to_tokens` script now formats output JSON files with Prettier for consistency. [[1]](diffhunk://#diff-c6ebff744c27b2aa73273a63748c9455b9a050b48d67f778641748eaf0cbd406R4) [[2]](diffhunk://#diff-c6ebff744c27b2aa73273a63748c9455b9a050b48d67f778641748eaf0cbd406R360-R371)

These changes provide maintainers with better insight into what will be updated during a sync, safer dry-run workflows, and improved automation support.

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
