### PR TITLE
[Docs] - Improvements to skills and agents - markdown backsticks

### DIFF
--- a/knowledge/capabilities/docs-refactor/agents/generate-mdx.agent.md
+++ b/knowledge/capabilities/docs-refactor/agents/generate-mdx.agent.md
@@ -93,7 +93,7 @@ You are the second step in the per-component docs refactor pipeline, running aft
 - **Never add a bare JSX comment as the only child** of an `<Example bestPractice>` block — this crashes `cloneElement` at runtime. Always wrap it in `<div>`.
 - **Gerund phrases only** for use case `###` subheadings. Never use noun phrases or questions.
 - **Do not invent sections** not present in `knowledge/capabilities/docs-refactor/docs/COMPONENT_TEMPLATE.md`.
-- **Follow `knowledge/core/skills/writing-style.skill.md` strictly:** imperative tone, sentence case headings, short sentences, favor lists over paragraphs, assert non-negotiables with "Always" or "Never".
+- **Follow `knowledge/core/skills/writing-style.skill.md` strictly:** imperative tone, sentence case headings, short sentences, favor lists over paragraphs, assert non-negotiables with "Always" or "Never", and apply inline code formatting only to literal identifiers (props, ARIA attributes and values, design token identifiers, and literal code/API identifiers), not prose terms.
 
 ## Output Format
 

--- a/knowledge/capabilities/docs-refactor/agents/review-copy.agent.md
+++ b/knowledge/capabilities/docs-refactor/agents/review-copy.agent.md
@@ -43,7 +43,8 @@ You run after `generate-mdx-agent` has produced `[component-name].mdx`. Read `kn
 
    **Specificity:**
    - Is advice objective, concise, and where appropriate quantitative? — flag subjective or qualitative explanations that could be sharpened
-   - Are component prop names and design token names wrapped in code formatting (backticks)?
+   - Are literal identifiers wrapped in inline code formatting? — flag missing formatting for component prop names, ARIA attributes and values, design token identifiers, and literal code or API identifiers
+   - Is inline code formatting overused for prose? — flag plain-language UI terms, section labels, anatomy region names, and emphasis-only wording that should be normal text
 
    **Scope:**
    - Are `whenToAvoid` items (counter-indications) absent from `## Use cases`? — flag any "when not to use" guidance that leaked into use case descriptions

--- a/knowledge/core/skills/writing-style.skill.md
+++ b/knowledge/core/skills/writing-style.skill.md
@@ -12,7 +12,13 @@ When writing documentation, consider these best practices:
 - **Favor specific advice** that’s objective, concise and often quantitative over subjective, qualitative, and laborious explanations.
 - **Favor examples and images**. When writing the guidelines, consider: “Would a picture work better here? If so, is it worth it?”
 - **Write in an impersonal style**. Avoid “I,” “we,” or “you.” Focus on the action, not the actor.
-- Use code styling from Markdown when referencing a prop of a token name.
+- Use inline code formatting only for literal identifiers, including:
+	- Component prop names, such as `label`, `reverse`, and `indeterminate`.
+	- ARIA attributes and values, such as `aria-labelledby`, `aria-checked`, `true`, and `mixed`.
+	- Design token identifiers.
+	- Literal code and API identifiers, such as component names, JSX tags, or symbol names when referenced as code.
+- Do not use inline code formatting for plain prose terms, section labels, anatomy region names, or emphasis-only styling.
+- If uncertain, default to prose unless the term is a literal API or code identifier.
 - When talking about design tokens, always make sure to refer to them as design tokens and not only tokens.
 
 ## Voice and tone


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
This PR refines and standardizes inline code formatting guidance across the docs workflow by clarifying when code-style formatting should be used (literal identifiers like props, ARIA, and token identifiers) and when it should not (plain prose). It also updates docs-refactor agent instructions so generation and copy review enforce that same rule consistently.

#### What are the relevant issues?

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
Comes from comment https://github.com/grommet/hpe-design-system/pull/6212#discussion_r3716204645
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
