### PR TITLE
Add SPDX headers: docs 1

### DIFF
--- a/apps/docs/src/examples/cardPreviews/SearchPreview.js
+++ b/apps/docs/src/examples/cardPreviews/SearchPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { useInert } from '@shared/hooks';
 import { SearchExample } from '../components/search';

--- a/apps/docs/src/examples/cardPreviews/anchor.js
+++ b/apps/docs/src/examples/cardPreviews/anchor.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, Text } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/avatar.js
+++ b/apps/docs/src/examples/cardPreviews/avatar.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Avatar } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/box.js
+++ b/apps/docs/src/examples/cardPreviews/box.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/button.js
+++ b/apps/docs/src/examples/cardPreviews/button.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Right } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/cardPreviews/checkbox.js
+++ b/apps/docs/src/examples/cardPreviews/checkbox.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CheckBox, FormField } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/checkboxgroup.js
+++ b/apps/docs/src/examples/cardPreviews/checkboxgroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CheckBoxGroup, Form, FormField } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/code-blocks.js
+++ b/apps/docs/src/examples/cardPreviews/code-blocks.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 
 import { Box, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/cardPreviews/content-layouts/ContentLayoutPreview.js
+++ b/apps/docs/src/examples/cardPreviews/content-layouts/ContentLayoutPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Grid } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/content-layouts/index.js
+++ b/apps/docs/src/examples/cardPreviews/content-layouts/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContentLayoutPreview';

--- a/apps/docs/src/examples/cardPreviews/data-how-to-add-additional-controls.js
+++ b/apps/docs/src/examples/cardPreviews/data-how-to-add-additional-controls.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, TextInput } from 'grommet';
 import { Filter, Search, Descend, Columns } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/cardPreviews/data-how-to.js
+++ b/apps/docs/src/examples/cardPreviews/data-how-to.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, TextInput } from 'grommet';
 import { Filter, Search } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/cardPreviews/datafilter.js
+++ b/apps/docs/src/examples/cardPreviews/datafilter.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataFilter } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/datafilters.js
+++ b/apps/docs/src/examples/cardPreviews/datafilters.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataFilters } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/datasearch.js
+++ b/apps/docs/src/examples/cardPreviews/datasearch.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataSearch } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/datasort.js
+++ b/apps/docs/src/examples/cardPreviews/datasort.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataSort } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/datasummary.js
+++ b/apps/docs/src/examples/cardPreviews/datasummary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataSummary } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/datatablecolumns.js
+++ b/apps/docs/src/examples/cardPreviews/datatablecolumns.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataTableColumns } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/datatablegroupby.js
+++ b/apps/docs/src/examples/cardPreviews/datatablegroupby.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataTableGroupBy } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/dataview.js
+++ b/apps/docs/src/examples/cardPreviews/dataview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, Toolbar, DataView } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/dateinput.js
+++ b/apps/docs/src/examples/cardPreviews/dateinput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, DateInput } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/double-confirmation.js
+++ b/apps/docs/src/examples/cardPreviews/double-confirmation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Button } from 'grommet';
 import { useInert } from '@shared/hooks';
 import { LayerHeader, ModalContainer, ModalFooter } from '@shared/aries-core';

--- a/apps/docs/src/examples/cardPreviews/emptystate.js
+++ b/apps/docs/src/examples/cardPreviews/emptystate.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { EmptyState } from '@shared/aries-core';
 import { Button, Box } from 'grommet';

--- a/apps/docs/src/examples/cardPreviews/feedback.js
+++ b/apps/docs/src/examples/cardPreviews/feedback.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { StarRating } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/footer.js
+++ b/apps/docs/src/examples/cardPreviews/footer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Footer, Text } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/grid.js
+++ b/apps/docs/src/examples/cardPreviews/grid.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Grid, Box } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/header.js
+++ b/apps/docs/src/examples/cardPreviews/header.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Header, Button, Text } from 'grommet';
 import { Menu, Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/cardPreviews/index.js
+++ b/apps/docs/src/examples/cardPreviews/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './avatar';
 export * from './anchor';
 export * from './box';

--- a/apps/docs/src/examples/cardPreviews/layer.js
+++ b/apps/docs/src/examples/cardPreviews/layer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';

--- a/apps/docs/src/examples/cardPreviews/maskedinput.js
+++ b/apps/docs/src/examples/cardPreviews/maskedinput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { MaskedInput } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/menu.js
+++ b/apps/docs/src/examples/cardPreviews/menu.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Menu } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/namevaluelist.js
+++ b/apps/docs/src/examples/cardPreviews/namevaluelist.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/page-layouts/HeaderFooterPreview.js
+++ b/apps/docs/src/examples/cardPreviews/page-layouts/HeaderFooterPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, defaultProps } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/page-layouts/HeaderOnlyPreview.js
+++ b/apps/docs/src/examples/cardPreviews/page-layouts/HeaderOnlyPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, defaultProps } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/page-layouts/StickyHeaderPreview.js
+++ b/apps/docs/src/examples/cardPreviews/page-layouts/StickyHeaderPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, defaultProps } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/page-layouts/index.js
+++ b/apps/docs/src/examples/cardPreviews/page-layouts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './HeaderFooterPreview';
 export * from './HeaderOnlyPreview';
 export * from './StickyHeaderPreview';

--- a/apps/docs/src/examples/cardPreviews/popover.js
+++ b/apps/docs/src/examples/cardPreviews/popover.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button, Box, Paragraph } from 'grommet';
 import { Info } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/cardPreviews/radiobuttonGroup.js
+++ b/apps/docs/src/examples/cardPreviews/radiobuttonGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { RadioButtonGroup } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/rangeinput.js
+++ b/apps/docs/src/examples/cardPreviews/rangeinput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { RangeInput } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/selector.js
+++ b/apps/docs/src/examples/cardPreviews/selector.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { SelectorGroup, Selector } from '@shared/aries-core';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/skeleton.js
+++ b/apps/docs/src/examples/cardPreviews/skeleton.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Skeleton } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/status-indicator.js
+++ b/apps/docs/src/examples/cardPreviews/status-indicator.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/cardPreviews/tabs.js
+++ b/apps/docs/src/examples/cardPreviews/tabs.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Tabs, Tab } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/tag.js
+++ b/apps/docs/src/examples/cardPreviews/tag.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Tag } from 'grommet';
 

--- a/apps/docs/src/examples/cardPreviews/textarea.js
+++ b/apps/docs/src/examples/cardPreviews/textarea.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TextArea } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/textinput.js
+++ b/apps/docs/src/examples/cardPreviews/textinput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, TextInput } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/cardPreviews/toast-notification.js
+++ b/apps/docs/src/examples/cardPreviews/toast-notification.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/cardPreviews/togglegroup.js
+++ b/apps/docs/src/examples/cardPreviews/togglegroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, ToggleGroup } from 'grommet';
 import { Table, List, Map } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/cardPreviews/toolbar.js
+++ b/apps/docs/src/examples/cardPreviews/toolbar.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Toolbar, TextInput, DropButton } from 'grommet';
 import { Search, Filter } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/accordion/AccordionExample.js
+++ b/apps/docs/src/examples/components/accordion/AccordionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Accordion, AccordionPanel, Box } from 'grommet';
 

--- a/apps/docs/src/examples/components/accordion/index.js
+++ b/apps/docs/src/examples/components/accordion/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AccordionExample';

--- a/apps/docs/src/examples/components/anchor/AnchorBadExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorBadExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/components/anchor/AnchorDisabledExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor } from 'grommet';
 

--- a/apps/docs/src/examples/components/anchor/AnchorExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/anchor/AnchorExternalExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorExternalExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/components/anchor/AnchorGoodExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorGoodExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/components/anchor/AnchorIconExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor } from 'grommet';
 import { NewWindow } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/anchor/AnchorInlineExample.js
+++ b/apps/docs/src/examples/components/anchor/AnchorInlineExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/components/anchor/index.js
+++ b/apps/docs/src/examples/components/anchor/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AnchorExample';
 export * from './AnchorBadExample';
 export * from './AnchorDisabledExample';

--- a/apps/docs/src/examples/components/avatar/AvatarAccessibilityExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarAccessibilityExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Avatar, Box, Button, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/avatar/AvatarDarkModeExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarDarkModeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Avatar, Box } from 'grommet';
 

--- a/apps/docs/src/examples/components/avatar/AvatarDataTableExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarDataTableExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Avatar, Box, DataTable, Text } from 'grommet';

--- a/apps/docs/src/examples/components/avatar/AvatarDataTableIconExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarDataTableIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/avatar/AvatarExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Avatar } from 'grommet';
 

--- a/apps/docs/src/examples/components/avatar/AvatarPageHeaderExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarPageHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { Avatar, Box, Button, PageHeader } from 'grommet';

--- a/apps/docs/src/examples/components/avatar/AvatarSizePreviewExample.js
+++ b/apps/docs/src/examples/components/avatar/AvatarSizePreviewExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Avatar, Box, Text } from 'grommet';

--- a/apps/docs/src/examples/components/avatar/index.js
+++ b/apps/docs/src/examples/components/avatar/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AvatarAccessibilityExample';
 export * from './AvatarDarkModeExample';
 export * from './AvatarDataTableExample';

--- a/apps/docs/src/examples/components/button/ButtonAlignmentTable.js
+++ b/apps/docs/src/examples/components/button/ButtonAlignmentTable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { Fragment } from 'react';
 import Link from 'next/link';
 import {

--- a/apps/docs/src/examples/components/button/ButtonBadgeExample.js
+++ b/apps/docs/src/examples/components/button/ButtonBadgeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button } from 'grommet';
 import { Notification } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/button/ButtonBusyExample.js
+++ b/apps/docs/src/examples/components/button/ButtonBusyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/button/ButtonBusySimpleExample.js
+++ b/apps/docs/src/examples/components/button/ButtonBusySimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Button } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/ButtonExample.js
+++ b/apps/docs/src/examples/components/button/ButtonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/ButtonIconExample.js
+++ b/apps/docs/src/examples/components/button/ButtonIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, ResponsiveContext } from 'grommet';
 import { Left, Right } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/button/ButtonLeftAlignExample.js
+++ b/apps/docs/src/examples/components/button/ButtonLeftAlignExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Header } from 'grommet';
 import { ButtonGroup, TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/button/ButtonRightAlignExample.js
+++ b/apps/docs/src/examples/components/button/ButtonRightAlignExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Header } from 'grommet';
 import { ButtonGroup, TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/button/ButtonSizingExample.js
+++ b/apps/docs/src/examples/components/button/ButtonSizingExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, ResponsiveContext } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/ButtonStatesExample.js
+++ b/apps/docs/src/examples/components/button/ButtonStatesExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, ResponsiveContext } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/DefaultButtonExample.js
+++ b/apps/docs/src/examples/components/button/DefaultButtonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/DosDonts/ButtonBadCancelPreview.js
+++ b/apps/docs/src/examples/components/button/DosDonts/ButtonBadCancelPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Heading, Header, Paragraph } from 'grommet';
 import { ButtonGroup } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/button/DosDonts/ButtonBadGroupPreview.js
+++ b/apps/docs/src/examples/components/button/DosDonts/ButtonBadGroupPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Heading, Header, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/DosDonts/ButtonBadSignUpPreview.js
+++ b/apps/docs/src/examples/components/button/DosDonts/ButtonBadSignUpPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/components/button/DosDonts/ButtonGoodCancelPreview.js
+++ b/apps/docs/src/examples/components/button/DosDonts/ButtonGoodCancelPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Heading, Header, Paragraph } from 'grommet';
 import { ButtonGroup } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/button/DosDonts/ButtonGoodLongTitlePreview.js
+++ b/apps/docs/src/examples/components/button/DosDonts/ButtonGoodLongTitlePreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Heading, Header, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/DosDonts/ButtonGoodSignUpPreview.js
+++ b/apps/docs/src/examples/components/button/DosDonts/ButtonGoodSignUpPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/components/button/DosDonts/index.js
+++ b/apps/docs/src/examples/components/button/DosDonts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ButtonBadCancelPreview';
 export * from './ButtonBadGroupPreview';
 export * from './ButtonBadSignUpPreview';

--- a/apps/docs/src/examples/components/button/PrimaryButtonExample.js
+++ b/apps/docs/src/examples/components/button/PrimaryButtonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/SecondaryButtonExample.js
+++ b/apps/docs/src/examples/components/button/SecondaryButtonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 

--- a/apps/docs/src/examples/components/button/ToolbarButtonExample.js
+++ b/apps/docs/src/examples/components/button/ToolbarButtonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/button/index.js
+++ b/apps/docs/src/examples/components/button/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ButtonAlignmentTable';
 export * from './ButtonExample';
 export * from './ButtonBadgeExample';

--- a/apps/docs/src/examples/components/calendar/CalendarExample.js
+++ b/apps/docs/src/examples/components/calendar/CalendarExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Calendar } from 'grommet';
 

--- a/apps/docs/src/examples/components/calendar/index.js
+++ b/apps/docs/src/examples/components/calendar/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CalendarExample';

--- a/apps/docs/src/examples/components/card/ActivitiesNavigationalCards.js
+++ b/apps/docs/src/examples/components/card/ActivitiesNavigationalCards.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Heading, Grid, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/components/card/ApplicationsNavigationalCards.js
+++ b/apps/docs/src/examples/components/card/ApplicationsNavigationalCards.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Anchor, Box, Button, Heading, Grid, ResponsiveContext } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/CallToActionAnatomy.js
+++ b/apps/docs/src/examples/components/card/CallToActionAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/card/CardAlignmentBestPractice.js
+++ b/apps/docs/src/examples/components/card/CardAlignmentBestPractice.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Card, CardBody, Heading, Paragraph } from 'grommet';

--- a/apps/docs/src/examples/components/card/CardContentBestPractice.js
+++ b/apps/docs/src/examples/components/card/CardContentBestPractice.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/card/CardFilteringBestPractice.js
+++ b/apps/docs/src/examples/components/card/CardFilteringBestPractice.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/card/CardKitchenSink.js
+++ b/apps/docs/src/examples/components/card/CardKitchenSink.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Grid } from 'grommet';
 import { EventPromotionCard, NavigationalCardPreview } from '.';

--- a/apps/docs/src/examples/components/card/CardSpacingBestPractice.js
+++ b/apps/docs/src/examples/components/card/CardSpacingBestPractice.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Grid } from 'grommet';

--- a/apps/docs/src/examples/components/card/CardTypes.js
+++ b/apps/docs/src/examples/components/card/CardTypes.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';

--- a/apps/docs/src/examples/components/card/EventPromotionCard.js
+++ b/apps/docs/src/examples/components/card/EventPromotionCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Image } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/EventPromotionRowCard.js
+++ b/apps/docs/src/examples/components/card/EventPromotionRowCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Image } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/FeaturePromotionCard.js
+++ b/apps/docs/src/examples/components/card/FeaturePromotionCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Heading } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/FeatureReleaseCard.js
+++ b/apps/docs/src/examples/components/card/FeatureReleaseCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/MarketplaceNavigationalCards.js
+++ b/apps/docs/src/examples/components/card/MarketplaceNavigationalCards.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Heading, Image, Grid, ResponsiveContext, Tag } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/NavigationalAnatomy.js
+++ b/apps/docs/src/examples/components/card/NavigationalAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/card/NavigationalCardPreview.js
+++ b/apps/docs/src/examples/components/card/NavigationalCardPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { activities } from './data';

--- a/apps/docs/src/examples/components/card/ToolsNavigationalCards.js
+++ b/apps/docs/src/examples/components/card/ToolsNavigationalCards.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Button, Heading, Grid, ResponsiveContext } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/TrialPromotionCard.js
+++ b/apps/docs/src/examples/components/card/TrialPromotionCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/TrialPromotionColorCard.js
+++ b/apps/docs/src/examples/components/card/TrialPromotionColorCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/TrialPromotionRowCard.js
+++ b/apps/docs/src/examples/components/card/TrialPromotionRowCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/card/data.js
+++ b/apps/docs/src/examples/components/card/data.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   CloudUpload,
   Notes,

--- a/apps/docs/src/examples/components/card/index.js
+++ b/apps/docs/src/examples/components/card/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ActivitiesNavigationalCards';
 export * from './ApplicationsNavigationalCards';
 export * from './CallToActionAnatomy';

--- a/apps/docs/src/examples/components/carousel/CarouselExample.js
+++ b/apps/docs/src/examples/components/carousel/CarouselExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Carousel, Image } from 'grommet';
 

--- a/apps/docs/src/examples/components/carousel/index.js
+++ b/apps/docs/src/examples/components/carousel/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CarouselExample';

--- a/apps/docs/src/examples/components/chart/ChartExample.js
+++ b/apps/docs/src/examples/components/chart/ChartExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Chart } from 'grommet';
 

--- a/apps/docs/src/examples/components/chart/index.js
+++ b/apps/docs/src/examples/components/chart/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ChartExample';

--- a/apps/docs/src/examples/components/checkbox/CheckBoxDisabledExample.js
+++ b/apps/docs/src/examples/components/checkbox/CheckBoxDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CheckBox, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkbox/CheckBoxSimpleExample.js
+++ b/apps/docs/src/examples/components/checkbox/CheckBoxSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { CheckBox, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkbox/CheckBoxSolelyExample.js
+++ b/apps/docs/src/examples/components/checkbox/CheckBoxSolelyExample.js
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
-
 import React, { useState } from 'react';
 import { CheckBox } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkbox/CheckBoxSolelyExample.js
+++ b/apps/docs/src/examples/components/checkbox/CheckBoxSolelyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
 import { CheckBox } from 'grommet';

--- a/apps/docs/src/examples/components/checkbox/CheckBoxToggleExample.js
+++ b/apps/docs/src/examples/components/checkbox/CheckBoxToggleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { CheckBox, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkbox/CheckBoxValidationExample.js
+++ b/apps/docs/src/examples/components/checkbox/CheckBoxValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, CheckBox, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkbox/index.js
+++ b/apps/docs/src/examples/components/checkbox/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CheckBoxDisabledExample';
 export * from './CheckBoxSimpleExample';
 export * from './CheckBoxSolelyExample';

--- a/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupDescriptionExample.js
+++ b/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupDescriptionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CheckBoxGroup, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupDisabledExample.js
+++ b/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CheckBoxGroup, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js
+++ b/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CheckBoxGroup, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
+++ b/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CheckBoxGroup, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupSimpleExample.js
+++ b/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CheckBoxGroup, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupValidationExample.js
+++ b/apps/docs/src/examples/components/checkboxgroup/CheckBoxGroupValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, CheckBoxGroup, Form, FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/checkboxgroup/index.js
+++ b/apps/docs/src/examples/components/checkboxgroup/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CheckBoxGroupDescriptionExample';
 export * from './CheckBoxGroupScrollExample';
 export * from './CheckBoxGroupDisabledExample';

--- a/apps/docs/src/examples/components/clock/ClockExample.js
+++ b/apps/docs/src/examples/components/clock/ClockExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Clock } from 'grommet';
 
 export const ClockExample = () => (

--- a/apps/docs/src/examples/components/clock/index.js
+++ b/apps/docs/src/examples/components/clock/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ClockExample';

--- a/apps/docs/src/examples/components/data/DataExample.js
+++ b/apps/docs/src/examples/components/data/DataExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/data/DataFilterExample.js
+++ b/apps/docs/src/examples/components/data/DataFilterExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataFilter, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataFiltersExample.js
+++ b/apps/docs/src/examples/components/data/DataFiltersExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataFilters, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataSearchExample.js
+++ b/apps/docs/src/examples/components/data/DataSearchExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataSearch, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataSortExample.js
+++ b/apps/docs/src/examples/components/data/DataSortExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataSort, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataSummaryExample.js
+++ b/apps/docs/src/examples/components/data/DataSummaryExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataSummary } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataTableColumnsExample.js
+++ b/apps/docs/src/examples/components/data/DataTableColumnsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataTableColumns, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataTableGroupByExample.js
+++ b/apps/docs/src/examples/components/data/DataTableGroupByExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataTableGroupBy, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/DataViewExample.js
+++ b/apps/docs/src/examples/components/data/DataViewExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataView, Toolbar } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/data/ToolbarExample.js
+++ b/apps/docs/src/examples/components/data/ToolbarExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/data/index.js
+++ b/apps/docs/src/examples/components/data/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DataExample';
 export * from './DataFilterExample';
 export * from './DataFiltersExample';

--- a/apps/docs/src/examples/components/datachart/DataChartExample.js
+++ b/apps/docs/src/examples/components/datachart/DataChartExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { DataChart, Text } from 'grommet';
 
 const data = [];

--- a/apps/docs/src/examples/components/datachart/index.js
+++ b/apps/docs/src/examples/components/datachart/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DataChartExample';

--- a/apps/docs/src/examples/components/datatable/DataTableAnatomy.js
+++ b/apps/docs/src/examples/components/datatable/DataTableAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/components/datatable/DataTableCombinedStatusStateExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableCombinedStatusStateExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/components/datatable/DataTableEmptyCellExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableEmptyCellExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/datatable/DataTableExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/datatable/DataTableFixedHeaderExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableFixedHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, DataTable, Text, Heading } from 'grommet';

--- a/apps/docs/src/examples/components/datatable/DataTableMultiSelectExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableMultiSelectExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/datatable/DataTableResizeColumnsExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableResizeColumnsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, DataTable, Heading, Text } from 'grommet';

--- a/apps/docs/src/examples/components/datatable/DataTableSeparateStatusStateExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableSeparateStatusStateExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/components/datatable/DataTableSingleSelectExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableSingleSelectExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/datatable/DataTableSortable.js
+++ b/apps/docs/src/examples/components/datatable/DataTableSortable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/datatable/DataTableStatusOnlyExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableStatusOnlyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/components/datatable/DataTableSummaryExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableSummaryExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, DataTable, Heading, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/components/datatable/DataTableVerticalListExample.js
+++ b/apps/docs/src/examples/components/datatable/DataTableVerticalListExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/datatable/StatusIcon.js
+++ b/apps/docs/src/examples/components/datatable/StatusIcon.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 
 import {

--- a/apps/docs/src/examples/components/datatable/index.js
+++ b/apps/docs/src/examples/components/datatable/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DataTableAnatomy';
 export * from './DataTableCombinedStatusStateExample';
 export * from './DataTableExample';

--- a/apps/docs/src/examples/components/dateinput/DateInputExample.js
+++ b/apps/docs/src/examples/components/dateinput/DateInputExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, DateInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/dateinput/DateInputRangeExample.js
+++ b/apps/docs/src/examples/components/dateinput/DateInputRangeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Form, FormField, DateInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/dateinput/DateInputReadOnlyExample.js
+++ b/apps/docs/src/examples/components/dateinput/DateInputReadOnlyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Form, FormField, DateInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/dateinput/DateInputSimpleExample.js
+++ b/apps/docs/src/examples/components/dateinput/DateInputSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, DateInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/dateinput/DateInputValidationExample.js
+++ b/apps/docs/src/examples/components/dateinput/DateInputValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Form, FormField, DateInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/dateinput/index.js
+++ b/apps/docs/src/examples/components/dateinput/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DateInputSimpleExample';
 export * from './DateInputRangeExample';
 export * from './DateInputExample';

--- a/apps/docs/src/examples/components/diagram/DiagramExample.js
+++ b/apps/docs/src/examples/components/diagram/DiagramExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Diagram, Stack } from 'grommet';

--- a/apps/docs/src/examples/components/diagram/index.js
+++ b/apps/docs/src/examples/components/diagram/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DiagramExample';

--- a/apps/docs/src/examples/components/drop/DropExample.js
+++ b/apps/docs/src/examples/components/drop/DropExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react';
 import { Box, Drop, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/drop/index.js
+++ b/apps/docs/src/examples/components/drop/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DropExample';

--- a/apps/docs/src/examples/components/dropbutton/DropButtonExample.js
+++ b/apps/docs/src/examples/components/dropbutton/DropButtonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, DropButton, Heading, Paragraph } from 'grommet';

--- a/apps/docs/src/examples/components/dropbutton/index.js
+++ b/apps/docs/src/examples/components/dropbutton/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DropButtonExample';

--- a/apps/docs/src/examples/components/fileinput/FileInputConfirmRemoveExample.js
+++ b/apps/docs/src/examples/components/fileinput/FileInputConfirmRemoveExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Button, FileInput, Heading, Layer, Paragraph } from 'grommet';
 import { ButtonGroup } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/fileinput/FileInputMultipleExample.js
+++ b/apps/docs/src/examples/components/fileinput/FileInputMultipleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, FileInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/fileinput/FileInputSimpleExample.js
+++ b/apps/docs/src/examples/components/fileinput/FileInputSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, FileInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/fileinput/FileInputValidationExample.js
+++ b/apps/docs/src/examples/components/fileinput/FileInputValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, FileInput, Form, FormField } from 'grommet';
 import { useState } from 'react';
 

--- a/apps/docs/src/examples/components/fileinput/index.js
+++ b/apps/docs/src/examples/components/fileinput/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FileInputConfirmRemoveExample';
 export * from './FileInputSimpleExample';
 export * from './FileInputMultipleExample';

--- a/apps/docs/src/examples/components/footer/FooterComboExample.js
+++ b/apps/docs/src/examples/components/footer/FooterComboExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Button, Footer, ResponsiveContext, Text } from 'grommet';
 import { Left, Right } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/footer/FooterExample.js
+++ b/apps/docs/src/examples/components/footer/FooterExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Button, Footer, ResponsiveContext, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/footer/FooterPageExample.js
+++ b/apps/docs/src/examples/components/footer/FooterPageExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button, Footer } from 'grommet';
 import { Left, Right } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/footer/index.js
+++ b/apps/docs/src/examples/components/footer/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FooterExample';
 export * from './FooterComboExample';
 export * from './FooterPageExample';

--- a/apps/docs/src/examples/components/grid/FlexGrid.js
+++ b/apps/docs/src/examples/components/grid/FlexGrid.js
@@ -1,0 +1,2 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0

--- a/apps/docs/src/examples/components/grid/FluidGrid1.js
+++ b/apps/docs/src/examples/components/grid/FluidGrid1.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import { ContentArea } from '../../templates/page-layouts/anatomy/components';
 import { contentAreaProps as props } from './utils';

--- a/apps/docs/src/examples/components/grid/FluidGrid2.js
+++ b/apps/docs/src/examples/components/grid/FluidGrid2.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import { ContentArea } from '../../templates/page-layouts/anatomy/components';
 import { contentAreaProps as props } from './utils';

--- a/apps/docs/src/examples/components/grid/GapExample.js
+++ b/apps/docs/src/examples/components/grid/GapExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import { ContentArea } from '../../templates/page-layouts/anatomy/components';
 import { contentAreaProps as props } from './utils';

--- a/apps/docs/src/examples/components/grid/MinMaxColumns1.js
+++ b/apps/docs/src/examples/components/grid/MinMaxColumns1.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import {
   ContentArea,

--- a/apps/docs/src/examples/components/grid/MinMaxColumns2.js
+++ b/apps/docs/src/examples/components/grid/MinMaxColumns2.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid, Paragraph, Text } from 'grommet';
 import {
   ContentArea,

--- a/apps/docs/src/examples/components/grid/MixedColumns1.js
+++ b/apps/docs/src/examples/components/grid/MixedColumns1.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import {
   ContentArea,

--- a/apps/docs/src/examples/components/grid/MixedColumns2.js
+++ b/apps/docs/src/examples/components/grid/MixedColumns2.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import {
   ContentArea,

--- a/apps/docs/src/examples/components/grid/UniformColumns.js
+++ b/apps/docs/src/examples/components/grid/UniformColumns.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid } from 'grommet';
 import { ContentArea } from '../../templates/page-layouts/anatomy/components';
 import { contentAreaProps } from './utils';

--- a/apps/docs/src/examples/components/grid/index.js
+++ b/apps/docs/src/examples/components/grid/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FluidGrid1';
 export * from './FluidGrid2';
 export * from './GapExample';

--- a/apps/docs/src/examples/components/grid/utils/definitions.js
+++ b/apps/docs/src/examples/components/grid/utils/definitions.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const contentAreaProps = {
   // TODO: Using opacity weak is a temporary solution until
   // we have a wider range of colors in the theme.

--- a/apps/docs/src/examples/components/grid/utils/index.js
+++ b/apps/docs/src/examples/components/grid/utils/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './definitions';

--- a/apps/docs/src/examples/components/header/HeaderActionExample.js
+++ b/apps/docs/src/examples/components/header/HeaderActionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Header, Text } from 'grommet';
 import { Add, Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/header/HeaderAvatarExample.js
+++ b/apps/docs/src/examples/components/header/HeaderAvatarExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Avatar, Box, Button, Header, Text } from 'grommet';
 import { Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/header/HeaderExample.js
+++ b/apps/docs/src/examples/components/header/HeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import {

--- a/apps/docs/src/examples/components/header/HeaderNavigationExample.js
+++ b/apps/docs/src/examples/components/header/HeaderNavigationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Button, Header, Menu, Nav, ResponsiveContext } from 'grommet';
 import { AppIdentity } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/header/HeaderSearchActionsExample.js
+++ b/apps/docs/src/examples/components/header/HeaderSearchActionsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import {

--- a/apps/docs/src/examples/components/header/index.js
+++ b/apps/docs/src/examples/components/header/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './HeaderExample';
 export * from './HeaderActionExample';
 export * from './HeaderAvatarExample';

--- a/apps/docs/src/examples/components/image/ImageExample.js
+++ b/apps/docs/src/examples/components/image/ImageExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Image } from 'grommet';
 

--- a/apps/docs/src/examples/components/image/index.js
+++ b/apps/docs/src/examples/components/image/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ImageExample';

--- a/apps/docs/src/examples/components/index.js
+++ b/apps/docs/src/examples/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './anchor';
 export * from './avatar';
 export * from './button';

--- a/apps/docs/src/examples/components/layer/ActionLabelTitle.js
+++ b/apps/docs/src/examples/components/layer/ActionLabelTitle.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/components/layer/ActionLabels.js
+++ b/apps/docs/src/examples/components/layer/ActionLabels.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button } from 'grommet';

--- a/apps/docs/src/examples/components/layer/ActionableLayerClose.js
+++ b/apps/docs/src/examples/components/layer/ActionableLayerClose.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button } from 'grommet';
 import { LayerHeader } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/layer/CenterInformational.js
+++ b/apps/docs/src/examples/components/layer/CenterInformational.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Heading, Layer, Paragraph } from 'grommet';

--- a/apps/docs/src/examples/components/layer/CenterLayerAnatomy.js
+++ b/apps/docs/src/examples/components/layer/CenterLayerAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Diagram, Grid, ResponsiveContext, Stack } from 'grommet';

--- a/apps/docs/src/examples/components/layer/ConfigurationForm.js
+++ b/apps/docs/src/examples/components/layer/ConfigurationForm.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/layer/DataFiltersAnatomy.js
+++ b/apps/docs/src/examples/components/layer/DataFiltersAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Data, DataFilters } from 'grommet';
 import applications from '../../../data/mockData/applications.json';

--- a/apps/docs/src/examples/components/layer/FullscreenLayerAnatomy.js
+++ b/apps/docs/src/examples/components/layer/FullscreenLayerAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Diagram, Grid, Page, PageContent, Stack } from 'grommet';

--- a/apps/docs/src/examples/components/layer/InformationalLayerClose.js
+++ b/apps/docs/src/examples/components/layer/InformationalLayerClose.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import { LayerHeader } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/layer/LayerAnatomy.js
+++ b/apps/docs/src/examples/components/layer/LayerAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   Button,
   Diagram,

--- a/apps/docs/src/examples/components/layer/LayerCenterExample.js
+++ b/apps/docs/src/examples/components/layer/LayerCenterExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import {
   Button,

--- a/apps/docs/src/examples/components/layer/LayerExample.js
+++ b/apps/docs/src/examples/components/layer/LayerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { AnnounceContext, Button, Box, Layer } from 'grommet';
 import { LayerHeader } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/layer/LayerSideDrawerExample.js
+++ b/apps/docs/src/examples/components/layer/LayerSideDrawerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/layer/LayerStickyExample.js
+++ b/apps/docs/src/examples/components/layer/LayerStickyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Box, Layer, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/components/layer/LayerTypes.js
+++ b/apps/docs/src/examples/components/layer/LayerTypes.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';

--- a/apps/docs/src/examples/components/layer/MonitorFormExample.js
+++ b/apps/docs/src/examples/components/layer/MonitorFormExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/layer/SideDrawerLayerAnatomy.js
+++ b/apps/docs/src/examples/components/layer/SideDrawerLayerAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Card, CardBody, Diagram, Grid, Stack } from 'grommet';

--- a/apps/docs/src/examples/components/layer/components/ConfirmationContext.js
+++ b/apps/docs/src/examples/components/layer/components/ConfirmationContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { AnnounceContext } from 'grommet';

--- a/apps/docs/src/examples/components/layer/components/DoubleConfirmation.js
+++ b/apps/docs/src/examples/components/layer/components/DoubleConfirmation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/components/layer/components/LayerContainer.js
+++ b/apps/docs/src/examples/components/layer/components/LayerContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 

--- a/apps/docs/src/examples/components/layer/components/Sidedrawer.js
+++ b/apps/docs/src/examples/components/layer/components/Sidedrawer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Layer } from 'grommet';

--- a/apps/docs/src/examples/components/layer/components/index.js
+++ b/apps/docs/src/examples/components/layer/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ConfirmationContext';
 export * from './DoubleConfirmation';
 export * from './LayerContainer';

--- a/apps/docs/src/examples/components/layer/index.js
+++ b/apps/docs/src/examples/components/layer/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ActionLabels';
 export * from './ActionLabelTitle';
 export * from './ActionableLayerClose';

--- a/apps/docs/src/examples/components/layouts/BoxExample.js
+++ b/apps/docs/src/examples/components/layouts/BoxExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/layouts/GridExample.js
+++ b/apps/docs/src/examples/components/layouts/GridExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Grid } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/layouts/index.js
+++ b/apps/docs/src/examples/components/layouts/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BoxExample';
 export * from './GridExample';

--- a/apps/docs/src/examples/components/main/MainExample.js
+++ b/apps/docs/src/examples/components/main/MainExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Grid } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/main/index.js
+++ b/apps/docs/src/examples/components/main/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './MainExample';

--- a/apps/docs/src/examples/components/markdown/MarkdownExample.js
+++ b/apps/docs/src/examples/components/markdown/MarkdownExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Markdown } from 'grommet';
 

--- a/apps/docs/src/examples/components/markdown/index.js
+++ b/apps/docs/src/examples/components/markdown/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './MarkdownExample';

--- a/apps/docs/src/examples/components/maskedinput/MaskedDateExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedDateExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { FormField, Form, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedDisabledExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { FormField, Form, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedEmailExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedEmailExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedIPAddressExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedIPAddressExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedIPRangeExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedIPRangeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedPhoneExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedPhoneExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedSizeUnitsExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedSizeUnitsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedTimeExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedTimeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/MaskedValidationExample.js
+++ b/apps/docs/src/examples/components/maskedinput/MaskedValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, FormField, Form, MaskedInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/maskedinput/index.js
+++ b/apps/docs/src/examples/components/maskedinput/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './MaskedDateExample';
 export * from './MaskedDisabledExample';
 export * from './MaskedEmailExample';

--- a/apps/docs/src/examples/components/menu/MenuAnatomy.js
+++ b/apps/docs/src/examples/components/menu/MenuAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Grid, Diagram, Stack, ThemeContext } from 'grommet';
 import { Add } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/menu/MenuBatchActionsExample.js
+++ b/apps/docs/src/examples/components/menu/MenuBatchActionsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useState, useEffect } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/menu/MenuDangerousExample.js
+++ b/apps/docs/src/examples/components/menu/MenuDangerousExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/components/menu/MenuDefaultExample.js
+++ b/apps/docs/src/examples/components/menu/MenuDefaultExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Menu } from 'grommet';
 

--- a/apps/docs/src/examples/components/menu/MenuDisabledExample.js
+++ b/apps/docs/src/examples/components/menu/MenuDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Menu } from 'grommet';
 

--- a/apps/docs/src/examples/components/menu/MenuExample.js
+++ b/apps/docs/src/examples/components/menu/MenuExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Menu } from 'grommet';
 

--- a/apps/docs/src/examples/components/menu/MenuGroupingExample.js
+++ b/apps/docs/src/examples/components/menu/MenuGroupingExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { MenuMock } from './MenuMock';
 

--- a/apps/docs/src/examples/components/menu/MenuHeaderExample.js
+++ b/apps/docs/src/examples/components/menu/MenuHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Button, Header, Menu, Text, ResponsiveContext } from 'grommet';
 import { Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/menu/MenuIconExample.js
+++ b/apps/docs/src/examples/components/menu/MenuIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Menu } from 'grommet';
 import { More, Settings } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/menu/MenuItemCountExample.js
+++ b/apps/docs/src/examples/components/menu/MenuItemCountExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { MenuMock } from './MenuMock';
 

--- a/apps/docs/src/examples/components/menu/MenuMock.js
+++ b/apps/docs/src/examples/components/menu/MenuMock.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import React, { useContext } from 'react';
 import { Box, Button, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/components/menu/MenuRecordActionsExample.js
+++ b/apps/docs/src/examples/components/menu/MenuRecordActionsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Heading, List, Menu, Notification, Text } from 'grommet';
 import {
   More,

--- a/apps/docs/src/examples/components/menu/MenuSelectValueExample.js
+++ b/apps/docs/src/examples/components/menu/MenuSelectValueExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { MenuMock } from './MenuMock';
 

--- a/apps/docs/src/examples/components/menu/MenuToolbarExample.js
+++ b/apps/docs/src/examples/components/menu/MenuToolbarExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Menu } from 'grommet';
 

--- a/apps/docs/src/examples/components/menu/index.js
+++ b/apps/docs/src/examples/components/menu/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './MenuAnatomy';
 export * from './MenuBatchActionsExample';
 export * from './MenuDangerousExample';

--- a/apps/docs/src/examples/components/meter/MeterExample.js
+++ b/apps/docs/src/examples/components/meter/MeterExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { TextEmphasis } from '@shared/aries-core';
 import { Box, Meter, Stack } from 'grommet';
 

--- a/apps/docs/src/examples/components/meter/index.js
+++ b/apps/docs/src/examples/components/meter/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './MeterExample';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListBoldExampleBad.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListBoldExampleBad.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { languageData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListBoldExampleGood.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListBoldExampleGood.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 import { languageData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListTextBadExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListTextBadExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { data } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListTextGoodExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListTextGoodExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { data } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListWeightBad.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListWeightBad.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { StatusGood } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListWeightGood.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/NameValueListWeightGood.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 import { StatusGood } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/namevaluelist/DoDonts/index.js
+++ b/apps/docs/src/examples/components/namevaluelist/DoDonts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NameValueListBoldExampleBad';
 export * from './NameValueListBoldExampleGood';
 export * from './NameValueListTextBadExample';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListDefaultExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListDefaultExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 import { defaultData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListDetailPage.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListDetailPage.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListEditExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListEditExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 import {

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListEditHorizontalExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListEditHorizontalExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { Fragment, useContext, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 import {

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListGridExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListGridExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { NameValueList, NameValuePair } from 'grommet';
 import { gridData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListMultipleDefaultExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListMultipleDefaultExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListPairPropsExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListPairPropsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, NameValueList, NameValuePair } from 'grommet';
 import { simpleData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListReadMoreExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListReadMoreExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Anchor, Box, Button, NameValueList, NameValuePair } from 'grommet';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListSimpleExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, NameValueList, NameValuePair } from 'grommet';
 import { simpleData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListSummaryExample.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListSummaryExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Card,

--- a/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListWizard.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/NameValueListWizard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/components/NameValueListFormField.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/components/NameValueListFormField.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { FormField } from 'grommet';
 

--- a/apps/docs/src/examples/components/namevaluelist/Examples/components/NameValueListFormLabel.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/components/NameValueListFormLabel.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/components/index.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/components/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NameValueListFormField';
 export * from './NameValueListFormLabel';

--- a/apps/docs/src/examples/components/namevaluelist/Examples/index.js
+++ b/apps/docs/src/examples/components/namevaluelist/Examples/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NameValueListDetailPage';
 export * from './NameValueListDefaultExample';
 export * from './NameValueListEditExample';

--- a/apps/docs/src/examples/components/namevaluelist/NameValueListAnatomy.js
+++ b/apps/docs/src/examples/components/namevaluelist/NameValueListAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Grid, Diagram, Stack, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/components/namevaluelist/NameValueListScaleTable.js
+++ b/apps/docs/src/examples/components/namevaluelist/NameValueListScaleTable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import {

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListAlignmentPreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListAlignmentPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 import { alignmentData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListAnatomyPreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListAnatomyPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListFontWeightPreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListFontWeightPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 import { fontData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListFontWeightSecondPreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListFontWeightSecondPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { fontWeightData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListHeadingPreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListHeadingPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Heading, NameValueList, NameValuePair } from 'grommet';
 import { simpleData } from '../data';

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListIconNamePreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListIconNamePreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair } from 'grommet';
 import { StatusGood, InProgress } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListIconValuePreview.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/NameValueListIconValuePreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { StatusGood, StatusWarning } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/namevaluelist/Previews/index.js
+++ b/apps/docs/src/examples/components/namevaluelist/Previews/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NameValueListAlignmentPreview';
 export * from './NameValueListAnatomyPreview';
 export * from './NameValueListFontWeightPreview';

--- a/apps/docs/src/examples/components/namevaluelist/data.js
+++ b/apps/docs/src/examples/components/namevaluelist/data.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Anchor, MaskedInput } from 'grommet';
 
 export const alignmentData = {

--- a/apps/docs/src/examples/components/namevaluelist/index.js
+++ b/apps/docs/src/examples/components/namevaluelist/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DoDonts';
 export * from './Examples';
 export * from './NameValueListAnatomy';

--- a/apps/docs/src/examples/components/nav/NavExample.js
+++ b/apps/docs/src/examples/components/nav/NavExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button, Nav } from 'grommet';
 

--- a/apps/docs/src/examples/components/nav/index.js
+++ b/apps/docs/src/examples/components/nav/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavExample';

--- a/apps/docs/src/examples/components/notifications/StateVsStatusDiagram.js
+++ b/apps/docs/src/examples/components/notifications/StateVsStatusDiagram.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { ToastPreview } from '../../cardPreviews';
 

--- a/apps/docs/src/examples/components/notifications/TaxonomyTable.js
+++ b/apps/docs/src/examples/components/notifications/TaxonomyTable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, DataTable } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/notifications/index.js
+++ b/apps/docs/src/examples/components/notifications/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './StateVsStatusDiagram';
 export * from './TaxonomyTable';

--- a/apps/docs/src/examples/components/page/PageBackGroundExample.js
+++ b/apps/docs/src/examples/components/page/PageBackGroundExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/page/PageExample.js
+++ b/apps/docs/src/examples/components/page/PageExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Paragraph, Page, PageContent } from 'grommet';
 

--- a/apps/docs/src/examples/components/page/PageFullExample.js
+++ b/apps/docs/src/examples/components/page/PageFullExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/page/PageNarrowExample.js
+++ b/apps/docs/src/examples/components/page/PageNarrowExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/page/PageWideExample.js
+++ b/apps/docs/src/examples/components/page/PageWideExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/page/SinglePageContent.js
+++ b/apps/docs/src/examples/components/page/SinglePageContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import {
   Anchor,

--- a/apps/docs/src/examples/components/page/demoStyle.js
+++ b/apps/docs/src/examples/components/page/demoStyle.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const demoStyle = { border: { style: 'dashed' } };

--- a/apps/docs/src/examples/components/page/index.js
+++ b/apps/docs/src/examples/components/page/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './PageBackGroundExample';
 export * from './PageExample';
 export * from './PageFullExample';

--- a/apps/docs/src/examples/components/pageheader/ChildPageHeaderExample.js
+++ b/apps/docs/src/examples/components/pageheader/ChildPageHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Page, PageContent, PageHeader } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/pageheader/PageHeaderActions.js
+++ b/apps/docs/src/examples/components/pageheader/PageHeaderActions.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Page, PageContent, PageHeader } from 'grommet';

--- a/apps/docs/src/examples/components/pageheader/PageHeaderAnatomy.js
+++ b/apps/docs/src/examples/components/pageheader/PageHeaderAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Diagram, Grid, ResponsiveContext, Stack, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/components/pageheader/PageHeaderContentRegions.js
+++ b/apps/docs/src/examples/components/pageheader/PageHeaderContentRegions.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/components/pageheader/PageHeaderIntroExample.js
+++ b/apps/docs/src/examples/components/pageheader/PageHeaderIntroExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState, useContext } from 'react';
 import {
   AnnounceContext,

--- a/apps/docs/src/examples/components/pageheader/PageHeaderResponsiveActions.js
+++ b/apps/docs/src/examples/components/pageheader/PageHeaderResponsiveActions.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/pageheader/PageHeaderSubtitle.js
+++ b/apps/docs/src/examples/components/pageheader/PageHeaderSubtitle.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PageHeader, NameValueList, NameValuePair } from 'grommet';

--- a/apps/docs/src/examples/components/pageheader/TopLevelPageHeaderExample.js
+++ b/apps/docs/src/examples/components/pageheader/TopLevelPageHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/pageheader/index.js
+++ b/apps/docs/src/examples/components/pageheader/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ChildPageHeaderExample';
 export * from './PageHeaderContentRegions';
 export * from './PageHeaderActions';

--- a/apps/docs/src/examples/components/pageheader/utils.js
+++ b/apps/docs/src/examples/components/pageheader/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const groupActions = (actions, breakpoint, bestPractice) => {
   let collapsedActions;
   let displayedActions;

--- a/apps/docs/src/examples/components/pagination/PaginationAnatomy.js
+++ b/apps/docs/src/examples/components/pagination/PaginationAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/pagination/PaginationCardsExample.js
+++ b/apps/docs/src/examples/components/pagination/PaginationCardsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/components/pagination/PaginationExample.js
+++ b/apps/docs/src/examples/components/pagination/PaginationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Pagination, Box } from 'grommet';
 

--- a/apps/docs/src/examples/components/pagination/PaginationListExample.js
+++ b/apps/docs/src/examples/components/pagination/PaginationListExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { List, Menu, ResponsiveContext } from 'grommet';
 import { More } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/pagination/PaginationServerTableExample.js
+++ b/apps/docs/src/examples/components/pagination/PaginationServerTableExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import { Box, DataTable, Heading, Pagination, Text, Tip } from 'grommet';
 import { StatusCritical } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/pagination/PaginationTableExample.js
+++ b/apps/docs/src/examples/components/pagination/PaginationTableExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/pagination/index.js
+++ b/apps/docs/src/examples/components/pagination/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './PaginationAnatomy';
 export * from './PaginationExample';
 export * from './PaginationCardsExample';

--- a/apps/docs/src/examples/components/radiobuttongroup/RadioButtonGroupDisabledExample.js
+++ b/apps/docs/src/examples/components/radiobuttongroup/RadioButtonGroupDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { CheckBox, Form, FormField, RadioButtonGroup } from 'grommet';
 

--- a/apps/docs/src/examples/components/radiobuttongroup/RadioButtonGroupExample.js
+++ b/apps/docs/src/examples/components/radiobuttongroup/RadioButtonGroupExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, RadioButtonGroup } from 'grommet';
 

--- a/apps/docs/src/examples/components/radiobuttongroup/RadioButtonGroupValidationExample.js
+++ b/apps/docs/src/examples/components/radiobuttongroup/RadioButtonGroupValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, RadioButtonGroup } from 'grommet';
 

--- a/apps/docs/src/examples/components/radiobuttongroup/index.js
+++ b/apps/docs/src/examples/components/radiobuttongroup/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './RadioButtonGroupDisabledExample';
 export * from './RadioButtonGroupExample';
 export * from './RadioButtonGroupValidationExample';

--- a/apps/docs/src/examples/components/rangeinput/RangeInputExample.js
+++ b/apps/docs/src/examples/components/rangeinput/RangeInputExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, RangeInput, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/rangeinput/index.js
+++ b/apps/docs/src/examples/components/rangeinput/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './RangeInputExample';

--- a/apps/docs/src/examples/components/rangeselector/RangeSelectorExample.js
+++ b/apps/docs/src/examples/components/rangeselector/RangeSelectorExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Box, RangeSelector, Stack, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/rangeselector/index.js
+++ b/apps/docs/src/examples/components/rangeselector/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './RangeSelectorExample';

--- a/apps/docs/src/examples/components/search/ClearSearchExample.js
+++ b/apps/docs/src/examples/components/search/ClearSearchExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TextInput } from 'grommet';
 import { Search as SearchIcon } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/search/SearchExample.js
+++ b/apps/docs/src/examples/components/search/SearchExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TextInput } from 'grommet';
 import { Search as SearchIcon } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/search/SearchIconPositionExample.js
+++ b/apps/docs/src/examples/components/search/SearchIconPositionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TextInput } from 'grommet';
 import { Search as SearchIcon } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/search/SearchPlaceholder.js
+++ b/apps/docs/src/examples/components/search/SearchPlaceholder.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TextInput, Box } from 'grommet';

--- a/apps/docs/src/examples/components/search/SearchSimpleExample.js
+++ b/apps/docs/src/examples/components/search/SearchSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TextInput, Box } from 'grommet';
 import { Search as SearchIcon } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/search/SearchSuggestionsExample.js
+++ b/apps/docs/src/examples/components/search/SearchSuggestionsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TextInput } from 'grommet';
 import { Search as SearchIcon } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/search/index.js
+++ b/apps/docs/src/examples/components/search/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './SearchExample';
 export * from './ClearSearchExample';
 export * from './SearchIconPositionExample';

--- a/apps/docs/src/examples/components/select/SelectDisabledExample.js
+++ b/apps/docs/src/examples/components/select/SelectDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, CheckBox, Form, FormField, Select } from 'grommet';
 

--- a/apps/docs/src/examples/components/select/SelectExample.js
+++ b/apps/docs/src/examples/components/select/SelectExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, Select } from 'grommet';
 

--- a/apps/docs/src/examples/components/select/SelectPreview.js
+++ b/apps/docs/src/examples/components/select/SelectPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Select } from 'grommet';
 import { useInert } from '@shared/hooks';

--- a/apps/docs/src/examples/components/select/SelectSearchExample.js
+++ b/apps/docs/src/examples/components/select/SelectSearchExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, Select } from 'grommet';
 

--- a/apps/docs/src/examples/components/select/SelectValidationExample.js
+++ b/apps/docs/src/examples/components/select/SelectValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, Select } from 'grommet';
 

--- a/apps/docs/src/examples/components/select/index.js
+++ b/apps/docs/src/examples/components/select/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './SelectDisabledExample';
 export * from './SelectExample';
 export * from './SelectPreview';

--- a/apps/docs/src/examples/components/selectmultiple/SelectMultipleAnatomy.js
+++ b/apps/docs/src/examples/components/selectmultiple/SelectMultipleAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import {
   Box,

--- a/apps/docs/src/examples/components/selectmultiple/SelectMultipleAnatomyExample.js
+++ b/apps/docs/src/examples/components/selectmultiple/SelectMultipleAnatomyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Diagram, Stack } from 'grommet';
 import React from 'react';
 import { Annotation } from '../../../layouts';

--- a/apps/docs/src/examples/components/selectmultiple/SelectMultipleSimpleExample.js
+++ b/apps/docs/src/examples/components/selectmultiple/SelectMultipleSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, SelectMultiple } from 'grommet';
 

--- a/apps/docs/src/examples/components/selectmultiple/index.js
+++ b/apps/docs/src/examples/components/selectmultiple/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './SelectMultipleSimpleExample';
 export * from './SelectMultipleAnatomyExample';

--- a/apps/docs/src/examples/components/sidebar/SidebarExample.js
+++ b/apps/docs/src/examples/components/sidebar/SidebarExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Avatar, Box, Button, Sidebar } from 'grommet';
 import {

--- a/apps/docs/src/examples/components/sidebar/index.js
+++ b/apps/docs/src/examples/components/sidebar/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './SidebarExample';

--- a/apps/docs/src/examples/components/skeleton/DashBoardSkeletonExample.js
+++ b/apps/docs/src/examples/components/skeleton/DashBoardSkeletonExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/skeleton/SkeletonAnatomy.js
+++ b/apps/docs/src/examples/components/skeleton/SkeletonAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Card, CardBody, Paragraph } from 'grommet';
 import { Skeleton } from 'grommet/components';

--- a/apps/docs/src/examples/components/skeleton/index.js
+++ b/apps/docs/src/examples/components/skeleton/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DashBoardSkeletonExample';
 export * from './SkeletonAnatomy';

--- a/apps/docs/src/examples/components/spinner/AnnounceSpinnerExample.js
+++ b/apps/docs/src/examples/components/spinner/AnnounceSpinnerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Button, Paragraph, Spinner } from 'grommet';
 

--- a/apps/docs/src/examples/components/spinner/ContentSpinnerExample.js
+++ b/apps/docs/src/examples/components/spinner/ContentSpinnerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/spinner/ListSpinnerExample.js
+++ b/apps/docs/src/examples/components/spinner/ListSpinnerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, List, Spinner, Text } from 'grommet';
 import {

--- a/apps/docs/src/examples/components/spinner/SpinnerExample.js
+++ b/apps/docs/src/examples/components/spinner/SpinnerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Spinner } from 'grommet';
 

--- a/apps/docs/src/examples/components/spinner/index.js
+++ b/apps/docs/src/examples/components/spinner/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AnnounceSpinnerExample';
 export * from './ListSpinnerExample';
 export * from './ContentSpinnerExample';

--- a/apps/docs/src/examples/components/tabs/TabContent.js
+++ b/apps/docs/src/examples/components/tabs/TabContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import { ContentPane } from '../../../layouts';

--- a/apps/docs/src/examples/components/tabs/TabResponsive.js
+++ b/apps/docs/src/examples/components/tabs/TabResponsive.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Tab, Tabs, Paragraph } from 'grommet';
 import { TabContent } from './TabContent';

--- a/apps/docs/src/examples/components/tabs/TabStatesExample.js
+++ b/apps/docs/src/examples/components/tabs/TabStatesExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Tab, Tabs } from 'grommet';
 import { TabContent } from './TabContent';

--- a/apps/docs/src/examples/components/tabs/TabWithIconExample.js
+++ b/apps/docs/src/examples/components/tabs/TabWithIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Tab, Tabs } from 'grommet';
 import { Currency, Home, User } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/tabs/TabsExample.js
+++ b/apps/docs/src/examples/components/tabs/TabsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Paragraph, Tab, Tabs } from 'grommet';
 import { TabContent } from './TabContent';

--- a/apps/docs/src/examples/components/tabs/index.js
+++ b/apps/docs/src/examples/components/tabs/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TabContent';
 export * from './TabsExample';
 export * from './TabStatesExample';

--- a/apps/docs/src/examples/components/tag/CreateTag/CreateTag.js
+++ b/apps/docs/src/examples/components/tag/CreateTag/CreateTag.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/tag/CreateTag/TagAppContainer.js
+++ b/apps/docs/src/examples/components/tag/CreateTag/TagAppContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 
 export const TagAppContainer = ({ ...rest }) => (

--- a/apps/docs/src/examples/components/tag/CreateTag/TagPageHeader.js
+++ b/apps/docs/src/examples/components/tag/CreateTag/TagPageHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, PageHeader, Text } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/components/tag/CreateTag/TagResults.js
+++ b/apps/docs/src/examples/components/tag/CreateTag/TagResults.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';
 

--- a/apps/docs/src/examples/components/tag/CreateTag/index.js
+++ b/apps/docs/src/examples/components/tag/CreateTag/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CreateTag';
 export * from './TagAppContainer';
 export * from './TagPageHeader';

--- a/apps/docs/src/examples/components/tag/CreateTag/utils.js
+++ b/apps/docs/src/examples/components/tag/CreateTag/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // the prefix name of the Create option entry
 export const prefix = 'Create';
 

--- a/apps/docs/src/examples/components/tag/CreateTagSimple.js
+++ b/apps/docs/src/examples/components/tag/CreateTagSimple.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/components/tag/TagAnatomy.js
+++ b/apps/docs/src/examples/components/tag/TagAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Grid, Diagram, Stack, Text, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/components/tag/TagAttention.js
+++ b/apps/docs/src/examples/components/tag/TagAttention.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Tag } from 'grommet';
 import { Card } from '../../templates';

--- a/apps/docs/src/examples/components/tag/TagBasicAnatomy.js
+++ b/apps/docs/src/examples/components/tag/TagBasicAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Diagram, Stack } from 'grommet';
 import { Annotation } from '../../../layouts';

--- a/apps/docs/src/examples/components/tag/TagMetaData.js
+++ b/apps/docs/src/examples/components/tag/TagMetaData.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Heading, Grid, ResponsiveContext, Tag } from 'grommet';
 import { User } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/tag/TagResource.js
+++ b/apps/docs/src/examples/components/tag/TagResource.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/tag/TagSimple.js
+++ b/apps/docs/src/examples/components/tag/TagSimple.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Tag } from 'grommet';
 

--- a/apps/docs/src/examples/components/tag/data.js
+++ b/apps/docs/src/examples/components/tag/data.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const details = {
   name: {
     displayName: 'Name',

--- a/apps/docs/src/examples/components/tag/index.js
+++ b/apps/docs/src/examples/components/tag/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CreateTag';
 export * from './CreateTagSimple';
 export * from './data';

--- a/apps/docs/src/examples/components/textarea/TextAreaDisabledExample.js
+++ b/apps/docs/src/examples/components/textarea/TextAreaDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, TextArea } from 'grommet';
 

--- a/apps/docs/src/examples/components/textarea/TextAreaExample.js
+++ b/apps/docs/src/examples/components/textarea/TextAreaExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, TextArea } from 'grommet';
 

--- a/apps/docs/src/examples/components/textarea/TextAreaValidationExample.js
+++ b/apps/docs/src/examples/components/textarea/TextAreaValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, TextArea } from 'grommet';
 

--- a/apps/docs/src/examples/components/textarea/index.js
+++ b/apps/docs/src/examples/components/textarea/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TextAreaExample';
 export * from './TextAreaDisabledExample';
 export * from './TextAreaValidationExample';

--- a/apps/docs/src/examples/components/textinput/TextInputDisabledExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputDisabledExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, TextInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/textinput/TextInputExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, TextInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/textinput/TextInputLabeledByExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputLabeledByExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import styled from 'styled-components';
 import { TextInput } from 'grommet';

--- a/apps/docs/src/examples/components/textinput/TextInputPasswordExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputPasswordExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, TextInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/textinput/TextInputReadOnlyExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputReadOnlyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Form, FormField, TextInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/textinput/TextInputSuggestionsExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputSuggestionsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Form, FormField, TextInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/textinput/TextInputValidationExample.js
+++ b/apps/docs/src/examples/components/textinput/TextInputValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Form, FormField, TextInput } from 'grommet';
 

--- a/apps/docs/src/examples/components/textinput/index.js
+++ b/apps/docs/src/examples/components/textinput/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TextInputExample';
 export * from './TextInputDisabledExample';
 export * from './TextInputLabeledByExample';

--- a/apps/docs/src/examples/components/tip/TipExitExample.js
+++ b/apps/docs/src/examples/components/tip/TipExitExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Paragraph } from 'grommet';
 import { Close } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/tip/TipIconExample.js
+++ b/apps/docs/src/examples/components/tip/TipIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Projects } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/tip/TipSimpleExample.js
+++ b/apps/docs/src/examples/components/tip/TipSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Tip, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/tip/TipSizeExample.js
+++ b/apps/docs/src/examples/components/tip/TipSizeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Tip, Text } from 'grommet';
 

--- a/apps/docs/src/examples/components/tip/index.js
+++ b/apps/docs/src/examples/components/tip/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TipExitExample';
 export * from './TipIconExample';
 export * from './TipSimpleExample';

--- a/apps/docs/src/examples/components/togglegroup/CardView.js
+++ b/apps/docs/src/examples/components/togglegroup/CardView.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/components/togglegroup/ListView.js
+++ b/apps/docs/src/examples/components/togglegroup/ListView.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, List, Text } from 'grommet';

--- a/apps/docs/src/examples/components/togglegroup/ToggleGroupAnatomy.js
+++ b/apps/docs/src/examples/components/togglegroup/ToggleGroupAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Grid, Text, Diagram, Stack } from 'grommet';

--- a/apps/docs/src/examples/components/togglegroup/ToggleGroupSimple.js
+++ b/apps/docs/src/examples/components/togglegroup/ToggleGroupSimple.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, ToggleGroup } from 'grommet';
 import { List, Table, Map } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/togglegroup/ToggleGroupTextEditor.js
+++ b/apps/docs/src/examples/components/togglegroup/ToggleGroupTextEditor.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, ToggleGroup } from 'grommet';
 

--- a/apps/docs/src/examples/components/togglegroup/ToggleGroupViews.js
+++ b/apps/docs/src/examples/components/togglegroup/ToggleGroupViews.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import {
   Data,

--- a/apps/docs/src/examples/components/togglegroup/index.js
+++ b/apps/docs/src/examples/components/togglegroup/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ToggleGroupAnatomy';
 export * from './ToggleGroupSimple';
 export * from './ToggleGroupTextEditor';

--- a/apps/docs/src/examples/components/togglegroup/utils.js
+++ b/apps/docs/src/examples/components/togglegroup/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button, Box, Paragraph, Text } from 'grommet';
 import { StatusCritical, StatusGood } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/components/video/VideoExample.js
+++ b/apps/docs/src/examples/components/video/VideoExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Video } from 'grommet';
 

--- a/apps/docs/src/examples/components/video/index.js
+++ b/apps/docs/src/examples/components/video/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './VideoExample';

--- a/apps/docs/src/examples/components/worldmap/WorldMapExample.js
+++ b/apps/docs/src/examples/components/worldmap/WorldMapExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { WorldMap } from 'grommet';
 

--- a/apps/docs/src/examples/components/worldmap/index.js
+++ b/apps/docs/src/examples/components/worldmap/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './WorldMapExample';

--- a/apps/docs/src/examples/foundation/accessibility/CorePrinciples.js
+++ b/apps/docs/src/examples/foundation/accessibility/CorePrinciples.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Grid, Image, Paragraph, Text, ThemeContext } from 'grommet';
 

--- a/apps/docs/src/examples/foundation/accessibility/GuideSection.js
+++ b/apps/docs/src/examples/foundation/accessibility/GuideSection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Link as LinkIcon } from '@hpe-design/icons-grommet';
 import { SectionCards } from '../../../components/cards';
 

--- a/apps/docs/src/examples/foundation/accessibility/VideoSection.js
+++ b/apps/docs/src/examples/foundation/accessibility/VideoSection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Play } from '@hpe-design/icons-grommet';
 import { SectionCards } from '../../../components/cards';
 

--- a/apps/docs/src/examples/foundation/accessibility/index.js
+++ b/apps/docs/src/examples/foundation/accessibility/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CorePrinciples';
 export * from './GuideSection';
 export * from './VideoSection';

--- a/apps/docs/src/examples/foundation/background-colors/BasicLayoutCardsExample.js
+++ b/apps/docs/src/examples/foundation/background-colors/BasicLayoutCardsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Button,

--- a/apps/docs/src/examples/foundation/background-colors/BasicLayoutExample.js
+++ b/apps/docs/src/examples/foundation/background-colors/BasicLayoutExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/foundation/background-colors/LayeredLayoutExample.js
+++ b/apps/docs/src/examples/foundation/background-colors/LayeredLayoutExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Card,

--- a/apps/docs/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js
+++ b/apps/docs/src/examples/foundation/background-colors/LayeredLayoutFixedExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Card,

--- a/apps/docs/src/examples/foundation/background-colors/index.js
+++ b/apps/docs/src/examples/foundation/background-colors/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BasicLayoutExample';
 export * from './BasicLayoutCardsExample';
 export * from './LayeredLayoutExample';

--- a/apps/docs/src/examples/foundation/branding/ArubaIconExample.js
+++ b/apps/docs/src/examples/foundation/branding/ArubaIconExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 // TODO replace with DS icon package when available

--- a/apps/docs/src/examples/foundation/branding/HpeElementExample.js
+++ b/apps/docs/src/examples/foundation/branding/HpeElementExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 import { Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/foundation/branding/index.js
+++ b/apps/docs/src/examples/foundation/branding/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ArubaIconExample';
 export * from './HpeElementExample';

--- a/apps/docs/src/examples/foundation/color/ColorAccessibility.js
+++ b/apps/docs/src/examples/foundation/color/ColorAccessibility.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 
 import { ColorCompliance } from '../../../components';

--- a/apps/docs/src/examples/foundation/color/ColorPalettes.js
+++ b/apps/docs/src/examples/foundation/color/ColorPalettes.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, ResponsiveContext, ThemeContext } from 'grommet';
 import { ColorRow, UsageExample } from '../../../layouts';

--- a/apps/docs/src/examples/foundation/color/ColorSwatches.js
+++ b/apps/docs/src/examples/foundation/color/ColorSwatches.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Text, Grid } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/foundation/color/ElevationExample.js
+++ b/apps/docs/src/examples/foundation/color/ElevationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/foundation/color/GraphExample.js
+++ b/apps/docs/src/examples/foundation/color/GraphExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/foundation/color/StatusExample.js
+++ b/apps/docs/src/examples/foundation/color/StatusExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/foundation/color/TextExample.js
+++ b/apps/docs/src/examples/foundation/color/TextExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/foundation/color/index.js
+++ b/apps/docs/src/examples/foundation/color/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ColorAccessibility';
 export * from './ColorPalettes';
 export * from './GraphExample';

--- a/apps/docs/src/examples/foundation/content-container-sizes/BorderWidths.jsx
+++ b/apps/docs/src/examples/foundation/content-container-sizes/BorderWidths.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, FormField, Select } from 'grommet';
 import { useDesignTokens } from '../../../components';

--- a/apps/docs/src/examples/foundation/content-container-sizes/ContainerSizes.jsx
+++ b/apps/docs/src/examples/foundation/content-container-sizes/ContainerSizes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, FormField, Select } from 'grommet';
 import { useDesignTokens } from '../../../components';

--- a/apps/docs/src/examples/foundation/content-container-sizes/DesignTokenCTAs.jsx
+++ b/apps/docs/src/examples/foundation/content-container-sizes/DesignTokenCTAs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import Link from 'next/link';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/foundation/content-container-sizes/RadiusSizes.jsx
+++ b/apps/docs/src/examples/foundation/content-container-sizes/RadiusSizes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, FormField, Select } from 'grommet';
 import { useDesignTokens } from '../../../components';

--- a/apps/docs/src/examples/foundation/content-container-sizes/index.js
+++ b/apps/docs/src/examples/foundation/content-container-sizes/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BorderWidths';
 export * from './ContainerSizes';
 export * from './DesignTokenCTAs';

--- a/apps/docs/src/examples/foundation/date-and-time/AbbreviatedDateExample.js
+++ b/apps/docs/src/examples/foundation/date-and-time/AbbreviatedDateExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 

--- a/apps/docs/src/examples/foundation/date-and-time/DateAlignmentExample.js
+++ b/apps/docs/src/examples/foundation/date-and-time/DateAlignmentExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { DataTable } from 'grommet';
 

--- a/apps/docs/src/examples/foundation/date-and-time/DateTimeNotificationExample.js
+++ b/apps/docs/src/examples/foundation/date-and-time/DateTimeNotificationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Notification } from 'grommet';

--- a/apps/docs/src/examples/foundation/date-and-time/RelativeTimeExample.js
+++ b/apps/docs/src/examples/foundation/date-and-time/RelativeTimeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable } from 'grommet';

--- a/apps/docs/src/examples/foundation/date-and-time/TimezoneExample.js
+++ b/apps/docs/src/examples/foundation/date-and-time/TimezoneExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Notification, Text } from 'grommet';

--- a/apps/docs/src/examples/foundation/date-and-time/ZeroPaddingExample.js
+++ b/apps/docs/src/examples/foundation/date-and-time/ZeroPaddingExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable } from 'grommet';

--- a/apps/docs/src/examples/foundation/date-and-time/index.js
+++ b/apps/docs/src/examples/foundation/date-and-time/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AbbreviatedDateExample';
 export * from './DateAlignmentExample';
 export * from './DateTimeNotificationExample';

--- a/apps/docs/src/examples/foundation/distinctive-brand-assets/ColorAndTexture.js
+++ b/apps/docs/src/examples/foundation/distinctive-brand-assets/ColorAndTexture.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Grid } from 'grommet';
 
 export const ColorAndTexture = () => (

--- a/apps/docs/src/examples/foundation/distinctive-brand-assets/HPEGreenLakeBadge.js
+++ b/apps/docs/src/examples/foundation/distinctive-brand-assets/HPEGreenLakeBadge.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Image, ThemeContext } from 'grommet';
 import { useContext } from 'react';
 

--- a/apps/docs/src/examples/foundation/distinctive-brand-assets/TypographyStyles.js
+++ b/apps/docs/src/examples/foundation/distinctive-brand-assets/TypographyStyles.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 
 export const TypographyStyles = () => (

--- a/apps/docs/src/examples/foundation/distinctive-brand-assets/index.js
+++ b/apps/docs/src/examples/foundation/distinctive-brand-assets/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ColorAndTexture';
 export * from './HPEGreenLakeBadge';
 export * from './TypographyStyles';

--- a/apps/docs/src/examples/foundation/icons/IconComponentExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconComponentExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Menu } from 'grommet';
 import { Add, Right } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/foundation/icons/IconCoreExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconCoreExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/foundation/icons/IconHeightExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconHeightExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Paragraph } from 'grommet';
 import { Add } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/foundation/icons/IconPlainExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconPlainExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import { Achievement, Aid, Alarm, Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/foundation/icons/IconSizeExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconSizeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import { Alarm } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/foundation/icons/IconStatusExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconStatusExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import {

--- a/apps/docs/src/examples/foundation/icons/IconTextExample.js
+++ b/apps/docs/src/examples/foundation/icons/IconTextExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button } from 'grommet';
 import { Chat } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/foundation/icons/index.js
+++ b/apps/docs/src/examples/foundation/icons/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './IconComponentExample';
 export * from './IconCoreExample';
 export * from './IconHeightExample';

--- a/apps/docs/src/examples/foundation/index.js
+++ b/apps/docs/src/examples/foundation/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './accessibility';
 export * from './background-colors';
 export * from './branding';

--- a/apps/docs/src/examples/foundation/scale-system/ComposableScale.jsx
+++ b/apps/docs/src/examples/foundation/scale-system/ComposableScale.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 
 const ScaleCell = ({

--- a/apps/docs/src/examples/foundation/scale-system/index.js
+++ b/apps/docs/src/examples/foundation/scale-system/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ComposableScale';

--- a/apps/docs/src/examples/foundation/spacing/AvoidMargin.js
+++ b/apps/docs/src/examples/foundation/spacing/AvoidMargin.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import { dimension } from 'hpe-design-tokens/grommet';

--- a/apps/docs/src/examples/foundation/spacing/SpacingCTAs.js
+++ b/apps/docs/src/examples/foundation/spacing/SpacingCTAs.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import Link from 'next/link';
 import { Anchor, Button } from 'grommet';

--- a/apps/docs/src/examples/foundation/spacing/SpacingScale.js
+++ b/apps/docs/src/examples/foundation/spacing/SpacingScale.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/foundation/spacing/SpacingVsElementTokens.js
+++ b/apps/docs/src/examples/foundation/spacing/SpacingVsElementTokens.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import { dimension } from 'hpe-design-tokens/grommet';

--- a/apps/docs/src/examples/foundation/spacing/index.js
+++ b/apps/docs/src/examples/foundation/spacing/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AvoidMargin';
 export * from './SpacingScale';
 export * from './SpacingCTAs';

--- a/apps/docs/src/examples/foundation/typography/HeadingExample.js
+++ b/apps/docs/src/examples/foundation/typography/HeadingExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Heading } from 'grommet';
 

--- a/apps/docs/src/examples/foundation/typography/ParagraphExample.js
+++ b/apps/docs/src/examples/foundation/typography/ParagraphExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/foundation/typography/TextSizeExample.js
+++ b/apps/docs/src/examples/foundation/typography/TextSizeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 

--- a/apps/docs/src/examples/foundation/typography/index.js
+++ b/apps/docs/src/examples/foundation/typography/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './HeadingExample';
 export * from './ParagraphExample';
 export * from './TextSizeExample';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- Adds license header text to set of docs files

#### What are the relevant issues?
relates to https://github.com/grommet/hpe-design-system/issues/6360

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>