### PR TITLE
[hpe-design-tokens] Added colors for v2.3.0

### DIFF
--- a/packages/hpe-design-tokens/src/semantic_color_core.ts
+++ b/packages/hpe-design-tokens/src/semantic_color_core.ts
@@ -67,6 +67,7 @@ export const SEMANTIC_COLOR_ROLES_BY_TARGET = {
     'accent',
   ],
   border: [
+    'accent',
     'critical',
     'default',
     'disabled',
@@ -86,7 +87,7 @@ export const SEMANTIC_COLOR_ROLES_BY_TARGET = {
   ],
   decorative: ['blue', 'brand', 'cyan', 'green', 'neutral', 'purple'],
   focus: ['support'],
-  foreground: ['critical', 'ok', 'primary', 'unknown', 'warning'],
+  foreground: ['critical', 'info', 'ok', 'primary', 'unknown', 'warning'],
   icon: [
     'critical',
     'default',
@@ -144,6 +145,9 @@ export const SEMANTIC_COLOR_SUBROLES_BY_TARGET_FAMILY = {
     selected: ['primary'],
     accent: ['blue', 'cyan', 'purple'],
   },
+  border: {
+    accent: ['blue', 'cyan', 'purple'],
+  },
   dataVis: {
     categorical: ['10', '20', '30', '40', '50', '60', '70', '80'],
   },
@@ -169,6 +173,7 @@ export type SemanticColorSubroleByTargetFamily<
 // Full path-shape reference: docs/SEMANTIC_COLOR_PATH_CONTRACT.md.
 export const SEMANTIC_COLOR_FIGMA_FAMILIES_BY_TARGET = {
   background: ['accent'],
+  border: ['accent'],
 } as const satisfies {
   // entries must be a subset of the family keys in the subroles map
   [T in keyof typeof SEMANTIC_COLOR_SUBROLES_BY_TARGET_FAMILY]?: ReadonlyArray<

--- a/packages/hpe-design-tokens/tokens/component/component.default.json
+++ b/packages/hpe-design-tokens/tokens/component/component.default.json
@@ -6057,7 +6057,7 @@
               }
             },
             "$type": "color",
-            "$value": "{color.border.default.REST}"
+            "$value": "{color.border.strong.REST}"
           }
         },
         "selected": {
@@ -15336,7 +15336,7 @@
                 }
               },
               "$type": "color",
-              "$value": "{color.border.default.REST}"
+              "$value": "{color.border.strong.REST}"
             }
           },
           "readOnly": {
@@ -17217,7 +17217,7 @@
               }
             },
             "$type": "color",
-            "$value": "{color.transparent}"
+            "$value": "{color.background.DEFAULT.hover}"
           },
           "borderColor": {
             "$description": "",
@@ -17255,7 +17255,7 @@
               }
             },
             "$type": "color",
-            "$value": "{color.border.default.REST}"
+            "$value": "{color.border.strong.REST}"
           }
         },
         "selected": {

--- a/packages/hpe-design-tokens/tokens/primitive/primitives.default.json
+++ b/packages/hpe-design-tokens/tokens/primitive/primitives.default.json
@@ -160,6 +160,18 @@
           "$type": "color",
           "$value": "#0070f8"
         },
+        "550": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#0069e8"
+        },
         "700": {
           "$description": "",
           "$extensions": {
@@ -183,6 +195,18 @@
           },
           "$type": "color",
           "$value": "#003cae"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#1c3053"
         },
         "1100": {
           "$description": "",
@@ -260,6 +284,18 @@
         }
       },
       "cyan": {
+        "50": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#c7f9ff"
+        },
         "100": {
           "$description": "",
           "$extensions": {
@@ -319,6 +355,30 @@
           },
           "$type": "color",
           "$value": "#04909d"
+        },
+        "600": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#00838f"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#163a3e"
         }
       },
       "fuschia": {
@@ -850,6 +910,18 @@
         }
       },
       "purple": {
+        "50": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#ece7ff"
+        },
         "100": {
           "$description": "Purple 3",
           "$extensions": {
@@ -886,6 +958,18 @@
           "$type": "color",
           "$value": "#7764fc"
         },
+        "450": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#6751ff"
+        },
         "700": {
           "$description": "Purple 4",
           "$extensions": {
@@ -909,6 +993,18 @@
           },
           "$type": "color",
           "$value": "#3c3aa1"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#32275c"
         }
       },
       "red": {

--- a/packages/hpe-design-tokens/tokens/primitive/primitives.v0.json
+++ b/packages/hpe-design-tokens/tokens/primitive/primitives.v0.json
@@ -160,6 +160,18 @@
           "$type": "color",
           "$value": "#0070f8"
         },
+        "550": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#0069e8"
+        },
         "700": {
           "$description": "",
           "$extensions": {
@@ -183,6 +195,18 @@
           },
           "$type": "color",
           "$value": "#00567a"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#1c3053"
         },
         "1100": {
           "$description": "",
@@ -260,6 +284,18 @@
         }
       },
       "cyan": {
+        "50": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#c7f9ff"
+        },
         "100": {
           "$description": "",
           "$extensions": {
@@ -319,6 +355,30 @@
           },
           "$type": "color",
           "$value": "#04909d"
+        },
+        "600": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#00838f"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#163a3e"
         }
       },
       "fuschia": {
@@ -850,6 +910,18 @@
         }
       },
       "purple": {
+        "50": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#ece7ff"
+        },
         "100": {
           "$description": "Purple 3",
           "$extensions": {
@@ -886,6 +958,18 @@
           "$type": "color",
           "$value": "#7764fc"
         },
+        "450": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#6751ff"
+        },
         "700": {
           "$description": "Purple 4",
           "$extensions": {
@@ -909,6 +993,18 @@
           },
           "$type": "color",
           "$value": "#3c3aa1"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#32275c"
         }
       },
       "red": {

--- a/packages/hpe-design-tokens/tokens/primitive/primitives.v1.json
+++ b/packages/hpe-design-tokens/tokens/primitive/primitives.v1.json
@@ -160,6 +160,18 @@
           "$type": "color",
           "$value": "#0070f8"
         },
+        "550": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#0069e8"
+        },
         "700": {
           "$description": "",
           "$extensions": {
@@ -183,6 +195,18 @@
           },
           "$type": "color",
           "$value": "#00567a"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#1c3053"
         },
         "1100": {
           "$description": "",
@@ -260,6 +284,18 @@
         }
       },
       "cyan": {
+        "50": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#c7f9ff"
+        },
         "100": {
           "$description": "",
           "$extensions": {
@@ -319,6 +355,30 @@
           },
           "$type": "color",
           "$value": "#04909d"
+        },
+        "600": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#00838f"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#163a3e"
         }
       },
       "fuschia": {
@@ -850,6 +910,18 @@
         }
       },
       "purple": {
+        "50": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#ece7ff"
+        },
         "100": {
           "$description": "Purple 3",
           "$extensions": {
@@ -886,6 +958,18 @@
           "$type": "color",
           "$value": "#7764fc"
         },
+        "450": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#6751ff"
+        },
         "700": {
           "$description": "Purple 4",
           "$extensions": {
@@ -909,6 +993,18 @@
           },
           "$type": "color",
           "$value": "#3c3aa1"
+        },
+        "1000": {
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "codeSyntax": {},
+              "hiddenFromPublishing": false,
+              "scopes": ["ALL_SCOPES"]
+            }
+          },
+          "$type": "color",
+          "$value": "#32275c"
         }
       },
       "red": {

--- a/packages/hpe-design-tokens/tokens/semantic/color.dark.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.dark.json
@@ -27,6 +27,98 @@
           "$value": "{base.color.white.opacity6}"
         }
       },
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong blue accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.blue.200}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "Use for subtle blue accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.blue.1000}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong cyan accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.cyan.400}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "Use for subtle cyan accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.cyan.1000}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong purple accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.purple.200}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "Use for subtle purple accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.purple.1000}"
+            }
+          }
+        }
+      },
       "back": {
         "DEFAULT": {
           "REST": {
@@ -263,7 +355,7 @@
               }
             },
             "$type": "color",
-            "$value": "{base.color.black.opacity12}"
+            "$value": "{base.color.black.opacity48}"
           }
         }
       },
@@ -357,6 +449,56 @@
       }
     },
     "border": {
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong blue accent borders. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["STROKE_COLOR", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.blue.200}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong cyan accent borders. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["STROKE_COLOR", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.cyan.400}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong purple accent borders. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["STROKE_COLOR", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.purple.200}"
+            }
+          }
+        }
+      },
       "critical": {
         "DEFAULT": {
           "REST": {
@@ -796,6 +938,22 @@
             },
             "$type": "color",
             "$value": "{base.color.red.500}"
+          }
+        }
+      },
+      "info": {
+        "DEFAULT": {
+          "REST": {
+            "$description": "Use for foreground regions representing a known, non-urgent status, such as informational-severity alerts or values that are noted but require no action. Often used in meters, progress bars, or chart segments where the value does not indicate a problem. Keywords: status, informational, low severity",
+            "$extensions": {
+              "com.figma": {
+                "codeSyntax": {},
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR", "EFFECT_COLOR"]
+              }
+            },
+            "$type": "color",
+            "$value": "{base.color.blue.200}"
           }
         }
       },

--- a/packages/hpe-design-tokens/tokens/semantic/color.dark.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.dark.json
@@ -453,7 +453,7 @@
         "blue": {
           "strong": {
             "REST": {
-              "$description": "Use for strong blue accent borders. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for strong blue accent borders. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -469,7 +469,7 @@
         "cyan": {
           "strong": {
             "REST": {
-              "$description": "Use for strong cyan accent borders. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for strong cyan accent borders. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -485,7 +485,7 @@
         "purple": {
           "strong": {
             "REST": {
-              "$description": "Use for strong purple accent borders. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for strong purple accent borders. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},

--- a/packages/hpe-design-tokens/tokens/semantic/color.light.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.light.json
@@ -27,6 +27,98 @@
           "$value": "{color.background.contrast.DEFAULT.REST}"
         }
       },
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong blue accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.blue.550}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "Use for subtle blue accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.blue.50}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong cyan accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.cyan.600}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "Use for subtle cyan accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.cyan.50}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong purple accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.purple.450}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "Use for subtle purple accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["FRAME_FILL", "SHAPE_FILL", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.purple.50}"
+            }
+          }
+        }
+      },
       "back": {
         "DEFAULT": {
           "REST": {
@@ -357,6 +449,56 @@
       }
     },
     "border": {
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong blue accent borders. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["STROKE_COLOR", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.blue.550}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong cyan accent borders. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["STROKE_COLOR", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.cyan.600}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "Use for strong purple accent borders. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["STROKE_COLOR", "EFFECT_COLOR"]
+                }
+              },
+              "$type": "color",
+              "$value": "{base.color.purple.450}"
+            }
+          }
+        }
+      },
       "critical": {
         "DEFAULT": {
           "REST": {
@@ -796,6 +938,22 @@
             },
             "$type": "color",
             "$value": "{base.color.red.600}"
+          }
+        }
+      },
+      "info": {
+        "DEFAULT": {
+          "REST": {
+            "$description": "Use for foreground regions representing a known, non-urgent status, such as informational-severity alerts or values that are noted but require no action. Often used in meters, progress bars, or chart segments where the value does not indicate a problem. Keywords: status, informational, low severity",
+            "$extensions": {
+              "com.figma": {
+                "codeSyntax": {},
+                "hiddenFromPublishing": false,
+                "scopes": ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR", "EFFECT_COLOR"]
+              }
+            },
+            "$type": "color",
+            "$value": "{base.color.blue.700}"
           }
         }
       },

--- a/packages/hpe-design-tokens/tokens/semantic/color.light.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.light.json
@@ -31,7 +31,7 @@
         "blue": {
           "strong": {
             "REST": {
-              "$description": "Use for strong blue accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for strong blue accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -45,7 +45,7 @@
           },
           "weak": {
             "REST": {
-              "$description": "Use for subtle blue accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for subtle blue accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -61,7 +61,7 @@
         "cyan": {
           "strong": {
             "REST": {
-              "$description": "Use for strong cyan accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for strong cyan accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -75,7 +75,7 @@
           },
           "weak": {
             "REST": {
-              "$description": "Use for subtle cyan accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for subtle cyan accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -91,7 +91,7 @@
         "purple": {
           "strong": {
             "REST": {
-              "$description": "Use for strong purple accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for strong purple accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},
@@ -105,7 +105,7 @@
           },
           "weak": {
             "REST": {
-              "$description": "Use for subtle purple accent backgrounds. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
+              "$description": "Use for subtle purple accent backgrounds. Should be used sparingly. The hue carries no fixed meaning. Keywords: accent, brand, decorative",
               "$extensions": {
                 "com.figma": {
                   "codeSyntax": {},

--- a/packages/hpe-design-tokens/tokens/semantic/color.v0-dark.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.v0-dark.json
@@ -27,6 +27,98 @@
           "$value": "{base.color.white.opacity6}"
         }
       },
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "back": {
         "DEFAULT": {
           "REST": {
@@ -357,6 +449,56 @@
       }
     },
     "border": {
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "critical": {
         "DEFAULT": {
           "REST": {
@@ -796,6 +938,22 @@
             },
             "$type": "color",
             "$value": "{deprecated.base.color.red.550}"
+          }
+        }
+      },
+      "info": {
+        "DEFAULT": {
+          "REST": {
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "codeSyntax": {},
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"]
+              }
+            },
+            "$type": "color",
+            "$value": "{color.transparent}"
           }
         }
       },

--- a/packages/hpe-design-tokens/tokens/semantic/color.v0-light.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.v0-light.json
@@ -27,6 +27,98 @@
           "$value": "{color.background.contrast.DEFAULT.REST}"
         }
       },
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "back": {
         "DEFAULT": {
           "REST": {
@@ -357,6 +449,56 @@
       }
     },
     "border": {
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "critical": {
         "DEFAULT": {
           "REST": {
@@ -796,6 +938,22 @@
             },
             "$type": "color",
             "$value": "{deprecated.base.color.red.600}"
+          }
+        }
+      },
+      "info": {
+        "DEFAULT": {
+          "REST": {
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "codeSyntax": {},
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"]
+              }
+            },
+            "$type": "color",
+            "$value": "{color.transparent}"
           }
         }
       },

--- a/packages/hpe-design-tokens/tokens/semantic/color.v1-dark.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.v1-dark.json
@@ -27,6 +27,98 @@
           "$value": "{base.color.white.opacity6}"
         }
       },
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "back": {
         "DEFAULT": {
           "REST": {
@@ -357,6 +449,56 @@
       }
     },
     "border": {
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "critical": {
         "DEFAULT": {
           "REST": {
@@ -796,6 +938,22 @@
             },
             "$type": "color",
             "$value": "{deprecated.base.color.red.550}"
+          }
+        }
+      },
+      "info": {
+        "DEFAULT": {
+          "REST": {
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "codeSyntax": {},
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"]
+              }
+            },
+            "$type": "color",
+            "$value": "{color.transparent}"
           }
         }
       },

--- a/packages/hpe-design-tokens/tokens/semantic/color.v1-light.json
+++ b/packages/hpe-design-tokens/tokens/semantic/color.v1-light.json
@@ -27,6 +27,98 @@
           "$value": "{color.background.contrast.DEFAULT.REST}"
         }
       },
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          },
+          "weak": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "back": {
         "DEFAULT": {
           "REST": {
@@ -357,6 +449,56 @@
       }
     },
     "border": {
+      "accent": {
+        "blue": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "cyan": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        },
+        "purple": {
+          "strong": {
+            "REST": {
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "codeSyntax": {},
+                  "hiddenFromPublishing": false,
+                  "scopes": ["ALL_SCOPES"]
+                }
+              },
+              "$type": "color",
+              "$value": "{color.transparent}"
+            }
+          }
+        }
+      },
       "critical": {
         "DEFAULT": {
           "REST": {
@@ -796,6 +938,22 @@
             },
             "$type": "color",
             "$value": "{deprecated.base.color.red.600}"
+          }
+        }
+      },
+      "info": {
+        "DEFAULT": {
+          "REST": {
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "codeSyntax": {},
+                "hiddenFromPublishing": false,
+                "scopes": ["ALL_SCOPES"]
+              }
+            },
+            "$type": "color",
+            "$value": "{color.transparent}"
           }
         }
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?

Related to: https://github.com/grommet/hpe-design-system/issues/6029

This pull request expands and updates the HPE design tokens with new color primitives and improved semantic color mappings. The main changes include the addition of new color steps for blue, cyan, and purple primitives, updates to semantic color role assignments, and adjustments to component border color references for improved consistency and visual clarity.

**Design token primitive expansion:**

* Added new color steps (e.g., 50, 450, 550, 600, 1000) for `blue`, `cyan`, and `purple` in all primitive token JSON files to provide finer granularity for these color scales. [[1]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R163-R174) [[2]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R199-R210) [[3]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R287-R298) [[4]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R358-R381) [[5]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R913-R924) [[6]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R961-R972) [[7]](diffhunk://#diff-d7c6717645187d0663249d4b2d03ba49720e066bcb3f6b5b3556c645fb863d86R996-R1007) [[8]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR163-R174) [[9]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR199-R210) [[10]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR287-R298) [[11]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR358-R381) [[12]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR913-R924) [[13]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR961-R972) [[14]](diffhunk://#diff-9daa57f38247c43d6f7dba8bcdd0ce69f6333b0505c3553c93b9d62c4c53dedbR996-R1007)

**Semantic color role and subrole updates:**

* Updated `semantic_color_core.ts` to include `accent` in the `border` roles and subroles, and added `info` to the `foreground` roles, improving semantic mapping flexibility. [[1]](diffhunk://#diff-a5b762539cba56060632e2fdb08afc59782eb8d1deeeb048fdea064f2f73c4ffR70) [[2]](diffhunk://#diff-a5b762539cba56060632e2fdb08afc59782eb8d1deeeb048fdea064f2f73c4ffL89-R90) [[3]](diffhunk://#diff-a5b762539cba56060632e2fdb08afc59782eb8d1deeeb048fdea064f2f73c4ffR148-R150) [[4]](diffhunk://#diff-a5b762539cba56060632e2fdb08afc59782eb8d1deeeb048fdea064f2f73c4ffR176)

**Component token reference improvements:**

* Changed several component border color references from `color.border.default.REST` to `color.border.strong.REST` for a stronger, more consistent border appearance. [[1]](diffhunk://#diff-9c1330715d86c3b00c8b5b2ae7dc772034ea14d1505c3c8b13d17c8f257824d4L6060-R6060) [[2]](diffhunk://#diff-9c1330715d86c3b00c8b5b2ae7dc772034ea14d1505c3c8b13d17c8f257824d4L15339-R15339) [[3]](diffhunk://#diff-9c1330715d86c3b00c8b5b2ae7dc772034ea14d1505c3c8b13d17c8f257824d4L17258-R17258)
* Updated a component background color reference from `{color.transparent}` to `{color.background.DEFAULT.hover}` for better visual feedback on hover states.

These changes together enhance the flexibility, consistency, and visual clarity of the HPE design token system.

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/6029

#### Where should the reviewer start?

#### How should this be manually tested?

Reference https://github.com/grommet/hpe-design-system/issues/6029#issuecomment-4924803471 for expected token changes. Use this as the spec.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
