### PR TITLE
Add SPDX headers: docs 2

### DIFF
--- a/apps/docs/applitools.config.js
+++ b/apps/docs/applitools.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 module.exports = {
   appName: 'HPE Design System Website',
   apiKey: process.env.APPLITOOLS_API_KEY,

--- a/apps/docs/config.js
+++ b/apps/docs/config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const Config = {
   apiUrl: 'http://localhost',
   gaId: 'UA-153720834-1',

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import createMDX from '@next/mdx';
 import remarkGfm from 'remark-gfm';
 

--- a/apps/docs/next.postexport.js
+++ b/apps/docs/next.postexport.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // Copies Netlify's _redirects file to NextJS's build directory ./out
 const fs = require('fs');
 

--- a/apps/docs/src/applitools/all-components.js
+++ b/apps/docs/src/applitools/all-components.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { waitForReact } from 'testcafe-react-selectors';
 import Eyes from '@applitools/eyes-testcafe';

--- a/apps/docs/src/applitools/button.js
+++ b/apps/docs/src/applitools/button.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { waitForReact } from 'testcafe-react-selectors';

--- a/apps/docs/src/applitools/forms.js
+++ b/apps/docs/src/applitools/forms.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { waitForReact } from 'testcafe-react-selectors';
 import Eyes from '@applitools/eyes-testcafe';

--- a/apps/docs/src/applitools/screen-container.js
+++ b/apps/docs/src/applitools/screen-container.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { waitForReact } from 'testcafe-react-selectors';

--- a/apps/docs/src/applitools/template.js
+++ b/apps/docs/src/applitools/template.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { waitForReact } from 'testcafe-react-selectors';

--- a/apps/docs/src/applitools/typography.js
+++ b/apps/docs/src/applitools/typography.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { waitForReact } from 'testcafe-react-selectors';

--- a/apps/docs/src/components/accessibility/Video.js
+++ b/apps/docs/src/components/accessibility/Video.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 
 import { AnnounceContext, Box, Button } from 'grommet';

--- a/apps/docs/src/components/accessibility/index.js
+++ b/apps/docs/src/components/accessibility/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Video';

--- a/apps/docs/src/components/cards/CardGrid.js
+++ b/apps/docs/src/components/cards/CardGrid.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'grommet';

--- a/apps/docs/src/components/cards/ContentCard.js
+++ b/apps/docs/src/components/cards/ContentCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, CardBody, Image, Text } from 'grommet';

--- a/apps/docs/src/components/cards/ContentPreviewCard.js
+++ b/apps/docs/src/components/cards/ContentPreviewCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import { LinkCard } from './LinkCard';
 

--- a/apps/docs/src/components/cards/ExampleImagePreview.js
+++ b/apps/docs/src/components/cards/ExampleImagePreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';

--- a/apps/docs/src/components/cards/LinkCard.js
+++ b/apps/docs/src/components/cards/LinkCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useRouter } from 'next/router';
 import { Card, useAnalytics } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/components/cards/PreviewCard.js
+++ b/apps/docs/src/components/cards/PreviewCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Card } from 'grommet';

--- a/apps/docs/src/components/cards/SectionCards.js
+++ b/apps/docs/src/components/cards/SectionCards.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, CardBody, Heading, Grid } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/components/cards/index.js
+++ b/apps/docs/src/components/cards/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CardGrid';
 export * from './ContentCard';
 export * from './ContentPreviewCard';

--- a/apps/docs/src/components/content/AppIdentity.js
+++ b/apps/docs/src/components/content/AppIdentity.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Image, Text } from 'grommet';

--- a/apps/docs/src/components/content/CollapsibleSection.js
+++ b/apps/docs/src/components/content/CollapsibleSection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Collapsible } from 'grommet';

--- a/apps/docs/src/components/content/ColorCompliance.js
+++ b/apps/docs/src/components/content/ColorCompliance.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Table, TableCell, TableBody, TableRow, Text } from 'grommet';

--- a/apps/docs/src/components/content/ColorSwatch.js
+++ b/apps/docs/src/components/content/ColorSwatch.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/components/content/DecisionTree/Answer.js
+++ b/apps/docs/src/components/content/DecisionTree/Answer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/components/content/DecisionTree/Decision.js
+++ b/apps/docs/src/components/content/DecisionTree/Decision.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Paragraph, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/components/content/DecisionTree/Destination.js
+++ b/apps/docs/src/components/content/DecisionTree/Destination.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/components/content/DecisionTree/index.js
+++ b/apps/docs/src/components/content/DecisionTree/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Answer';
 export * from './Decision';
 export * from './Destination';

--- a/apps/docs/src/components/content/DocsMessage.js
+++ b/apps/docs/src/components/content/DocsMessage.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { SubsectionText } from '.';
 

--- a/apps/docs/src/components/content/HighlightPhrase.js
+++ b/apps/docs/src/components/content/HighlightPhrase.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';

--- a/apps/docs/src/components/content/MarkdownComponents.js
+++ b/apps/docs/src/components/content/MarkdownComponents.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/components/content/PageBackground.js
+++ b/apps/docs/src/components/content/PageBackground.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Card, Grid, Image, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/components/content/Status.js
+++ b/apps/docs/src/components/content/Status.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';

--- a/apps/docs/src/components/content/SubmitFeedback.js
+++ b/apps/docs/src/components/content/SubmitFeedback.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { createContext, useContext, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';

--- a/apps/docs/src/components/content/SubsectionText.js
+++ b/apps/docs/src/components/content/SubsectionText.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/components/content/ThemeModeToggle.js
+++ b/apps/docs/src/components/content/ThemeModeToggle.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Tip } from 'grommet';

--- a/apps/docs/src/components/content/design-tokens/DesignTokenContext.js
+++ b/apps/docs/src/components/content/design-tokens/DesignTokenContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext } from 'react';
 
 export const DesignTokenContext = createContext({});

--- a/apps/docs/src/components/content/design-tokens/DesignTokensTable.js
+++ b/apps/docs/src/components/content/design-tokens/DesignTokensTable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/components/content/design-tokens/cssTokenUtils.js
+++ b/apps/docs/src/components/content/design-tokens/cssTokenUtils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { addStructuredTokens } from './tokenUtilsShared';
 
 const getCssTokenType = (token, value) => {

--- a/apps/docs/src/components/content/design-tokens/designTokenUtils.js
+++ b/apps/docs/src/components/content/design-tokens/designTokenUtils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { useEffect, useState } from 'react';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/components/content/design-tokens/docsTokenUtils.js
+++ b/apps/docs/src/components/content/design-tokens/docsTokenUtils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { addStructuredTokens } from './tokenUtilsShared';
 
 const addDocsTokens = structuredTokens => {

--- a/apps/docs/src/components/content/design-tokens/figmaTokenUtils.js
+++ b/apps/docs/src/components/content/design-tokens/figmaTokenUtils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { addStructuredTokens } from './tokenUtilsShared';
 
 const toFigmaTokenName = tokenName => tokenName.replaceAll('.', '/');

--- a/apps/docs/src/components/content/design-tokens/grommetThemeHpeUtils.js
+++ b/apps/docs/src/components/content/design-tokens/grommetThemeHpeUtils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 const grommetThemeHpeHeadingLabelMap = {
   borderWidth: 'borderWidth (borderSize)',
   breakpoint: 'breakpoint (breakpoint)',

--- a/apps/docs/src/components/content/design-tokens/index.js
+++ b/apps/docs/src/components/content/design-tokens/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './cssTokenUtils';
 export * from './DesignTokensTable';
 export * from './DesignTokenContext';

--- a/apps/docs/src/components/content/design-tokens/tokenUtilsShared.js
+++ b/apps/docs/src/components/content/design-tokens/tokenUtilsShared.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // eslint-disable-next-line import/no-unresolved
 import * as tokens from 'hpe-design-tokens/docs';
 

--- a/apps/docs/src/components/content/index.js
+++ b/apps/docs/src/components/content/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppIdentity';
 export * from './CollapsibleSection';
 export * from './ColorCompliance';

--- a/apps/docs/src/components/feedback/Feedback.js
+++ b/apps/docs/src/components/feedback/Feedback.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/components/feedback/FeedbackButton.js
+++ b/apps/docs/src/components/feedback/FeedbackButton.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/components/feedback/Question.js
+++ b/apps/docs/src/components/feedback/Question.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/components/feedback/index.js
+++ b/apps/docs/src/components/feedback/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Feedback';
 export * from './FeedbackButton';
 export * from './Question';

--- a/apps/docs/src/components/headings/Subheading.js
+++ b/apps/docs/src/components/headings/Subheading.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Heading } from 'grommet';

--- a/apps/docs/src/components/headings/index.js
+++ b/apps/docs/src/components/headings/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Subheading';

--- a/apps/docs/src/components/home/Community.js
+++ b/apps/docs/src/components/home/Community.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/components/home/CreativeToolkit.js
+++ b/apps/docs/src/components/home/CreativeToolkit.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Image, PageContent, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/components/home/Featured.js
+++ b/apps/docs/src/components/home/Featured.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 
 import {

--- a/apps/docs/src/components/home/Hero.js
+++ b/apps/docs/src/components/home/Hero.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { Box, ResponsiveContext, ThemeContext } from 'grommet';

--- a/apps/docs/src/components/home/Quote.js
+++ b/apps/docs/src/components/home/Quote.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Avatar,

--- a/apps/docs/src/components/home/Video.js
+++ b/apps/docs/src/components/home/Video.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react';
 
 import { Box, Video as GrommetVideo } from 'grommet';

--- a/apps/docs/src/components/home/WhatIs.js
+++ b/apps/docs/src/components/home/WhatIs.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Box, Heading, PageContent, Paragraph } from 'grommet';

--- a/apps/docs/src/components/home/index.js
+++ b/apps/docs/src/components/home/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Community';
 export * from './CreativeToolkit';
 export * from './Featured';

--- a/apps/docs/src/components/icons/IconCircle.js
+++ b/apps/docs/src/components/icons/IconCircle.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Blank } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/components/icons/IconDiamond.js
+++ b/apps/docs/src/components/icons/IconDiamond.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Blank } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/components/icons/IconExtend.js
+++ b/apps/docs/src/components/icons/IconExtend.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Blank } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/components/icons/IconSquare.js
+++ b/apps/docs/src/components/icons/IconSquare.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Blank } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/components/icons/IconTriangle.js
+++ b/apps/docs/src/components/icons/IconTriangle.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Blank } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/components/icons/index.js
+++ b/apps/docs/src/components/icons/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './IconCircle';
 export * from './IconDiamond';
 export * from './IconExtend';

--- a/apps/docs/src/components/index.js
+++ b/apps/docs/src/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './cards';
 export * from './content';
 export * from './feedback';

--- a/apps/docs/src/components/seo/Meta.js
+++ b/apps/docs/src/components/seo/Meta.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import Head from 'next/head';

--- a/apps/docs/src/components/seo/index.js
+++ b/apps/docs/src/components/seo/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Meta';

--- a/apps/docs/src/data/__tests__/buildCategoryMapping.test.ts
+++ b/apps/docs/src/data/__tests__/buildCategoryMapping.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import {
   buildCategoryMapping,

--- a/apps/docs/src/data/__tests__/structure.validation.test.ts
+++ b/apps/docs/src/data/__tests__/structure.validation.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { readdir } from 'node:fs/promises';
 import path from 'node:path';

--- a/apps/docs/src/data/__tests__/structureIndexes.test.ts
+++ b/apps/docs/src/data/__tests__/structureIndexes.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import { buildCategoryMapping } from '../buildCategoryMapping';
 import { buildStructureIndexes } from '../structureIndexes';

--- a/apps/docs/src/data/buildCategoryMapping.ts
+++ b/apps/docs/src/data/buildCategoryMapping.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Builds category weight mappings from structure data.
  *

--- a/apps/docs/src/data/color.js
+++ b/apps/docs/src/data/color.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /*
  * The following is holding content until Content Management Solution
  * is in place.

--- a/apps/docs/src/data/featured.js
+++ b/apps/docs/src/data/featured.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Theme, Code } from '@hpe-design/icons-grommet';
 
 export const featured = [

--- a/apps/docs/src/data/index.js
+++ b/apps/docs/src/data/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './color';
 export * from './featured';
 export * from './structure.tsx';

--- a/apps/docs/src/data/structure.d.ts
+++ b/apps/docs/src/data/structure.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 export interface PageDetails {

--- a/apps/docs/src/data/structure.tsx
+++ b/apps/docs/src/data/structure.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { Cube, Grow } from '@hpe-design/icons-grommet';
 import { IconCircle, IconDiamond, IconSquare } from '../components/icons';

--- a/apps/docs/src/data/structureIndexes.ts
+++ b/apps/docs/src/data/structureIndexes.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import type { CategoryMappings } from './buildCategoryMapping';
 
 export type StructurePage = {

--- a/apps/docs/src/data/structureValidation.ts
+++ b/apps/docs/src/data/structureValidation.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { z, type ZodIssue } from 'zod';
 import type { CategoryMappings } from './buildCategoryMapping';
 import {

--- a/apps/docs/src/data/structures/Structure.ts
+++ b/apps/docs/src/data/structures/Structure.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* Functions to support page structure array manipulations */
 
 export type StructureItem = {

--- a/apps/docs/src/data/structures/components.tsx
+++ b/apps/docs/src/data/structures/components.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { FileInput, Spinner } from 'grommet';
 import {

--- a/apps/docs/src/data/structures/foundation.tsx
+++ b/apps/docs/src/data/structures/foundation.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text, Image } from 'grommet';
 
 export const foundation = [

--- a/apps/docs/src/data/structures/index.ts
+++ b/apps/docs/src/data/structures/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './components';
 export * from './foundation';
 export * from './learn';

--- a/apps/docs/src/data/structures/learn.tsx
+++ b/apps/docs/src/data/structures/learn.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 // TODO replace with DS icon package when available
 import { Grommet } from 'grommet-icons';

--- a/apps/docs/src/data/structures/templates/content-layouts.ts
+++ b/apps/docs/src/data/structures/templates/content-layouts.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // these pages do not necessarily have their own routes but instead
 // link to sections of existing pages
 

--- a/apps/docs/src/data/structures/templates/index.ts
+++ b/apps/docs/src/data/structures/templates/index.ts
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './content-layouts';
 export * from './templates';

--- a/apps/docs/src/data/structures/templates/templates.tsx
+++ b/apps/docs/src/data/structures/templates/templates.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Notification } from 'grommet';
 import {
   ContentLayoutPreview,

--- a/apps/docs/src/data/structures/tokens.tsx
+++ b/apps/docs/src/data/structures/tokens.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { Code, Book, Table } from '@hpe-design/icons-grommet';
 // TODO replace with DS icon package when available

--- a/apps/docs/src/data/toolkitItems.js
+++ b/apps/docs/src/data/toolkitItems.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const toolkitItems = [
   {
     name: 'Foundation',

--- a/apps/docs/src/examples/index.js
+++ b/apps/docs/src/examples/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './cardPreviews';
 export * from './components';
 export * from './foundation';

--- a/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/Completed.js
+++ b/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/Completed.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable grommet/datatable-aria-describedby */
 import { useEffect, useState } from 'react';
 import {

--- a/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/components/Pagination.jsx
+++ b/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/components/Pagination.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Pagination as GrommetPagination, DataContext } from 'grommet';

--- a/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/components/PaginationStep.jsx
+++ b/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/components/PaginationStep.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Select, Text } from 'grommet';

--- a/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/components/PaginationSummary.jsx
+++ b/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/components/PaginationSummary.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/index.js
+++ b/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Completed';

--- a/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/utils.jsx
+++ b/apps/docs/src/examples/learn/how-to/how-to-add-additional-controls-to-a-toolbar/utils.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Text } from 'grommet';
 
 const buildQuery = view => {

--- a/apps/docs/src/examples/learn/how-to/index.js
+++ b/apps/docs/src/examples/learn/how-to/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './how-to-add-additional-controls-to-a-toolbar';

--- a/apps/docs/src/examples/learn/index.js
+++ b/apps/docs/src/examples/learn/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './how-to';
 export * from './tutorials';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/ProductCard.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/ProductCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import {
   Box,

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StarterTemplate.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StarterTemplate.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grommet, Text } from 'grommet';
 import { hpe } from 'grommet-theme-hpe';
 

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepFive.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepFive.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Grommet, Heading, ThemeContext, Grid } from 'grommet';
 import { hpe } from 'grommet-theme-hpe';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepFour.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepFour.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid, Heading, Grommet } from 'grommet';
 import { hpe } from 'grommet-theme-hpe';
 import { ProductCard } from './ProductCard';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepOne.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepOne.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { Box, Text, Heading, Grid, Grommet } from 'grommet';
 import { hpe } from 'grommet-theme-hpe';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepThree.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepThree.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Grid, Heading, Grommet } from 'grommet';
 import { hpe } from 'grommet-theme-hpe';
 import { ProductCard } from './ProductCard';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepTwo.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/StepTwo.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Heading, Grid, Grommet } from 'grommet';
 import { hpe } from 'grommet-theme-hpe';
 import { ProductCard } from './ProductCard';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/index.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { App as StarterTemplate } from './StarterTemplate';
 export { App as GridStepOne } from './StepOne';
 export { App as StepTwo } from './StepTwo';

--- a/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/utils.js
+++ b/apps/docs/src/examples/learn/tutorials/grid-fundamentals-part-1/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // Calculate the mid point between two t-shirt sizes from the theme
 export const midSize = (size1, size2, theme) => {
   const a = parseInt(theme.global.size[size1], 10);

--- a/apps/docs/src/examples/learn/tutorials/index.js
+++ b/apps/docs/src/examples/learn/tutorials/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './grid-fundamentals-part-1';

--- a/apps/docs/src/examples/templates/Card/Card.js
+++ b/apps/docs/src/examples/templates/Card/Card.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/Card/index.js
+++ b/apps/docs/src/examples/templates/Card/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { Card } from './Card';

--- a/apps/docs/src/examples/templates/Card/utils.js
+++ b/apps/docs/src/examples/templates/Card/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // avoid duplication of padding between Card header, body, and footer
 export const adjustPad = (direction, context, theme) => {
   const pad = theme?.card?.body?.pad;

--- a/apps/docs/src/examples/templates/DestructiveConfirmation/DestructiveConfirmation.js
+++ b/apps/docs/src/examples/templates/DestructiveConfirmation/DestructiveConfirmation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/DestructiveConfirmation/index.js
+++ b/apps/docs/src/examples/templates/DestructiveConfirmation/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DestructiveConfirmation';

--- a/apps/docs/src/examples/templates/FilterControls/FilterControls.js
+++ b/apps/docs/src/examples/templates/FilterControls/FilterControls.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Box, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/FilterControls/Filters.js
+++ b/apps/docs/src/examples/templates/FilterControls/Filters.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect, useState } from 'react';
 import { Box, Button, ThemeContext } from 'grommet';
 import { Filter } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/FilterControls/FiltersContext.js
+++ b/apps/docs/src/examples/templates/FilterControls/FiltersContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/templates/FilterControls/FiltersLayer.js
+++ b/apps/docs/src/examples/templates/FilterControls/FiltersLayer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/FilterControls/ResultsSummary.js
+++ b/apps/docs/src/examples/templates/FilterControls/ResultsSummary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Text } from 'grommet';
 
 import { useFilters } from '.';

--- a/apps/docs/src/examples/templates/FilterControls/SearchFilter.js
+++ b/apps/docs/src/examples/templates/FilterControls/SearchFilter.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/FilterControls/filterTypes/FilterCheckBoxGroup.js
+++ b/apps/docs/src/examples/templates/FilterControls/filterTypes/FilterCheckBoxGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, CheckBoxGroup, FormField } from 'grommet';

--- a/apps/docs/src/examples/templates/FilterControls/filterTypes/FilterRangeSelector.js
+++ b/apps/docs/src/examples/templates/FilterControls/filterTypes/FilterRangeSelector.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, FormField, RangeSelector, Stack, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/FilterControls/filterTypes/index.js
+++ b/apps/docs/src/examples/templates/FilterControls/filterTypes/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FilterCheckBoxGroup';
 export * from './FilterRangeSelector';

--- a/apps/docs/src/examples/templates/FilterControls/index.js
+++ b/apps/docs/src/examples/templates/FilterControls/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FiltersContext';
 export * from './FilterControls';
 export * from './Filters';

--- a/apps/docs/src/examples/templates/FormChildObject/ChildHeader.js
+++ b/apps/docs/src/examples/templates/FormChildObject/ChildHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Header, Heading, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/FormChildObject/FormChildObject.js
+++ b/apps/docs/src/examples/templates/FormChildObject/FormChildObject.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Collapsible } from 'grommet';

--- a/apps/docs/src/examples/templates/FormChildObject/FormChildObjects.js
+++ b/apps/docs/src/examples/templates/FormChildObject/FormChildObjects.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Button } from 'grommet';
 import { ButtonGroup } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/FormChildObject/index.js
+++ b/apps/docs/src/examples/templates/FormChildObject/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ChildHeader';
 export * from './FormChildObject';
 export * from './FormChildObjects';

--- a/apps/docs/src/examples/templates/ReverseAnchor/ReverseAnchor.js
+++ b/apps/docs/src/examples/templates/ReverseAnchor/ReverseAnchor.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Anchor } from 'grommet';
 import PropTypes from 'prop-types';
 import { Left } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/ReverseAnchor/index.js
+++ b/apps/docs/src/examples/templates/ReverseAnchor/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ReverseAnchor';

--- a/apps/docs/src/examples/templates/StatusIndicator/StatusIndicator.js
+++ b/apps/docs/src/examples/templates/StatusIndicator/StatusIndicator.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/StatusIndicator/index.js
+++ b/apps/docs/src/examples/templates/StatusIndicator/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './StatusIndicator';

--- a/apps/docs/src/examples/templates/ascending-navigation/AscendingNavigationCodeExample.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/AscendingNavigationCodeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Button, PageHeader } from 'grommet';
 import { Left } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/ascending-navigation/AscendingNavigationExample.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/AscendingNavigationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
  import React, { useState } from 'react';
 import { Anchor, Box, Button, PageContent, PageHeader } from 'grommet';
 import { Left } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/ascending-navigation/components/HomeContent.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/components/HomeContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { Grid } from 'grommet';
 import { SectionCard } from './SectionCard';

--- a/apps/docs/src/examples/templates/ascending-navigation/components/PageOneContent.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/components/PageOneContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
  import { useState } from 'react';
 import { Box, DataTable, Avatar, Text } from 'grommet';
 

--- a/apps/docs/src/examples/templates/ascending-navigation/components/PageTwoContent.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/components/PageTwoContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { DataTable, Text } from 'grommet';
 

--- a/apps/docs/src/examples/templates/ascending-navigation/components/SectionCard.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/components/SectionCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { Card, Box, Heading, Paragraph } from 'grommet';
 import { LinkNext } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/ascending-navigation/data/sections.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/data/sections.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { User, Home, Template } from '@hpe-design/icons-grommet';
 
 export const sectionConfig = {

--- a/apps/docs/src/examples/templates/ascending-navigation/index.js
+++ b/apps/docs/src/examples/templates/ascending-navigation/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AscendingNavigationExample';
 export * from './AscendingNavigationCodeExample';

--- a/apps/docs/src/examples/templates/code-blocks/CodeBlocks.js
+++ b/apps/docs/src/examples/templates/code-blocks/CodeBlocks.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 
 import { Box, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/templates/code-blocks/index.js
+++ b/apps/docs/src/examples/templates/code-blocks/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CodeBlocks';

--- a/apps/docs/src/examples/templates/content-layouts/ContainerDrivenLayout/AppResults.js
+++ b/apps/docs/src/examples/templates/content-layouts/ContainerDrivenLayout/AppResults.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Card, Cards, Heading, ResponsiveContext } from 'grommet';
 

--- a/apps/docs/src/examples/templates/content-layouts/ContainerDrivenLayout/ContainerDrivenLayout.js
+++ b/apps/docs/src/examples/templates/content-layouts/ContainerDrivenLayout/ContainerDrivenLayout.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/content-layouts/ContainerDrivenLayout/index.js
+++ b/apps/docs/src/examples/templates/content-layouts/ContainerDrivenLayout/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppResults';
 export * from './ContainerDrivenLayout';

--- a/apps/docs/src/examples/templates/content-layouts/ContentDrivenLayout.js
+++ b/apps/docs/src/examples/templates/content-layouts/ContentDrivenLayout.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button } from 'grommet';

--- a/apps/docs/src/examples/templates/content-layouts/NestedGrid.js
+++ b/apps/docs/src/examples/templates/content-layouts/NestedGrid.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Grid } from 'grommet';
 import { ContentArea } from '../page-layouts/anatomy/components';
 

--- a/apps/docs/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
+++ b/apps/docs/src/examples/templates/content-layouts/ResponsiveContentLayoutExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/content-layouts/index.js
+++ b/apps/docs/src/examples/templates/content-layouts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContainerDrivenLayout';
 export * from './ContentDrivenLayout';
 export * from './NestedGrid';

--- a/apps/docs/src/examples/templates/dashboards/DashboardExample.js
+++ b/apps/docs/src/examples/templates/dashboards/DashboardExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useMemo, useState } from 'react';
 import { Box, Button, Text, Page, PageContent, Main } from 'grommet';
 import { defaultUser, GlobalHeader, UserContext } from '../global-header';

--- a/apps/docs/src/examples/templates/dashboards/ThreeColumnDashboard.js
+++ b/apps/docs/src/examples/templates/dashboards/ThreeColumnDashboard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useState } from 'react';
 import {
   Grid,

--- a/apps/docs/src/examples/templates/dashboards/TwoColumnDashboard.js
+++ b/apps/docs/src/examples/templates/dashboards/TwoColumnDashboard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useContext } from 'react';
 import {

--- a/apps/docs/src/examples/templates/dashboards/components/Activity.js
+++ b/apps/docs/src/examples/templates/dashboards/components/Activity.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Anchor, Box, Grid, Text } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/dashboards/components/ActivityFeed.js
+++ b/apps/docs/src/examples/templates/dashboards/components/ActivityFeed.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import {
   Card,

--- a/apps/docs/src/examples/templates/dashboards/components/ChartCard.js
+++ b/apps/docs/src/examples/templates/dashboards/components/ChartCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/dashboards/components/DashboardCard.js
+++ b/apps/docs/src/examples/templates/dashboards/components/DashboardCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card, CardBody, Heading, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/components/DashboardCardHeader.js
+++ b/apps/docs/src/examples/templates/dashboards/components/DashboardCardHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Heading, Menu, Text } from 'grommet';
 import { MoreVertical } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/dashboards/components/DashboardFooter.js
+++ b/apps/docs/src/examples/templates/dashboards/components/DashboardFooter.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Footer, Text } from 'grommet';
 import { Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/dashboards/components/DashboardGrid.js
+++ b/apps/docs/src/examples/templates/dashboards/components/DashboardGrid.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Grid, ResponsiveContext } from 'grommet';
 import { data, DashboardCard } from '.';

--- a/apps/docs/src/examples/templates/dashboards/components/Greeting.js
+++ b/apps/docs/src/examples/templates/dashboards/components/Greeting.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { PageHeader } from 'grommet';
 import { UserContext } from '../../global-header';

--- a/apps/docs/src/examples/templates/dashboards/components/ItemCountList.js
+++ b/apps/docs/src/examples/templates/dashboards/components/ItemCountList.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/dashboards/components/Legend.js
+++ b/apps/docs/src/examples/templates/dashboards/components/Legend.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, List, Text, ThemeContext } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/components/Measure.js
+++ b/apps/docs/src/examples/templates/dashboards/components/Measure.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, NameValuePair, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/components/MeterGroup.js
+++ b/apps/docs/src/examples/templates/dashboards/components/MeterGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Grid } from 'grommet';
 

--- a/apps/docs/src/examples/templates/dashboards/components/StatusBar.js
+++ b/apps/docs/src/examples/templates/dashboards/components/StatusBar.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/dashboards/components/UpdateItem.js
+++ b/apps/docs/src/examples/templates/dashboards/components/UpdateItem.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Anchor, Box, Paragraph } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/components/UpdateNotificationsList.js
+++ b/apps/docs/src/examples/templates/dashboards/components/UpdateNotificationsList.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { List } from 'grommet';
 import { UpdateItem } from './UpdateItem';

--- a/apps/docs/src/examples/templates/dashboards/components/UpdatesFeed.js
+++ b/apps/docs/src/examples/templates/dashboards/components/UpdatesFeed.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Card, CardBody, CardHeader, ThemeContext } from 'grommet';
 import { useContext } from 'react';

--- a/apps/docs/src/examples/templates/dashboards/components/data.js
+++ b/apps/docs/src/examples/templates/dashboards/components/data.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   DocumentUpdate,
   Group,

--- a/apps/docs/src/examples/templates/dashboards/components/index.js
+++ b/apps/docs/src/examples/templates/dashboards/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './data';
 export * from './Activity';
 export * from './ActivityFeed';

--- a/apps/docs/src/examples/templates/dashboards/content/FirmwareBaselines.js
+++ b/apps/docs/src/examples/templates/dashboards/content/FirmwareBaselines.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import { ItemCountList } from '../components';
 

--- a/apps/docs/src/examples/templates/dashboards/content/FirmwareStatus.js
+++ b/apps/docs/src/examples/templates/dashboards/content/FirmwareStatus.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import {
   InProgress,

--- a/apps/docs/src/examples/templates/dashboards/content/RecentActivity.js
+++ b/apps/docs/src/examples/templates/dashboards/content/RecentActivity.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import { Button } from 'grommet';
 import { Info, Right } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/dashboards/content/ServerAttention.js
+++ b/apps/docs/src/examples/templates/dashboards/content/ServerAttention.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import { Info, StatusWarning } from '@hpe-design/icons-grommet';
 import { Measure, StatusBar } from '../components';

--- a/apps/docs/src/examples/templates/dashboards/content/ServerHealth.js
+++ b/apps/docs/src/examples/templates/dashboards/content/ServerHealth.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import {
   StatusCritical,

--- a/apps/docs/src/examples/templates/dashboards/content/UpdatesAvaliable.js
+++ b/apps/docs/src/examples/templates/dashboards/content/UpdatesAvaliable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import { UpdatesFeed, UpdateNotificationsList } from '../components';
 

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/CostByMonth.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/CostByMonth.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { DataChart, Text, Box, NameValueList } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/CostByService.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/CostByService.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/CostByYear.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/CostByYear.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { DataChart, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/RulesAudit.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/RulesAudit.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Meter, NameValueList, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/index.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CostByMonth';
 export * from './CostByService';
 export * from './CostByYear';

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/formatValues.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/formatValues.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const formatCurrency = (value, locale = 'en-US', currency = 'USD') =>
   Intl.NumberFormat(locale, {
     style: 'currency',

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/index.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './formatValues';
 export * from './window';
 export * from './statistics';

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/statistics.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/statistics.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* Utility functions for statistics used in charting */
 
 export const mean = series =>

--- a/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/window.js
+++ b/apps/docs/src/examples/templates/dashboards/content/chartCards/utils/window.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // eslint-disable-next-line max-len
 const mockAccountData = require('../../../../../../data/mockData/accounts.json');
 

--- a/apps/docs/src/examples/templates/dashboards/content/index.js
+++ b/apps/docs/src/examples/templates/dashboards/content/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './chartCards';
 export * from './FirmwareBaselines';
 export * from './FirmwareStatus';

--- a/apps/docs/src/examples/templates/dashboards/index.js
+++ b/apps/docs/src/examples/templates/dashboards/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './components';
 export * from './content';
 export * from './DashboardExample';

--- a/apps/docs/src/examples/templates/double-confirmation/DoubleConfirmationAnatomy.js
+++ b/apps/docs/src/examples/templates/double-confirmation/DoubleConfirmationAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Button, Diagram, Grid, Stack } from 'grommet';
 import { LayerHeader, ModalContainer, ModalFooter } from '@shared/aries-core';
 import { Annotation } from '../../../layouts';

--- a/apps/docs/src/examples/templates/double-confirmation/DoubleConfirmationBestPractice.js
+++ b/apps/docs/src/examples/templates/double-confirmation/DoubleConfirmationBestPractice.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/templates/double-confirmation/DoubleConfirmationExample.js
+++ b/apps/docs/src/examples/templates/double-confirmation/DoubleConfirmationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button } from 'grommet';

--- a/apps/docs/src/examples/templates/double-confirmation/index.js
+++ b/apps/docs/src/examples/templates/double-confirmation/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DoubleConfirmationAnatomy';
 export * from './DoubleConfirmationBestPractice';
 export * from './DoubleConfirmationExample';

--- a/apps/docs/src/examples/templates/drill-down-navigation/drill-down-card-example.js
+++ b/apps/docs/src/examples/templates/drill-down-navigation/drill-down-card-example.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { NameValueList, NameValuePair } from 'grommet';
 

--- a/apps/docs/src/examples/templates/drill-down-navigation/drill-down-datatable-example.js
+++ b/apps/docs/src/examples/templates/drill-down-navigation/drill-down-datatable-example.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { NameValueList, NameValuePair } from 'grommet';
 

--- a/apps/docs/src/examples/templates/drill-down-navigation/drill-down-list-example.js
+++ b/apps/docs/src/examples/templates/drill-down-navigation/drill-down-list-example.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { NameValueList, NameValuePair } from 'grommet';
 

--- a/apps/docs/src/examples/templates/drill-down-navigation/index.js
+++ b/apps/docs/src/examples/templates/drill-down-navigation/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './drill-down-card-example';
 export * from './drill-down-datatable-example';
 export * from './drill-down-list-example';

--- a/apps/docs/src/examples/templates/empty-state/AccessDenied.js
+++ b/apps/docs/src/examples/templates/empty-state/AccessDenied.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Button } from 'grommet';
 import { Lock } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/empty-state/ActionEmptyState.js
+++ b/apps/docs/src/examples/templates/empty-state/ActionEmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { EmptyState } from '@shared/aries-core';
 import { Anchor, Box, Button, Grid, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/empty-state/CardEmptyState.js
+++ b/apps/docs/src/examples/templates/empty-state/CardEmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Main, Grid, Page, PageContent, PageHeader } from 'grommet';
 import { Card } from '../Card';

--- a/apps/docs/src/examples/templates/empty-state/EmptyStateAnatomy.js
+++ b/apps/docs/src/examples/templates/empty-state/EmptyStateAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/templates/empty-state/EmptyStateExample.js
+++ b/apps/docs/src/examples/templates/empty-state/EmptyStateExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { EmptyState } from '@shared/aries-core';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/templates/empty-state/ErrorManagementEmptyState.js
+++ b/apps/docs/src/examples/templates/empty-state/ErrorManagementEmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { EmptyState } from '@shared/aries-core';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/templates/empty-state/LayerEmptyState.js
+++ b/apps/docs/src/examples/templates/empty-state/LayerEmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Page, PageContent, PageHeader } from 'grommet';

--- a/apps/docs/src/examples/templates/empty-state/ListingEmptyState.js
+++ b/apps/docs/src/examples/templates/empty-state/ListingEmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'grommet';

--- a/apps/docs/src/examples/templates/empty-state/NoData.js
+++ b/apps/docs/src/examples/templates/empty-state/NoData.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { EmptyState } from '@shared/aries-core';
 import { Anchor, Box, Button, Grid, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/empty-state/PageEmptyState.js
+++ b/apps/docs/src/examples/templates/empty-state/PageEmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   PageHeader,

--- a/apps/docs/src/examples/templates/empty-state/index.js
+++ b/apps/docs/src/examples/templates/empty-state/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AccessDenied';
 export * from './ActionEmptyState';
 export * from './CardEmptyState';

--- a/apps/docs/src/examples/templates/export-data/ExportDataContainer.js
+++ b/apps/docs/src/examples/templates/export-data/ExportDataContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Form, FormField, RadioButtonGroup } from 'grommet';
 import {

--- a/apps/docs/src/examples/templates/export-data/index.js
+++ b/apps/docs/src/examples/templates/export-data/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ExportDataContainer';

--- a/apps/docs/src/examples/templates/feedback/FeedbackAnatomy.js
+++ b/apps/docs/src/examples/templates/feedback/FeedbackAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Diagram, Grid, Header, Heading, Stack } from 'grommet';
 import { ButtonGroup } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/ModalTaskFlowExample.js
+++ b/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/ModalTaskFlowExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-use-before-define */
 import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/PowerOnFlow.js
+++ b/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/PowerOnFlow.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Spinner, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/TaskFlowFeedback.js
+++ b/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/TaskFlowFeedback.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';

--- a/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/index.js
+++ b/apps/docs/src/examples/templates/feedback/ModalTaskFlowExample/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ModalTaskFlowExample';

--- a/apps/docs/src/examples/templates/feedback/SimpleFeedbackExample.js
+++ b/apps/docs/src/examples/templates/feedback/SimpleFeedbackExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Form, FormField, Heading, StarRating } from 'grommet';

--- a/apps/docs/src/examples/templates/feedback/index.js
+++ b/apps/docs/src/examples/templates/feedback/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FeedbackAnatomy';
 export * from './ModalTaskFlowExample';
 export * from './SimpleFeedbackExample';

--- a/apps/docs/src/examples/templates/filtering/FilteringCards/FilteringCards.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringCards/FilteringCards.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/filtering/FilteringCards/index.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringCards/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FilteringCards';

--- a/apps/docs/src/examples/templates/filtering/FilteringCards/mockData.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringCards/mockData.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const users = [
   {
     id: 1,

--- a/apps/docs/src/examples/templates/filtering/FilteringLists/FilteringLists.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringLists/FilteringLists.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/filtering/FilteringLists/index.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringLists/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FilteringLists';

--- a/apps/docs/src/examples/templates/filtering/FilteringLists/mockData.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringLists/mockData.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const orders = [
   {
     name: 'My PVT Cloud Order',

--- a/apps/docs/src/examples/templates/filtering/FilteringTable/FilterServers.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringTable/FilterServers.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/filtering/FilteringTable/FilteringTable.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringTable/FilteringTable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Heading } from 'grommet';
 import { FilterServers } from './FilterServers';

--- a/apps/docs/src/examples/templates/filtering/FilteringTable/index.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringTable/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FilteringTable';
 export * from './FilterServers';

--- a/apps/docs/src/examples/templates/filtering/FilteringTable/mockData.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringTable/mockData.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const servers = [
   {
     id: 'id-1',

--- a/apps/docs/src/examples/templates/filtering/FilteringWithSelect.js
+++ b/apps/docs/src/examples/templates/filtering/FilteringWithSelect.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/filtering/PersistentFiltering.js
+++ b/apps/docs/src/examples/templates/filtering/PersistentFiltering.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   useCallback,
   useContext,

--- a/apps/docs/src/examples/templates/filtering/QuickFilterToolbar.js
+++ b/apps/docs/src/examples/templates/filtering/QuickFilterToolbar.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/filtering/index.js
+++ b/apps/docs/src/examples/templates/filtering/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FilteringCards/index';
 export * from './FilteringLists/index';
 export * from './FilteringTable/index';

--- a/apps/docs/src/examples/templates/forms/ChangePasswordExample.js
+++ b/apps/docs/src/examples/templates/forms/ChangePasswordExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/CharacterCounterExample.js
+++ b/apps/docs/src/examples/templates/forms/CharacterCounterExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Form, FormField, TextArea } from 'grommet';
 

--- a/apps/docs/src/examples/templates/forms/CustomizeExample.js
+++ b/apps/docs/src/examples/templates/forms/CustomizeExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/templates/forms/FormPresentationDecisionTree.js
+++ b/apps/docs/src/examples/templates/forms/FormPresentationDecisionTree.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import { Anchor, Diagram, Grid, ResponsiveContext, Stack, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/forms/FullPageFormExample.js
+++ b/apps/docs/src/examples/templates/forms/FullPageFormExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Image } from 'grommet';
 import { useDarkMode } from '../../../utils';

--- a/apps/docs/src/examples/templates/forms/PayExample.js
+++ b/apps/docs/src/examples/templates/forms/PayExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/RequiredFieldsExample.js
+++ b/apps/docs/src/examples/templates/forms/RequiredFieldsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/SettingsExample.js
+++ b/apps/docs/src/examples/templates/forms/SettingsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/Shipping/ContactInfomation.js
+++ b/apps/docs/src/examples/templates/forms/Shipping/ContactInfomation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, FormField, MaskedInput, Text, TextInput } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/forms/Shipping/ShippingInfomation.js
+++ b/apps/docs/src/examples/templates/forms/Shipping/ShippingInfomation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CheckBox, FormField, Select, Text, TextInput } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/forms/Shipping/index.js
+++ b/apps/docs/src/examples/templates/forms/Shipping/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContactInfomation';
 export * from './ShippingInfomation';

--- a/apps/docs/src/examples/templates/forms/ShippingExample.js
+++ b/apps/docs/src/examples/templates/forms/ShippingExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/SignInExample.js
+++ b/apps/docs/src/examples/templates/forms/SignInExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/forms/SignUpExample.js
+++ b/apps/docs/src/examples/templates/forms/SignUpExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/apps/docs/src/examples/templates/forms/SimpleSignUpExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/templates/forms/SingleFormFieldExample.js
+++ b/apps/docs/src/examples/templates/forms/SingleFormFieldExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/SortExample.js
+++ b/apps/docs/src/examples/templates/forms/SortExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/do-dont/ColumnFormDo.js
+++ b/apps/docs/src/examples/templates/forms/do-dont/ColumnFormDo.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/do-dont/ColumnFormDont.js
+++ b/apps/docs/src/examples/templates/forms/do-dont/ColumnFormDont.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/do-dont/index.js
+++ b/apps/docs/src/examples/templates/forms/do-dont/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
  export * from './ColumnFormDo';
  export * from './ColumnFormDont';

--- a/apps/docs/src/examples/templates/forms/index.js
+++ b/apps/docs/src/examples/templates/forms/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './do-dont';
 export * from './managing-child-objects';
 export * from './ChangePasswordExample';

--- a/apps/docs/src/examples/templates/forms/managing-child-objects/CollapsedStateAnatomy.js
+++ b/apps/docs/src/examples/templates/forms/managing-child-objects/CollapsedStateAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Diagram, Grid, ResponsiveContext, Stack } from 'grommet';
 import { connection } from '../../../../utils';

--- a/apps/docs/src/examples/templates/forms/managing-child-objects/CreateCluster.js
+++ b/apps/docs/src/examples/templates/forms/managing-child-objects/CreateCluster.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/managing-child-objects/CreateRole.js
+++ b/apps/docs/src/examples/templates/forms/managing-child-objects/CreateRole.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/managing-child-objects/EditRole.js
+++ b/apps/docs/src/examples/templates/forms/managing-child-objects/EditRole.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/managing-child-objects/ExpandedStateAnatomy.js
+++ b/apps/docs/src/examples/templates/forms/managing-child-objects/ExpandedStateAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/forms/managing-child-objects/index.js
+++ b/apps/docs/src/examples/templates/forms/managing-child-objects/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CollapsedStateAnatomy';
 export * from './CreateCluster';
 export * from './CreateRole';

--- a/apps/docs/src/examples/templates/forms/utils/FormValidation.js
+++ b/apps/docs/src/examples/templates/forms/utils/FormValidation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const emailMask = [
   {
     regexp: /^[\w\-_.]+$/,

--- a/apps/docs/src/examples/templates/global-banner-notifications/BannerContentLayoutExample.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/BannerContentLayoutExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Avatar,

--- a/apps/docs/src/examples/templates/global-banner-notifications/BannerNotificationDiagram.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/BannerNotificationDiagram.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Anchor, Box, Grid, Diagram, Stack, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/global-banner-notifications/Dos&Donts/BannerNotificationDoExample.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Dos&Donts/BannerNotificationDoExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Dos&Donts/BannerNotificationDontExample.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Dos&Donts/BannerNotificationDontExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Dos&Donts/index.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Dos&Donts/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BannerNotificationDoExample';
 export * from './BannerNotificationDontExample';

--- a/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationCritical.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationCritical.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationCriticalClose.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationCriticalClose.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationInfo.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationInfo.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationWarning.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationWarning.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationWarningClose.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationWarningClose.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Notification } from 'grommet';
 

--- a/apps/docs/src/examples/templates/global-banner-notifications/Examples/index.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/Examples/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BannerNotificationCritical';
 export * from './BannerNotificationCriticalClose';
 export * from './BannerNotificationInfo';

--- a/apps/docs/src/examples/templates/global-banner-notifications/index.js
+++ b/apps/docs/src/examples/templates/global-banner-notifications/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BannerContentLayoutExample';
 export * from './BannerNotificationDiagram';
 export * from './Dos&Donts';

--- a/apps/docs/src/examples/templates/global-header/components/AppIdentity.js
+++ b/apps/docs/src/examples/templates/global-header/components/AppIdentity.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Box, ResponsiveContext, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/global-header/components/GlobalHeader.js
+++ b/apps/docs/src/examples/templates/global-header/components/GlobalHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Header, ResponsiveContext } from 'grommet';
 import { AppIdentity, HeaderNav, UserContext } from '.';

--- a/apps/docs/src/examples/templates/global-header/components/GlobalHeaderExample.js
+++ b/apps/docs/src/examples/templates/global-header/components/GlobalHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import { MockGlobalHeader } from './MockGlobalHeader';

--- a/apps/docs/src/examples/templates/global-header/components/HeaderNav.js
+++ b/apps/docs/src/examples/templates/global-header/components/HeaderNav.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import {
   Avatar,

--- a/apps/docs/src/examples/templates/global-header/components/MenuLayer.js
+++ b/apps/docs/src/examples/templates/global-header/components/MenuLayer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/global-header/components/MockGlobalHeader.js
+++ b/apps/docs/src/examples/templates/global-header/components/MockGlobalHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Image, ResponsiveContext } from 'grommet';
 import { useContext } from 'react';

--- a/apps/docs/src/examples/templates/global-header/components/UserContext.js
+++ b/apps/docs/src/examples/templates/global-header/components/UserContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 export const UserContext = React.createContext({

--- a/apps/docs/src/examples/templates/global-header/components/index.js
+++ b/apps/docs/src/examples/templates/global-header/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppIdentity';
 export * from './GlobalHeader';
 export * from './GlobalHeaderExample';

--- a/apps/docs/src/examples/templates/global-header/index.js
+++ b/apps/docs/src/examples/templates/global-header/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './components';

--- a/apps/docs/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
+++ b/apps/docs/src/examples/templates/hub-spoke-navigation/HubSpokeCardsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/hub-spoke-navigation/index.js
+++ b/apps/docs/src/examples/templates/hub-spoke-navigation/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './HubSpokeCardsExample';

--- a/apps/docs/src/examples/templates/index.js
+++ b/apps/docs/src/examples/templates/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* Template page examples */
 export * from './ascending-navigation';
 export * from './Card';

--- a/apps/docs/src/examples/templates/inline-notifications/InlineFormValidation.js
+++ b/apps/docs/src/examples/templates/inline-notifications/InlineFormValidation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Alert } from '@hpe-design/icons-grommet';
 import {

--- a/apps/docs/src/examples/templates/inline-notifications/InlineNotificationAnatomy.js
+++ b/apps/docs/src/examples/templates/inline-notifications/InlineNotificationAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, Button, Diagram, Grid, Stack, Paragraph } from 'grommet';
 import { Close, StatusWarning } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/inline-notifications/InlineNotificationExample.js
+++ b/apps/docs/src/examples/templates/inline-notifications/InlineNotificationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/examples/templates/inline-notifications/PageBannerExample.js
+++ b/apps/docs/src/examples/templates/inline-notifications/PageBannerExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import {
   Anchor,

--- a/apps/docs/src/examples/templates/inline-notifications/PromotionExample.js
+++ b/apps/docs/src/examples/templates/inline-notifications/PromotionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import {
   Box,

--- a/apps/docs/src/examples/templates/inline-notifications/StatusUpdateExample.js
+++ b/apps/docs/src/examples/templates/inline-notifications/StatusUpdateExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Notification } from 'grommet';
 import { CostByService } from '../dashboards/content';

--- a/apps/docs/src/examples/templates/inline-notifications/index.js
+++ b/apps/docs/src/examples/templates/inline-notifications/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './InlineFormValidation';
 export * from './InlineNotificationAnatomy';
 export * from './InlineNotificationExample';

--- a/apps/docs/src/examples/templates/list-views/ListIconIdentifierExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListIconIdentifierExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, List, Text } from 'grommet';
 import {

--- a/apps/docs/src/examples/templates/list-views/ListImageIdentifierExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListImageIdentifierExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Image, List, Text } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/list-views/ListNameDescriptionOptionExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListNameDescriptionOptionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, List, Text } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/list-views/ListNameExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListNameExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, List } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/list-views/ListNameOptionActionExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListNameOptionActionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, List, Menu, Text } from 'grommet';
 import { More, StatusGood, StatusCritical } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/list-views/ListOrderExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListOrderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Button, Heading, List } from 'grommet';
 import { ContentPane } from '../../../layouts/content/ContentPane';

--- a/apps/docs/src/examples/templates/list-views/ListScreenExample.js
+++ b/apps/docs/src/examples/templates/list-views/ListScreenExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/list-views/index.js
+++ b/apps/docs/src/examples/templates/list-views/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ListIconIdentifierExample';
 export * from './ListImageIdentifierExample';
 export * from './ListNameDescriptionOptionExample';

--- a/apps/docs/src/examples/templates/page-layouts/HeaderFooterExample.js
+++ b/apps/docs/src/examples/templates/page-layouts/HeaderFooterExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Header, Box, Footer, Main, ResponsiveContext } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/page-layouts/HeaderOnlyExample.js
+++ b/apps/docs/src/examples/templates/page-layouts/HeaderOnlyExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Header, Box, Main, ResponsiveContext } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/page-layouts/PageContainerInteractive.js
+++ b/apps/docs/src/examples/templates/page-layouts/PageContainerInteractive.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Header, Main, Page, PageContent } from 'grommet';
 import { AppContainer } from './components';
 import { ContentArea } from './anatomy/components';

--- a/apps/docs/src/examples/templates/page-layouts/StickyHeaderExample.js
+++ b/apps/docs/src/examples/templates/page-layouts/StickyHeaderExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Header, Box, Footer, Main, ResponsiveContext } from 'grommet';
 import { TextEmphasis } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/AppAnatomy.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/AppAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { ThemeContext } from 'grommet';
 

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/PageAnatomy.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/PageAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { ThemeContext } from 'grommet';
 

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/PageContainerFull.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/PageContainerFull.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Diagram, Stack, ThemeContext } from 'grommet';
 import { LinkPrev, LinkNext } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/PageContainerNarrow.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/PageContainerNarrow.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Diagram, Stack, ThemeContext } from 'grommet';
 import { LinkPrev, LinkNext } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/PageContainerWide.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Diagram, Stack, ThemeContext } from 'grommet';
 import { LinkPrev, LinkNext } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/PageMarginAnatomy.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/PageMarginAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Box, Grid, Text, ThemeContext } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/components/ContentArea.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/components/ContentArea.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, ThemeContext } from 'grommet';
 import { Element } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/components/ContentLabel.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/components/ContentLabel.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';
 

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/components/index.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/components/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContentArea';
 export * from './ContentLabel';

--- a/apps/docs/src/examples/templates/page-layouts/anatomy/index.js
+++ b/apps/docs/src/examples/templates/page-layouts/anatomy/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppAnatomy';
 export * from './PageAnatomy';
 export * from './PageContainerFull';

--- a/apps/docs/src/examples/templates/page-layouts/components/AppContainer.js
+++ b/apps/docs/src/examples/templates/page-layouts/components/AppContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 
 // Theme-like object specifying alignment, width, and spacing for

--- a/apps/docs/src/examples/templates/page-layouts/components/PageContainer.js
+++ b/apps/docs/src/examples/templates/page-layouts/components/PageContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Box, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/page-layouts/components/index.js
+++ b/apps/docs/src/examples/templates/page-layouts/components/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppContainer';
 export * from './PageContainer';

--- a/apps/docs/src/examples/templates/page-layouts/index.js
+++ b/apps/docs/src/examples/templates/page-layouts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './anatomy';
 export * from './components';
 export * from './HeaderFooterExample';

--- a/apps/docs/src/examples/templates/popover/PopoverAnatomy.js
+++ b/apps/docs/src/examples/templates/popover/PopoverAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/popover/PopoverInlineExample.js
+++ b/apps/docs/src/examples/templates/popover/PopoverInlineExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState, useRef, useContext } from 'react';
 import { Popover } from '@shared/aries-core';
 import {

--- a/apps/docs/src/examples/templates/popover/PopoverSimpleExample.js
+++ b/apps/docs/src/examples/templates/popover/PopoverSimpleExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState, useRef } from 'react';
 
 import { Popover } from '@shared/aries-core';

--- a/apps/docs/src/examples/templates/popover/index.js
+++ b/apps/docs/src/examples/templates/popover/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './PopoverAnatomy';
 export * from './PopoverInlineExample';
 export * from './PopoverSimpleExample';

--- a/apps/docs/src/examples/templates/selector/QuickFilter.js
+++ b/apps/docs/src/examples/templates/selector/QuickFilter.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable grommet/datatable-aria-describedby */
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/examples/templates/selector/SelectorAnatomy.js
+++ b/apps/docs/src/examples/templates/selector/SelectorAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import styled from 'styled-components';
 import { Box, Button, Diagram, Grid, Stack, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/selector/SelectorMutli.js
+++ b/apps/docs/src/examples/templates/selector/SelectorMutli.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Iteration } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/selector/SelectorSimple.js
+++ b/apps/docs/src/examples/templates/selector/SelectorSimple.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Iteration } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/selector/SelectorSingle.js
+++ b/apps/docs/src/examples/templates/selector/SelectorSingle.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Iteration } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/templates/selector/SupportSelector.js
+++ b/apps/docs/src/examples/templates/selector/SupportSelector.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 
 import {

--- a/apps/docs/src/examples/templates/selector/TEMP.js
+++ b/apps/docs/src/examples/templates/selector/TEMP.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 

--- a/apps/docs/src/examples/templates/selector/index.js
+++ b/apps/docs/src/examples/templates/selector/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TEMP';
 export * from './SupportSelector';
 export * from './QuickFilter';

--- a/apps/docs/src/examples/templates/table-customization/components/ColumnSettingsExample.js
+++ b/apps/docs/src/examples/templates/table-customization/components/ColumnSettingsExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Data, DataTableColumns } from 'grommet';
 
 const COLUMNS = [

--- a/apps/docs/src/examples/templates/table-customization/components/TableCustomizationExample.js
+++ b/apps/docs/src/examples/templates/table-customization/components/TableCustomizationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import {
   Box,

--- a/apps/docs/src/examples/templates/table-customization/components/index.js
+++ b/apps/docs/src/examples/templates/table-customization/components/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ColumnSettingsExample';
 export * from './TableCustomizationExample';

--- a/apps/docs/src/examples/templates/table-customization/index.js
+++ b/apps/docs/src/examples/templates/table-customization/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './components';

--- a/apps/docs/src/examples/templates/toast-notifications/ToastDiagram.js
+++ b/apps/docs/src/examples/templates/toast-notifications/ToastDiagram.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Diagram, Stack } from 'grommet';
 import { ToastPreview } from '../../cardPreviews';

--- a/apps/docs/src/examples/templates/toast-notifications/ToastNotificationExample.js
+++ b/apps/docs/src/examples/templates/toast-notifications/ToastNotificationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Button, Notification, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/templates/toast-notifications/ToastNotificationPositionExample.js
+++ b/apps/docs/src/examples/templates/toast-notifications/ToastNotificationPositionExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Button, Notification, Paragraph } from 'grommet';
 

--- a/apps/docs/src/examples/templates/toast-notifications/index.js
+++ b/apps/docs/src/examples/templates/toast-notifications/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ToastNotificationExample';
 export * from './ToastNotificationPositionExample';
 export * from './ToastDiagram';

--- a/apps/docs/src/examples/templates/wizard/TwoColumnWizardExample.js
+++ b/apps/docs/src/examples/templates/wizard/TwoColumnWizardExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/examples/templates/wizard/WizardAnatomy.js
+++ b/apps/docs/src/examples/templates/wizard/WizardAnatomy.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/examples/templates/wizard/WizardValidationExample.js
+++ b/apps/docs/src/examples/templates/wizard/WizardValidationExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/examples/templates/wizard/components/CancellationLayer.js
+++ b/apps/docs/src/examples/templates/wizard/components/CancellationLayer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Heading, Layer, Text, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/wizard/components/Error.js
+++ b/apps/docs/src/examples/templates/wizard/components/Error.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/wizard/components/StepContent.js
+++ b/apps/docs/src/examples/templates/wizard/components/StepContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Form, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/wizard/components/StepFooter.js
+++ b/apps/docs/src/examples/templates/wizard/components/StepFooter.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Footer, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/examples/templates/wizard/components/StepHeader.js
+++ b/apps/docs/src/examples/templates/wizard/components/StepHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Paragraph, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/wizard/components/WizardContext.js
+++ b/apps/docs/src/examples/templates/wizard/components/WizardContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 export const WizardContext = React.createContext({});

--- a/apps/docs/src/examples/templates/wizard/components/WizardHeader.js
+++ b/apps/docs/src/examples/templates/wizard/components/WizardHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Header, ResponsiveContext, Text } from 'grommet';

--- a/apps/docs/src/examples/templates/wizard/components/index.js
+++ b/apps/docs/src/examples/templates/wizard/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CancellationLayer';
 export * from './Error';
 export * from './StepContent';

--- a/apps/docs/src/examples/templates/wizard/index.js
+++ b/apps/docs/src/examples/templates/wizard/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TwoColumnWizardExample';
 export * from './WizardValidationExample';
 export * from './WizardAnatomy';

--- a/apps/docs/src/examples/templates/wizard/utils.js
+++ b/apps/docs/src/examples/templates/wizard/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // Wizard width is not a t-shirt size but instead dependent
 // on the max number of columns it will contain * the width
 // of those columns (medium) + gap between columns + small amount

--- a/apps/docs/src/examples/tokens/BetaNotification.js
+++ b/apps/docs/src/examples/tokens/BetaNotification.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Notification } from 'grommet';
 
 export const BetaNotification = () => (

--- a/apps/docs/src/examples/tokens/ComponentStates.js
+++ b/apps/docs/src/examples/tokens/ComponentStates.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import styled from 'styled-components';
 // eslint-disable-next-line import/no-unresolved

--- a/apps/docs/src/examples/tokens/SpecialtyBackgrounds.js
+++ b/apps/docs/src/examples/tokens/SpecialtyBackgrounds.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Paragraph, Text } from 'grommet';
 import { Add } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/tokens/StandardBackgrounds.js
+++ b/apps/docs/src/examples/tokens/StandardBackgrounds.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 import { ContentPane } from '../../layouts';

--- a/apps/docs/src/examples/tokens/StandardForegrounds.js
+++ b/apps/docs/src/examples/tokens/StandardForegrounds.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Grid, Text } from 'grommet';
 import { Trigger } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/examples/tokens/StrongBackgrounds.js
+++ b/apps/docs/src/examples/tokens/StrongBackgrounds.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { Box, Button, Text } from 'grommet';

--- a/apps/docs/src/examples/tokens/TokenHighlight.js
+++ b/apps/docs/src/examples/tokens/TokenHighlight.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text } from 'grommet';

--- a/apps/docs/src/examples/tokens/TokenTypes.js
+++ b/apps/docs/src/examples/tokens/TokenTypes.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Grid, Heading, Paragraph, Text } from 'grommet';

--- a/apps/docs/src/examples/tokens/element/ElementToken.js
+++ b/apps/docs/src/examples/tokens/element/ElementToken.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, CheckBox, Text } from 'grommet';

--- a/apps/docs/src/examples/tokens/element/index.js
+++ b/apps/docs/src/examples/tokens/element/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ElementToken';

--- a/apps/docs/src/examples/tokens/index.js
+++ b/apps/docs/src/examples/tokens/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BetaNotification';
 export * from './ComponentStates';
 export * from './TokenHighlight';

--- a/apps/docs/src/layouts/content/AccessibilitySection.js
+++ b/apps/docs/src/layouts/content/AccessibilitySection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import React, { useMemo } from 'react';
 import { Notification } from 'grommet';

--- a/apps/docs/src/layouts/content/Annotation.js
+++ b/apps/docs/src/layouts/content/Annotation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/layouts/content/ButtonRow.js
+++ b/apps/docs/src/layouts/content/ButtonRow.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';

--- a/apps/docs/src/layouts/content/ColorRow.js
+++ b/apps/docs/src/layouts/content/ColorRow.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';

--- a/apps/docs/src/layouts/content/ContentPane.js
+++ b/apps/docs/src/layouts/content/ContentPane.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 

--- a/apps/docs/src/layouts/content/ContentSection.js
+++ b/apps/docs/src/layouts/content/ContentSection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';

--- a/apps/docs/src/layouts/content/DocsLayout.js
+++ b/apps/docs/src/layouts/content/DocsLayout.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import {
   Box,

--- a/apps/docs/src/layouts/content/DocsPageHeader.js
+++ b/apps/docs/src/layouts/content/DocsPageHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';

--- a/apps/docs/src/layouts/content/Example/BestPracticeGroup.js
+++ b/apps/docs/src/layouts/content/Example/BestPracticeGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Grid, ResponsiveContext } from 'grommet';
 

--- a/apps/docs/src/layouts/content/Example/BrowserWrapper.js
+++ b/apps/docs/src/layouts/content/Example/BrowserWrapper.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/Container.js
+++ b/apps/docs/src/layouts/content/Example/Container.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, defaultProps } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/DiagramPreview.js
+++ b/apps/docs/src/layouts/content/Example/DiagramPreview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Image, ThemeContext } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/DoDontContainer.js
+++ b/apps/docs/src/layouts/content/Example/DoDontContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Paragraph, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/Example.js
+++ b/apps/docs/src/layouts/content/Example/Example.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   cloneElement,
   useCallback,

--- a/apps/docs/src/layouts/content/Example/ExampleControls.js
+++ b/apps/docs/src/layouts/content/Example/ExampleControls.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/ExampleResources.js
+++ b/apps/docs/src/layouts/content/Example/ExampleResources.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Stack, ThemeContext } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/FigureWrapper.js
+++ b/apps/docs/src/layouts/content/Example/FigureWrapper.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/content/Example/HorizontalExample.js
+++ b/apps/docs/src/layouts/content/Example/HorizontalExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Grid, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/ResponsiveContainer.js
+++ b/apps/docs/src/layouts/content/Example/ResponsiveContainer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';

--- a/apps/docs/src/layouts/content/Example/ResponsiveControls.js
+++ b/apps/docs/src/layouts/content/Example/ResponsiveControls.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Button } from 'grommet';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/layouts/content/Example/index.js
+++ b/apps/docs/src/layouts/content/Example/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BestPracticeGroup';
 export * from './BrowserWrapper';
 export * from './Container';

--- a/apps/docs/src/layouts/content/FeedbackSection.js
+++ b/apps/docs/src/layouts/content/FeedbackSection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { ContentSection, Subsection } from '.';
 import { SubmitFeedback, SubsectionText } from '../../components';

--- a/apps/docs/src/layouts/content/Head.js
+++ b/apps/docs/src/layouts/content/Head.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import HeadNext from 'next/head';

--- a/apps/docs/src/layouts/content/InPageNavigation.js
+++ b/apps/docs/src/layouts/content/InPageNavigation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useRef, useEffect, useContext } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/content/NotificationTag.js
+++ b/apps/docs/src/layouts/content/NotificationTag.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Tag } from 'grommet';
 

--- a/apps/docs/src/layouts/content/PageIntro.js
+++ b/apps/docs/src/layouts/content/PageIntro.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Card, Grid, ResponsiveContext } from 'grommet';

--- a/apps/docs/src/layouts/content/RelatedContent.js
+++ b/apps/docs/src/layouts/content/RelatedContent.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ContentSection, Subsection } from '.';

--- a/apps/docs/src/layouts/content/StyleTable.js
+++ b/apps/docs/src/layouts/content/StyleTable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/layouts/content/Subsection.js
+++ b/apps/docs/src/layouts/content/Subsection.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/content/SubsectionHeader.js
+++ b/apps/docs/src/layouts/content/SubsectionHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Heading } from 'grommet';

--- a/apps/docs/src/layouts/content/UpdateNotification.js
+++ b/apps/docs/src/layouts/content/UpdateNotification.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Anchor, Text, Notification } from 'grommet';
 import { useContext } from 'react';

--- a/apps/docs/src/layouts/content/UsageExample.js
+++ b/apps/docs/src/layouts/content/UsageExample.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, ResponsiveContext, Text } from 'grommet';

--- a/apps/docs/src/layouts/content/WCAGRuleDetail.js
+++ b/apps/docs/src/layouts/content/WCAGRuleDetail.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import {
   Accordion,

--- a/apps/docs/src/layouts/content/WCAGRuleSummary.js
+++ b/apps/docs/src/layouts/content/WCAGRuleSummary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import {

--- a/apps/docs/src/layouts/content/index.js
+++ b/apps/docs/src/layouts/content/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AccessibilitySection';
 export * from './Annotation';
 export * from './ButtonRow';

--- a/apps/docs/src/layouts/index.js
+++ b/apps/docs/src/layouts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './content';
 export * from './main';
 export * from './navigation';

--- a/apps/docs/src/layouts/main/AppHeader.js
+++ b/apps/docs/src/layouts/main/AppHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Box, Button, Header, Page, PageContent } from 'grommet';
 import Link from 'next/link';

--- a/apps/docs/src/layouts/main/Layout.js
+++ b/apps/docs/src/layouts/main/Layout.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useContext } from 'react';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/main/ThemeMode.js
+++ b/apps/docs/src/layouts/main/ThemeMode.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Grommet } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/main/UserFeedback.js
+++ b/apps/docs/src/layouts/main/UserFeedback.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/router';
 import {

--- a/apps/docs/src/layouts/main/index.js
+++ b/apps/docs/src/layouts/main/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppHeader';
 export * from './Layout';
 export * from './ThemeMode';

--- a/apps/docs/src/layouts/navigation/MobileNavHeader.js
+++ b/apps/docs/src/layouts/navigation/MobileNavHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { Button, Header } from 'grommet';

--- a/apps/docs/src/layouts/navigation/NavContext.js
+++ b/apps/docs/src/layouts/navigation/NavContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState, useMemo, useEffect } from 'react';
 import { ResponsiveContext } from 'grommet';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/navigation/Navigation.js
+++ b/apps/docs/src/layouts/navigation/Navigation.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useAnalytics, Layer } from 'grommet';
 import { useRouter } from 'next/router';
 import { NavigationMenu } from '@shared/aries-core';

--- a/apps/docs/src/layouts/navigation/Search.js
+++ b/apps/docs/src/layouts/navigation/Search.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useState } from 'react';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';

--- a/apps/docs/src/layouts/navigation/SearchInput.js
+++ b/apps/docs/src/layouts/navigation/SearchInput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { forwardRef } from 'react';
 import styled from 'styled-components';
 import { TextInput } from 'grommet';

--- a/apps/docs/src/layouts/navigation/SearchResult.js
+++ b/apps/docs/src/layouts/navigation/SearchResult.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Paragraph, Text } from 'grommet';
 

--- a/apps/docs/src/layouts/navigation/SearchResults.js
+++ b/apps/docs/src/layouts/navigation/SearchResults.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/apps/docs/src/layouts/navigation/SideNavHeader.js
+++ b/apps/docs/src/layouts/navigation/SideNavHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';

--- a/apps/docs/src/layouts/navigation/__tests__/navItems.test.ts
+++ b/apps/docs/src/layouts/navigation/__tests__/navItems.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 
 import { structure } from '../../../data';

--- a/apps/docs/src/layouts/navigation/index.js
+++ b/apps/docs/src/layouts/navigation/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavContext';
 export * from './Navigation';
 export * from './Search';

--- a/apps/docs/src/layouts/navigation/navItems.ts
+++ b/apps/docs/src/layouts/navigation/navItems.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { NavItemType } from '@shared/aries-core';
 import { structure } from '../../data';
 import { categoryOrders, structureIndexes } from '../../data/structure';

--- a/apps/docs/src/page-objects/components/Navbar.js
+++ b/apps/docs/src/page-objects/components/Navbar.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Selector, t } from 'testcafe';
 import { repeatKeyPress, tabToSearch } from '../../tests/utils';
 

--- a/apps/docs/src/pages/404.js
+++ b/apps/docs/src/pages/404.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import { ThemeContext } from 'styled-components';

--- a/apps/docs/src/pages/_app.js
+++ b/apps/docs/src/pages/_app.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { MDXProvider } from '@mdx-js/react';
 import PropTypes from 'prop-types';
 import React, { useEffect, createContext, useState, useMemo } from 'react';

--- a/apps/docs/src/pages/_document.js
+++ b/apps/docs/src/pages/_document.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 

--- a/apps/docs/src/pages/components/index.js
+++ b/apps/docs/src/pages/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, Heading, PageContent, Paragraph } from 'grommet';
 

--- a/apps/docs/src/pages/design-tokens/all-design-tokens.js
+++ b/apps/docs/src/pages/design-tokens/all-design-tokens.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import React, { useEffect, useContext, useState, useMemo, useRef } from 'react';
 import {

--- a/apps/docs/src/pages/design-tokens/index.js
+++ b/apps/docs/src/pages/design-tokens/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/pages/feedback.js
+++ b/apps/docs/src/pages/feedback.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Page, PageContent } from 'grommet';

--- a/apps/docs/src/pages/foundation/index.js
+++ b/apps/docs/src/pages/foundation/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Heading, PageContent, Paragraph } from 'grommet';
 

--- a/apps/docs/src/pages/index.js
+++ b/apps/docs/src/pages/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { Box, Card, Heading, PageContent, Paragraph } from 'grommet';

--- a/apps/docs/src/pages/learn/index.js
+++ b/apps/docs/src/pages/learn/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   Box,

--- a/apps/docs/src/pages/templates/index.js
+++ b/apps/docs/src/pages/templates/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Heading, PageContent, Paragraph } from 'grommet';
 

--- a/apps/docs/src/scripts/site-contents.mjs
+++ b/apps/docs/src/scripts/site-contents.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { readdir, readFile, mkdir, writeFile, access } from 'fs/promises';
 import { resolve, sep } from 'path';
 

--- a/apps/docs/src/tests/accessibility/axe.js
+++ b/apps/docs/src/tests/accessibility/axe.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { axeCheck, createReport } from 'axe-testcafe';

--- a/apps/docs/src/tests/navigation/deeplinks.js
+++ b/apps/docs/src/tests/navigation/deeplinks.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { waitForReact } from 'testcafe-react-selectors';
 // import { Selector } from 'testcafe';

--- a/apps/docs/src/tests/navigation/homepage.js
+++ b/apps/docs/src/tests/navigation/homepage.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { baseUrl, getLocation, tabToHref } from '../utils';

--- a/apps/docs/src/tests/navigation/navpage.js
+++ b/apps/docs/src/tests/navigation/navpage.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';

--- a/apps/docs/src/tests/navigation/search.js
+++ b/apps/docs/src/tests/navigation/search.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { waitForReact } from 'testcafe-react-selectors';
 import { screen } from '@testing-library/testcafe';

--- a/apps/docs/src/tests/navigation/topic.js
+++ b/apps/docs/src/tests/navigation/topic.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
 import { baseUrl, getLocation, tabToHref } from '../utils';

--- a/apps/docs/src/tests/utils.js
+++ b/apps/docs/src/tests/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-await-in-loop */
 import { ClientFunction, Selector } from 'testcafe';
 import { ReactSelector } from 'testcafe-react-selectors';

--- a/apps/docs/src/themes/aries.js
+++ b/apps/docs/src/themes/aries.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { hpe, hpePop } from 'grommet-theme-hpe';
 import { deepMerge } from 'grommet/utils';
 import { Info } from '@hpe-design/icons-grommet';

--- a/apps/docs/src/themes/scaled.js
+++ b/apps/docs/src/themes/scaled.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 // import { generate } from 'grommet/themes/base';
 // import { deepMerge } from 'grommet/utils';

--- a/apps/docs/src/utils/__tests__/route-parity.test.ts
+++ b/apps/docs/src/utils/__tests__/route-parity.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { nameToPath, getPageDetails } from '../search';
 

--- a/apps/docs/src/utils/__tests__/search.test.ts
+++ b/apps/docs/src/utils/__tests__/search.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
 import { buildStructureIndexes } from '../../data/structureIndexes';
 import {

--- a/apps/docs/src/utils/analytics.js
+++ b/apps/docs/src/utils/analytics.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 
 // eslint-disable-next-line no-unused-vars

--- a/apps/docs/src/utils/createGlobalState.js
+++ b/apps/docs/src/utils/createGlobalState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 const globalState = {};
 
 export const createGlobalState = (key, thisCallback, initialValue) => {

--- a/apps/docs/src/utils/createPersistedState.js
+++ b/apps/docs/src/utils/createPersistedState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { createStorage, usePersistedState } from '.';
 

--- a/apps/docs/src/utils/createStorage.js
+++ b/apps/docs/src/utils/createStorage.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const createStorage = provider => ({
   get(key, defaultValue) {
     const json = provider.getItem(key);

--- a/apps/docs/src/utils/diagram.js
+++ b/apps/docs/src/utils/diagram.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const connection = (fromTarget, toTarget, direction, type) => ({
   anchor: direction || 'horizontal',
   type: type || 'direct',

--- a/apps/docs/src/utils/hooks/index.js
+++ b/apps/docs/src/utils/hooks/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './useDarkMode';
 export * from './useEventListener';
 export * from './usePersistedState';

--- a/apps/docs/src/utils/hooks/useDarkMode.js
+++ b/apps/docs/src/utils/hooks/useDarkMode.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useCallback, useMemo } from 'react';
 import { initialize, useEventListener } from '..';
 

--- a/apps/docs/src/utils/hooks/useEventListener.js
+++ b/apps/docs/src/utils/hooks/useEventListener.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useRef, useEffect } from 'react';
 
 export const useEventListener = (eventName, handler, element = global) => {

--- a/apps/docs/src/utils/hooks/usePersistedState.js
+++ b/apps/docs/src/utils/hooks/usePersistedState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useRef } from 'react';
 import { createGlobalState, useEventListener } from '..';
 

--- a/apps/docs/src/utils/index.js
+++ b/apps/docs/src/utils/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './analytics';
 export * from './createGlobalState';
 export * from './createPersistedState';

--- a/apps/docs/src/utils/initialize.js
+++ b/apps/docs/src/utils/initialize.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { createPersistedState } from '.';
 

--- a/apps/docs/src/utils/pageVisitTracker.js
+++ b/apps/docs/src/utils/pageVisitTracker.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const getLocalStorageKey = title =>
   `${title?.toLowerCase().replace(/\s+/g, '-')}-last-visited`;
 

--- a/apps/docs/src/utils/search.js
+++ b/apps/docs/src/utils/search.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as data from '../data';
 import {
   buildStructureIndexes,

--- a/apps/docs/vitest.config.mts
+++ b/apps/docs/vitest.config.mts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
 import { transformWithEsbuild } from 'vite';
 import react from '@vitejs/plugin-react';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- Adds license header text to set of docs files

#### What are the relevant issues?
relates to https://github.com/grommet/hpe-design-system/issues/6360

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>