### PR TITLE
Add SPDX headers: icons

### DIFF
--- a/packages/icons-grommet/.storybook/main.ts
+++ b/packages/icons-grommet/.storybook/main.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {

--- a/packages/icons-grommet/.storybook/preview.tsx
+++ b/packages/icons-grommet/.storybook/preview.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import type { Preview } from '@storybook/react';
 import { Grommet, type ThemeType } from 'grommet';
 import { hpe as theme } from 'grommet-theme-hpe';

--- a/packages/icons-grommet/eslint.config.mjs
+++ b/packages/icons-grommet/eslint.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';

--- a/packages/icons-grommet/src/js/StyledIcon.d.ts
+++ b/packages/icons-grommet/src/js/StyledIcon.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';
 
 export interface StyledIconProps extends SVGProps<SVGSVGElement> {

--- a/packages/icons-grommet/src/js/StyledIcon.jsx
+++ b/packages/icons-grommet/src/js/StyledIcon.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import { styled, css } from 'styled-components';
 

--- a/packages/icons-grommet/src/js/default-props.js
+++ b/packages/icons-grommet/src/js/default-props.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { deepMerge } from './utils';
 import { base } from './themes';
 

--- a/packages/icons-grommet/src/js/icon.stories.tsx
+++ b/packages/icons-grommet/src/js/icon.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import type { Meta, StoryObj } from '@storybook/react';
 import { ThemeProvider } from 'styled-components';
 import { hpe } from 'grommet-theme-hpe';

--- a/packages/icons-grommet/src/js/icons/AIGen.jsx
+++ b/packages/icons-grommet/src/js/icons/AIGen.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/AIGenFill.jsx
+++ b/packages/icons-grommet/src/js/icons/AIGenFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/AISystems.jsx
+++ b/packages/icons-grommet/src/js/icons/AISystems.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Accessibility.jsx
+++ b/packages/icons-grommet/src/js/icons/Accessibility.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Achievement.jsx
+++ b/packages/icons-grommet/src/js/icons/Achievement.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Actions.jsx
+++ b/packages/icons-grommet/src/js/icons/Actions.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Ad.jsx
+++ b/packages/icons-grommet/src/js/icons/Ad.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Add.jsx
+++ b/packages/icons-grommet/src/js/icons/Add.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Aed.jsx
+++ b/packages/icons-grommet/src/js/icons/Aed.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Aggregate.jsx
+++ b/packages/icons-grommet/src/js/icons/Aggregate.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Aid.jsx
+++ b/packages/icons-grommet/src/js/icons/Aid.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Alarm.jsx
+++ b/packages/icons-grommet/src/js/icons/Alarm.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Alert.jsx
+++ b/packages/icons-grommet/src/js/icons/Alert.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Analytics.jsx
+++ b/packages/icons-grommet/src/js/icons/Analytics.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Anchor.jsx
+++ b/packages/icons-grommet/src/js/icons/Anchor.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Announce.jsx
+++ b/packages/icons-grommet/src/js/icons/Announce.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/App.jsx
+++ b/packages/icons-grommet/src/js/icons/App.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Apps.jsx
+++ b/packages/icons-grommet/src/js/icons/Apps.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Archive.jsx
+++ b/packages/icons-grommet/src/js/icons/Archive.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Article.jsx
+++ b/packages/icons-grommet/src/js/icons/Article.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Ascend.jsx
+++ b/packages/icons-grommet/src/js/icons/Ascend.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Ascending.jsx
+++ b/packages/icons-grommet/src/js/icons/Ascending.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/AssistListening.jsx
+++ b/packages/icons-grommet/src/js/icons/AssistListening.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Atm.jsx
+++ b/packages/icons-grommet/src/js/icons/Atm.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Attachment.jsx
+++ b/packages/icons-grommet/src/js/icons/Attachment.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Attraction.jsx
+++ b/packages/icons-grommet/src/js/icons/Attraction.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Baby.jsx
+++ b/packages/icons-grommet/src/js/icons/Baby.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BackTen.jsx
+++ b/packages/icons-grommet/src/js/icons/BackTen.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bar.jsx
+++ b/packages/icons-grommet/src/js/icons/Bar.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Battery.jsx
+++ b/packages/icons-grommet/src/js/icons/Battery.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BatteryEmpty.jsx
+++ b/packages/icons-grommet/src/js/icons/BatteryEmpty.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BatteryFull.jsx
+++ b/packages/icons-grommet/src/js/icons/BatteryFull.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BatteryLow.jsx
+++ b/packages/icons-grommet/src/js/icons/BatteryLow.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Beacon.jsx
+++ b/packages/icons-grommet/src/js/icons/Beacon.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bike.jsx
+++ b/packages/icons-grommet/src/js/icons/Bike.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BladesHorizontal.jsx
+++ b/packages/icons-grommet/src/js/icons/BladesHorizontal.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BladesVertical.jsx
+++ b/packages/icons-grommet/src/js/icons/BladesVertical.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Blank.jsx
+++ b/packages/icons-grommet/src/js/icons/Blank.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Blog.jsx
+++ b/packages/icons-grommet/src/js/icons/Blog.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bluetooth.jsx
+++ b/packages/icons-grommet/src/js/icons/Bluetooth.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Book.jsx
+++ b/packages/icons-grommet/src/js/icons/Book.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bookmark.jsx
+++ b/packages/icons-grommet/src/js/icons/Bookmark.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Braille.jsx
+++ b/packages/icons-grommet/src/js/icons/Braille.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Briefcase.jsx
+++ b/packages/icons-grommet/src/js/icons/Briefcase.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Brush.jsx
+++ b/packages/icons-grommet/src/js/icons/Brush.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bucket.jsx
+++ b/packages/icons-grommet/src/js/icons/Bucket.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bug.jsx
+++ b/packages/icons-grommet/src/js/icons/Bug.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bulb.jsx
+++ b/packages/icons-grommet/src/js/icons/Bulb.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bundle.jsx
+++ b/packages/icons-grommet/src/js/icons/Bundle.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Bus.jsx
+++ b/packages/icons-grommet/src/js/icons/Bus.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/BusinessService.jsx
+++ b/packages/icons-grommet/src/js/icons/BusinessService.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cafeteria.jsx
+++ b/packages/icons-grommet/src/js/icons/Cafeteria.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Calculator.jsx
+++ b/packages/icons-grommet/src/js/icons/Calculator.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Calendar.jsx
+++ b/packages/icons-grommet/src/js/icons/Calendar.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Camera.jsx
+++ b/packages/icons-grommet/src/js/icons/Camera.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Car.jsx
+++ b/packages/icons-grommet/src/js/icons/Car.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CaretDown.jsx
+++ b/packages/icons-grommet/src/js/icons/CaretDown.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CaretLeft.jsx
+++ b/packages/icons-grommet/src/js/icons/CaretLeft.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CaretRight.jsx
+++ b/packages/icons-grommet/src/js/icons/CaretRight.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CaretUp.jsx
+++ b/packages/icons-grommet/src/js/icons/CaretUp.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cart.jsx
+++ b/packages/icons-grommet/src/js/icons/Cart.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Catalog.jsx
+++ b/packages/icons-grommet/src/js/icons/Catalog.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Certificate.jsx
+++ b/packages/icons-grommet/src/js/icons/Certificate.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Channel.jsx
+++ b/packages/icons-grommet/src/js/icons/Channel.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChapterAdd.jsx
+++ b/packages/icons-grommet/src/js/icons/ChapterAdd.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChapterNext.jsx
+++ b/packages/icons-grommet/src/js/icons/ChapterNext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChapterPrevious.jsx
+++ b/packages/icons-grommet/src/js/icons/ChapterPrevious.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChartBar.jsx
+++ b/packages/icons-grommet/src/js/icons/ChartBar.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChartLine.jsx
+++ b/packages/icons-grommet/src/js/icons/ChartLine.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChartPie.jsx
+++ b/packages/icons-grommet/src/js/icons/ChartPie.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Chat.jsx
+++ b/packages/icons-grommet/src/js/icons/Chat.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ChatConversation.jsx
+++ b/packages/icons-grommet/src/js/icons/ChatConversation.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Checkmark.jsx
+++ b/packages/icons-grommet/src/js/icons/Checkmark.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CircleEmpty.jsx
+++ b/packages/icons-grommet/src/js/icons/CircleEmpty.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CircleFill.jsx
+++ b/packages/icons-grommet/src/js/icons/CircleFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Clear.jsx
+++ b/packages/icons-grommet/src/js/icons/Clear.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Clipboard.jsx
+++ b/packages/icons-grommet/src/js/icons/Clipboard.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Clock.jsx
+++ b/packages/icons-grommet/src/js/icons/Clock.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Clone.jsx
+++ b/packages/icons-grommet/src/js/icons/Clone.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Close.jsx
+++ b/packages/icons-grommet/src/js/icons/Close.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ClosedCaption.jsx
+++ b/packages/icons-grommet/src/js/icons/ClosedCaption.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cloud.jsx
+++ b/packages/icons-grommet/src/js/icons/Cloud.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudAdd.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudAdd.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudComputer.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudComputer.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudDownload.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudDownload.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudLocked.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudLocked.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudOffline.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudOffline.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudSoftware.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudSoftware.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CloudUpload.jsx
+++ b/packages/icons-grommet/src/js/icons/CloudUpload.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cluster.jsx
+++ b/packages/icons-grommet/src/js/icons/Cluster.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CoatCheck.jsx
+++ b/packages/icons-grommet/src/js/icons/CoatCheck.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Code.jsx
+++ b/packages/icons-grommet/src/js/icons/Code.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Coffee.jsx
+++ b/packages/icons-grommet/src/js/icons/Coffee.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Columns.jsx
+++ b/packages/icons-grommet/src/js/icons/Columns.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Command.jsx
+++ b/packages/icons-grommet/src/js/icons/Command.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Compare.jsx
+++ b/packages/icons-grommet/src/js/icons/Compare.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Compass.jsx
+++ b/packages/icons-grommet/src/js/icons/Compass.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Compliance.jsx
+++ b/packages/icons-grommet/src/js/icons/Compliance.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Configure.jsx
+++ b/packages/icons-grommet/src/js/icons/Configure.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Connect.jsx
+++ b/packages/icons-grommet/src/js/icons/Connect.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Connectivity.jsx
+++ b/packages/icons-grommet/src/js/icons/Connectivity.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Console.jsx
+++ b/packages/icons-grommet/src/js/icons/Console.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Contact.jsx
+++ b/packages/icons-grommet/src/js/icons/Contact.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Contract.jsx
+++ b/packages/icons-grommet/src/js/icons/Contract.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Copy.jsx
+++ b/packages/icons-grommet/src/js/icons/Copy.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cpu.jsx
+++ b/packages/icons-grommet/src/js/icons/Cpu.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/CreditCard.jsx
+++ b/packages/icons-grommet/src/js/icons/CreditCard.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cube.jsx
+++ b/packages/icons-grommet/src/js/icons/Cube.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cubes.jsx
+++ b/packages/icons-grommet/src/js/icons/Cubes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Currency.jsx
+++ b/packages/icons-grommet/src/js/icons/Currency.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cursor.jsx
+++ b/packages/icons-grommet/src/js/icons/Cursor.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cut.jsx
+++ b/packages/icons-grommet/src/js/icons/Cut.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Cycle.jsx
+++ b/packages/icons-grommet/src/js/icons/Cycle.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Dashboard.jsx
+++ b/packages/icons-grommet/src/js/icons/Dashboard.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Database.jsx
+++ b/packages/icons-grommet/src/js/icons/Database.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Deliver.jsx
+++ b/packages/icons-grommet/src/js/icons/Deliver.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Deploy.jsx
+++ b/packages/icons-grommet/src/js/icons/Deploy.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Descend.jsx
+++ b/packages/icons-grommet/src/js/icons/Descend.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Descending.jsx
+++ b/packages/icons-grommet/src/js/icons/Descending.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Desktop.jsx
+++ b/packages/icons-grommet/src/js/icons/Desktop.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Detach.jsx
+++ b/packages/icons-grommet/src/js/icons/Detach.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Device.jsx
+++ b/packages/icons-grommet/src/js/icons/Device.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Dial.jsx
+++ b/packages/icons-grommet/src/js/icons/Dial.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Diamond.jsx
+++ b/packages/icons-grommet/src/js/icons/Diamond.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Directions.jsx
+++ b/packages/icons-grommet/src/js/icons/Directions.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Disc.jsx
+++ b/packages/icons-grommet/src/js/icons/Disc.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Dislike.jsx
+++ b/packages/icons-grommet/src/js/icons/Dislike.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DislikeFill.jsx
+++ b/packages/icons-grommet/src/js/icons/DislikeFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Document.jsx
+++ b/packages/icons-grommet/src/js/icons/Document.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentCloud.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentCloud.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentConfig.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentConfig.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentCsv.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentCsv.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentDownload.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentDownload.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentExcel.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentExcel.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentImage.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentImage.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentLocked.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentLocked.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentMissing.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentMissing.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentNotes.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentNotes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentOutlook.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentOutlook.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentPdf.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentPdf.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentPerformance.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentPerformance.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentPpt.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentPpt.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentRtf.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentRtf.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentSound.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentSound.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentStore.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentStore.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentTest.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentTest.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentText.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentText.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentThreat.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentThreat.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentTime.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentTime.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentTransfer.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentTransfer.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentTxt.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentTxt.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentUpdate.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentUpdate.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentUpload.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentUpload.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentUser.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentUser.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentVerified.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentVerified.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentVideo.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentVideo.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentWarning.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentWarning.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentWindows.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentWindows.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentWord.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentWord.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DocumentZip.jsx
+++ b/packages/icons-grommet/src/js/icons/DocumentZip.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Domain.jsx
+++ b/packages/icons-grommet/src/js/icons/Domain.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Down.jsx
+++ b/packages/icons-grommet/src/js/icons/Down.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Download.jsx
+++ b/packages/icons-grommet/src/js/icons/Download.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Drag.jsx
+++ b/packages/icons-grommet/src/js/icons/Drag.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/DriveCage.jsx
+++ b/packages/icons-grommet/src/js/icons/DriveCage.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Duplicate.jsx
+++ b/packages/icons-grommet/src/js/icons/Duplicate.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Edit.jsx
+++ b/packages/icons-grommet/src/js/icons/Edit.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Eject.jsx
+++ b/packages/icons-grommet/src/js/icons/Eject.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Element.jsx
+++ b/packages/icons-grommet/src/js/icons/Element.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Elevator.jsx
+++ b/packages/icons-grommet/src/js/icons/Elevator.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Emergency.jsx
+++ b/packages/icons-grommet/src/js/icons/Emergency.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/EmergencyFill.jsx
+++ b/packages/icons-grommet/src/js/icons/EmergencyFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Erase.jsx
+++ b/packages/icons-grommet/src/js/icons/Erase.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Escalator.jsx
+++ b/packages/icons-grommet/src/js/icons/Escalator.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Expand.jsx
+++ b/packages/icons-grommet/src/js/icons/Expand.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Fan.jsx
+++ b/packages/icons-grommet/src/js/icons/Fan.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FastForward.jsx
+++ b/packages/icons-grommet/src/js/icons/FastForward.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Favorite.jsx
+++ b/packages/icons-grommet/src/js/icons/Favorite.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Filter.jsx
+++ b/packages/icons-grommet/src/js/icons/Filter.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FingerPrint.jsx
+++ b/packages/icons-grommet/src/js/icons/FingerPrint.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Firewall.jsx
+++ b/packages/icons-grommet/src/js/icons/Firewall.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FiveG.jsx
+++ b/packages/icons-grommet/src/js/icons/FiveG.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Flag.jsx
+++ b/packages/icons-grommet/src/js/icons/Flag.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Flows.jsx
+++ b/packages/icons-grommet/src/js/icons/Flows.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Focus.jsx
+++ b/packages/icons-grommet/src/js/icons/Focus.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Folder.jsx
+++ b/packages/icons-grommet/src/js/icons/Folder.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FolderAdd.jsx
+++ b/packages/icons-grommet/src/js/icons/FolderAdd.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FolderCycle.jsx
+++ b/packages/icons-grommet/src/js/icons/FolderCycle.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FolderOpen.jsx
+++ b/packages/icons-grommet/src/js/icons/FolderOpen.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/FolderSearch.jsx
+++ b/packages/icons-grommet/src/js/icons/FolderSearch.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ForwardTen.jsx
+++ b/packages/icons-grommet/src/js/icons/ForwardTen.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Gallery.jsx
+++ b/packages/icons-grommet/src/js/icons/Gallery.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Gamepad.jsx
+++ b/packages/icons-grommet/src/js/icons/Gamepad.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Gateway.jsx
+++ b/packages/icons-grommet/src/js/icons/Gateway.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Gem.jsx
+++ b/packages/icons-grommet/src/js/icons/Gem.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Gift.jsx
+++ b/packages/icons-grommet/src/js/icons/Gift.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Globe.jsx
+++ b/packages/icons-grommet/src/js/icons/Globe.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Gpu.jsx
+++ b/packages/icons-grommet/src/js/icons/Gpu.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Grid.jsx
+++ b/packages/icons-grommet/src/js/icons/Grid.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Group.jsx
+++ b/packages/icons-grommet/src/js/icons/Group.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Grow.jsx
+++ b/packages/icons-grommet/src/js/icons/Grow.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Halt.jsx
+++ b/packages/icons-grommet/src/js/icons/Halt.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Help.jsx
+++ b/packages/icons-grommet/src/js/icons/Help.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/HelpBook.jsx
+++ b/packages/icons-grommet/src/js/icons/HelpBook.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Hide.jsx
+++ b/packages/icons-grommet/src/js/icons/Hide.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/History.jsx
+++ b/packages/icons-grommet/src/js/icons/History.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Home.jsx
+++ b/packages/icons-grommet/src/js/icons/Home.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Host.jsx
+++ b/packages/icons-grommet/src/js/icons/Host.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/HostMaintenance.jsx
+++ b/packages/icons-grommet/src/js/icons/HostMaintenance.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/IceCream.jsx
+++ b/packages/icons-grommet/src/js/icons/IceCream.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Image.jsx
+++ b/packages/icons-grommet/src/js/icons/Image.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Impact.jsx
+++ b/packages/icons-grommet/src/js/icons/Impact.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/InProgress.jsx
+++ b/packages/icons-grommet/src/js/icons/InProgress.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Inbox.jsx
+++ b/packages/icons-grommet/src/js/icons/Inbox.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Info.jsx
+++ b/packages/icons-grommet/src/js/icons/Info.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Inherit.jsx
+++ b/packages/icons-grommet/src/js/icons/Inherit.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Insecure.jsx
+++ b/packages/icons-grommet/src/js/icons/Insecure.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Inspect.jsx
+++ b/packages/icons-grommet/src/js/icons/Inspect.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Install.jsx
+++ b/packages/icons-grommet/src/js/icons/Install.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Integration.jsx
+++ b/packages/icons-grommet/src/js/icons/Integration.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Iteration.jsx
+++ b/packages/icons-grommet/src/js/icons/Iteration.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Key.jsx
+++ b/packages/icons-grommet/src/js/icons/Key.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Keyboard.jsx
+++ b/packages/icons-grommet/src/js/icons/Keyboard.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Language.jsx
+++ b/packages/icons-grommet/src/js/icons/Language.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Layer.jsx
+++ b/packages/icons-grommet/src/js/icons/Layer.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Left.jsx
+++ b/packages/icons-grommet/src/js/icons/Left.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Like.jsx
+++ b/packages/icons-grommet/src/js/icons/Like.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/LikeFill.jsx
+++ b/packages/icons-grommet/src/js/icons/LikeFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Link.jsx
+++ b/packages/icons-grommet/src/js/icons/Link.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/LinkBottom.jsx
+++ b/packages/icons-grommet/src/js/icons/LinkBottom.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/LinkNext.jsx
+++ b/packages/icons-grommet/src/js/icons/LinkNext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/LinkPrev.jsx
+++ b/packages/icons-grommet/src/js/icons/LinkPrev.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/LinkTop.jsx
+++ b/packages/icons-grommet/src/js/icons/LinkTop.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/List.jsx
+++ b/packages/icons-grommet/src/js/icons/List.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ListOrdered.jsx
+++ b/packages/icons-grommet/src/js/icons/ListOrdered.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ListUnordered.jsx
+++ b/packages/icons-grommet/src/js/icons/ListUnordered.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Local.jsx
+++ b/packages/icons-grommet/src/js/icons/Local.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Location.jsx
+++ b/packages/icons-grommet/src/js/icons/Location.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/LocationPin.jsx
+++ b/packages/icons-grommet/src/js/icons/LocationPin.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Lock.jsx
+++ b/packages/icons-grommet/src/js/icons/Lock.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Lodging.jsx
+++ b/packages/icons-grommet/src/js/icons/Lodging.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Login.jsx
+++ b/packages/icons-grommet/src/js/icons/Login.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Logout.jsx
+++ b/packages/icons-grommet/src/js/icons/Logout.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Lounge.jsx
+++ b/packages/icons-grommet/src/js/icons/Lounge.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Magic.jsx
+++ b/packages/icons-grommet/src/js/icons/Magic.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Mail.jsx
+++ b/packages/icons-grommet/src/js/icons/Mail.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Manual.jsx
+++ b/packages/icons-grommet/src/js/icons/Manual.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Map.jsx
+++ b/packages/icons-grommet/src/js/icons/Map.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/MapAdd.jsx
+++ b/packages/icons-grommet/src/js/icons/MapAdd.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Meeting.jsx
+++ b/packages/icons-grommet/src/js/icons/Meeting.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Memory.jsx
+++ b/packages/icons-grommet/src/js/icons/Memory.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Menu.jsx
+++ b/packages/icons-grommet/src/js/icons/Menu.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Microphone.jsx
+++ b/packages/icons-grommet/src/js/icons/Microphone.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Mode.jsx
+++ b/packages/icons-grommet/src/js/icons/Mode.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Money.jsx
+++ b/packages/icons-grommet/src/js/icons/Money.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Monitor.jsx
+++ b/packages/icons-grommet/src/js/icons/Monitor.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Moon.jsx
+++ b/packages/icons-grommet/src/js/icons/Moon.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/More.jsx
+++ b/packages/icons-grommet/src/js/icons/More.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/MoreVertical.jsx
+++ b/packages/icons-grommet/src/js/icons/MoreVertical.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Mouse.jsx
+++ b/packages/icons-grommet/src/js/icons/Mouse.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Multimedia.jsx
+++ b/packages/icons-grommet/src/js/icons/Multimedia.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Multiple.jsx
+++ b/packages/icons-grommet/src/js/icons/Multiple.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Music.jsx
+++ b/packages/icons-grommet/src/js/icons/Music.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Navigate.jsx
+++ b/packages/icons-grommet/src/js/icons/Navigate.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Network.jsx
+++ b/packages/icons-grommet/src/js/icons/Network.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/NetworkDrive.jsx
+++ b/packages/icons-grommet/src/js/icons/NetworkDrive.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/NetworkSwitch.jsx
+++ b/packages/icons-grommet/src/js/icons/NetworkSwitch.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/New.jsx
+++ b/packages/icons-grommet/src/js/icons/New.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/NewWindow.jsx
+++ b/packages/icons-grommet/src/js/icons/NewWindow.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Nodes.jsx
+++ b/packages/icons-grommet/src/js/icons/Nodes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Note.jsx
+++ b/packages/icons-grommet/src/js/icons/Note.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Notes.jsx
+++ b/packages/icons-grommet/src/js/icons/Notes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Notification.jsx
+++ b/packages/icons-grommet/src/js/icons/Notification.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ObjectGroup.jsx
+++ b/packages/icons-grommet/src/js/icons/ObjectGroup.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ObjectUngroup.jsx
+++ b/packages/icons-grommet/src/js/icons/ObjectUngroup.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/OfflineStorage.jsx
+++ b/packages/icons-grommet/src/js/icons/OfflineStorage.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Optimize.jsx
+++ b/packages/icons-grommet/src/js/icons/Optimize.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Organization.jsx
+++ b/packages/icons-grommet/src/js/icons/Organization.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Overview.jsx
+++ b/packages/icons-grommet/src/js/icons/Overview.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Package.jsx
+++ b/packages/icons-grommet/src/js/icons/Package.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Paint.jsx
+++ b/packages/icons-grommet/src/js/icons/Paint.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Pan.jsx
+++ b/packages/icons-grommet/src/js/icons/Pan.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Pause.jsx
+++ b/packages/icons-grommet/src/js/icons/Pause.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PauseFill.jsx
+++ b/packages/icons-grommet/src/js/icons/PauseFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Performance.jsx
+++ b/packages/icons-grommet/src/js/icons/Performance.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PersonalComputer.jsx
+++ b/packages/icons-grommet/src/js/icons/PersonalComputer.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Phone.jsx
+++ b/packages/icons-grommet/src/js/icons/Phone.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PhoneFlip.jsx
+++ b/packages/icons-grommet/src/js/icons/PhoneFlip.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PhoneHorizontal.jsx
+++ b/packages/icons-grommet/src/js/icons/PhoneHorizontal.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PhoneVertical.jsx
+++ b/packages/icons-grommet/src/js/icons/PhoneVertical.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Pin.jsx
+++ b/packages/icons-grommet/src/js/icons/Pin.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Play.jsx
+++ b/packages/icons-grommet/src/js/icons/Play.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PlayFill.jsx
+++ b/packages/icons-grommet/src/js/icons/PlayFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Power.jsx
+++ b/packages/icons-grommet/src/js/icons/Power.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PowerCycle.jsx
+++ b/packages/icons-grommet/src/js/icons/PowerCycle.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PowerForceShutdown.jsx
+++ b/packages/icons-grommet/src/js/icons/PowerForceShutdown.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/PowerReset.jsx
+++ b/packages/icons-grommet/src/js/icons/PowerReset.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Print.jsx
+++ b/packages/icons-grommet/src/js/icons/Print.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Progress.jsx
+++ b/packages/icons-grommet/src/js/icons/Progress.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Projects.jsx
+++ b/packages/icons-grommet/src/js/icons/Projects.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Qr.jsx
+++ b/packages/icons-grommet/src/js/icons/Qr.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Redo.jsx
+++ b/packages/icons-grommet/src/js/icons/Redo.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Refresh.jsx
+++ b/packages/icons-grommet/src/js/icons/Refresh.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Resources.jsx
+++ b/packages/icons-grommet/src/js/icons/Resources.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Restaurant.jsx
+++ b/packages/icons-grommet/src/js/icons/Restaurant.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Restroom.jsx
+++ b/packages/icons-grommet/src/js/icons/Restroom.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/RestroomMen.jsx
+++ b/packages/icons-grommet/src/js/icons/RestroomMen.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/RestroomUnisex.jsx
+++ b/packages/icons-grommet/src/js/icons/RestroomUnisex.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/RestroomWomen.jsx
+++ b/packages/icons-grommet/src/js/icons/RestroomWomen.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Resume.jsx
+++ b/packages/icons-grommet/src/js/icons/Resume.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Return.jsx
+++ b/packages/icons-grommet/src/js/icons/Return.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Revert.jsx
+++ b/packages/icons-grommet/src/js/icons/Revert.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Rewind.jsx
+++ b/packages/icons-grommet/src/js/icons/Rewind.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Right.jsx
+++ b/packages/icons-grommet/src/js/icons/Right.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Risk.jsx
+++ b/packages/icons-grommet/src/js/icons/Risk.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Robot.jsx
+++ b/packages/icons-grommet/src/js/icons/Robot.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/RotateLeft.jsx
+++ b/packages/icons-grommet/src/js/icons/RotateLeft.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/RotateRight.jsx
+++ b/packages/icons-grommet/src/js/icons/RotateRight.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Rss.jsx
+++ b/packages/icons-grommet/src/js/icons/Rss.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Run.jsx
+++ b/packages/icons-grommet/src/js/icons/Run.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/SD.jsx
+++ b/packages/icons-grommet/src/js/icons/SD.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Sans.jsx
+++ b/packages/icons-grommet/src/js/icons/Sans.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Satellite.jsx
+++ b/packages/icons-grommet/src/js/icons/Satellite.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Save.jsx
+++ b/packages/icons-grommet/src/js/icons/Save.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Scan.jsx
+++ b/packages/icons-grommet/src/js/icons/Scan.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Scorecard.jsx
+++ b/packages/icons-grommet/src/js/icons/Scorecard.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Script.jsx
+++ b/packages/icons-grommet/src/js/icons/Script.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Search.jsx
+++ b/packages/icons-grommet/src/js/icons/Search.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/SearchAdvanced.jsx
+++ b/packages/icons-grommet/src/js/icons/SearchAdvanced.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Secure.jsx
+++ b/packages/icons-grommet/src/js/icons/Secure.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Select.jsx
+++ b/packages/icons-grommet/src/js/icons/Select.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Selection.jsx
+++ b/packages/icons-grommet/src/js/icons/Selection.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Semantics.jsx
+++ b/packages/icons-grommet/src/js/icons/Semantics.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Send.jsx
+++ b/packages/icons-grommet/src/js/icons/Send.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Sensor.jsx
+++ b/packages/icons-grommet/src/js/icons/Sensor.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/SensorLocked.jsx
+++ b/packages/icons-grommet/src/js/icons/SensorLocked.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/SensorOff.jsx
+++ b/packages/icons-grommet/src/js/icons/SensorOff.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Server.jsx
+++ b/packages/icons-grommet/src/js/icons/Server.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ServerCluster.jsx
+++ b/packages/icons-grommet/src/js/icons/ServerCluster.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Servers.jsx
+++ b/packages/icons-grommet/src/js/icons/Servers.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ServicePlay.jsx
+++ b/packages/icons-grommet/src/js/icons/ServicePlay.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Services.jsx
+++ b/packages/icons-grommet/src/js/icons/Services.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Settings.jsx
+++ b/packages/icons-grommet/src/js/icons/Settings.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Share.jsx
+++ b/packages/icons-grommet/src/js/icons/Share.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Shield.jsx
+++ b/packages/icons-grommet/src/js/icons/Shield.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ShieldCheck.jsx
+++ b/packages/icons-grommet/src/js/icons/ShieldCheck.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ShieldEmergency.jsx
+++ b/packages/icons-grommet/src/js/icons/ShieldEmergency.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ShieldSecurity.jsx
+++ b/packages/icons-grommet/src/js/icons/ShieldSecurity.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ShieldUnsecure.jsx
+++ b/packages/icons-grommet/src/js/icons/ShieldUnsecure.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Shift.jsx
+++ b/packages/icons-grommet/src/js/icons/Shift.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Shop.jsx
+++ b/packages/icons-grommet/src/js/icons/Shop.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Sidebar.jsx
+++ b/packages/icons-grommet/src/js/icons/Sidebar.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Sign.jsx
+++ b/packages/icons-grommet/src/js/icons/Sign.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Spa.jsx
+++ b/packages/icons-grommet/src/js/icons/Spa.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Split.jsx
+++ b/packages/icons-grommet/src/js/icons/Split.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Splits.jsx
+++ b/packages/icons-grommet/src/js/icons/Splits.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Stakeholder.jsx
+++ b/packages/icons-grommet/src/js/icons/Stakeholder.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Star.jsx
+++ b/packages/icons-grommet/src/js/icons/Star.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StarFill.jsx
+++ b/packages/icons-grommet/src/js/icons/StarFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StarHalf.jsx
+++ b/packages/icons-grommet/src/js/icons/StarHalf.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StarHalfFill.jsx
+++ b/packages/icons-grommet/src/js/icons/StarHalfFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StatusCritical.jsx
+++ b/packages/icons-grommet/src/js/icons/StatusCritical.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StatusDisabled.jsx
+++ b/packages/icons-grommet/src/js/icons/StatusDisabled.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StatusGood.jsx
+++ b/packages/icons-grommet/src/js/icons/StatusGood.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StatusInfo.jsx
+++ b/packages/icons-grommet/src/js/icons/StatusInfo.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StatusUnknown.jsx
+++ b/packages/icons-grommet/src/js/icons/StatusUnknown.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StatusWarning.jsx
+++ b/packages/icons-grommet/src/js/icons/StatusWarning.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Steps.jsx
+++ b/packages/icons-grommet/src/js/icons/Steps.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Stop.jsx
+++ b/packages/icons-grommet/src/js/icons/Stop.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StopFill.jsx
+++ b/packages/icons-grommet/src/js/icons/StopFill.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Storage.jsx
+++ b/packages/icons-grommet/src/js/icons/Storage.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/StreetView.jsx
+++ b/packages/icons-grommet/src/js/icons/StreetView.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Subtract.jsx
+++ b/packages/icons-grommet/src/js/icons/Subtract.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Sun.jsx
+++ b/packages/icons-grommet/src/js/icons/Sun.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Support.jsx
+++ b/packages/icons-grommet/src/js/icons/Support.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Swim.jsx
+++ b/packages/icons-grommet/src/js/icons/Swim.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Switch.jsx
+++ b/packages/icons-grommet/src/js/icons/Switch.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Sync.jsx
+++ b/packages/icons-grommet/src/js/icons/Sync.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/System.jsx
+++ b/packages/icons-grommet/src/js/icons/System.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Table.jsx
+++ b/packages/icons-grommet/src/js/icons/Table.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/TableAdd.jsx
+++ b/packages/icons-grommet/src/js/icons/TableAdd.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/TableAddColumn.jsx
+++ b/packages/icons-grommet/src/js/icons/TableAddColumn.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/TableSearch.jsx
+++ b/packages/icons-grommet/src/js/icons/TableSearch.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Tag.jsx
+++ b/packages/icons-grommet/src/js/icons/Tag.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Tape.jsx
+++ b/packages/icons-grommet/src/js/icons/Tape.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Target.jsx
+++ b/packages/icons-grommet/src/js/icons/Target.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Task.jsx
+++ b/packages/icons-grommet/src/js/icons/Task.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Technology.jsx
+++ b/packages/icons-grommet/src/js/icons/Technology.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Temperature.jsx
+++ b/packages/icons-grommet/src/js/icons/Temperature.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Template.jsx
+++ b/packages/icons-grommet/src/js/icons/Template.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Test.jsx
+++ b/packages/icons-grommet/src/js/icons/Test.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/TestDesktop.jsx
+++ b/packages/icons-grommet/src/js/icons/TestDesktop.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/TextWrap.jsx
+++ b/packages/icons-grommet/src/js/icons/TextWrap.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Theme.jsx
+++ b/packages/icons-grommet/src/js/icons/Theme.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Threats.jsx
+++ b/packages/icons-grommet/src/js/icons/Threats.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ThreeD.jsx
+++ b/packages/icons-grommet/src/js/icons/ThreeD.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ThreeDffects.jsx
+++ b/packages/icons-grommet/src/js/icons/ThreeDffects.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Ticket.jsx
+++ b/packages/icons-grommet/src/js/icons/Ticket.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Time.jsx
+++ b/packages/icons-grommet/src/js/icons/Time.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Tools.jsx
+++ b/packages/icons-grommet/src/js/icons/Tools.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Tooltip.jsx
+++ b/packages/icons-grommet/src/js/icons/Tooltip.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Train.jsx
+++ b/packages/icons-grommet/src/js/icons/Train.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Transaction.jsx
+++ b/packages/icons-grommet/src/js/icons/Transaction.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Trash.jsx
+++ b/packages/icons-grommet/src/js/icons/Trash.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Tree.jsx
+++ b/packages/icons-grommet/src/js/icons/Tree.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/TreeNode.jsx
+++ b/packages/icons-grommet/src/js/icons/TreeNode.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Trigger.jsx
+++ b/packages/icons-grommet/src/js/icons/Trigger.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Trophy.jsx
+++ b/packages/icons-grommet/src/js/icons/Trophy.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Tty.jsx
+++ b/packages/icons-grommet/src/js/icons/Tty.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Undo.jsx
+++ b/packages/icons-grommet/src/js/icons/Undo.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Unlink.jsx
+++ b/packages/icons-grommet/src/js/icons/Unlink.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Unlock.jsx
+++ b/packages/icons-grommet/src/js/icons/Unlock.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Unsorted.jsx
+++ b/packages/icons-grommet/src/js/icons/Unsorted.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Up.jsx
+++ b/packages/icons-grommet/src/js/icons/Up.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Update.jsx
+++ b/packages/icons-grommet/src/js/icons/Update.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Upgrade.jsx
+++ b/packages/icons-grommet/src/js/icons/Upgrade.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Upload.jsx
+++ b/packages/icons-grommet/src/js/icons/Upload.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UsbKey.jsx
+++ b/packages/icons-grommet/src/js/icons/UsbKey.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/User.jsx
+++ b/packages/icons-grommet/src/js/icons/User.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserAdd.jsx
+++ b/packages/icons-grommet/src/js/icons/UserAdd.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserAdmin.jsx
+++ b/packages/icons-grommet/src/js/icons/UserAdmin.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserExpert.jsx
+++ b/packages/icons-grommet/src/js/icons/UserExpert.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserFemale.jsx
+++ b/packages/icons-grommet/src/js/icons/UserFemale.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserManager.jsx
+++ b/packages/icons-grommet/src/js/icons/UserManager.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserNew.jsx
+++ b/packages/icons-grommet/src/js/icons/UserNew.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserPolice.jsx
+++ b/packages/icons-grommet/src/js/icons/UserPolice.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserSettings.jsx
+++ b/packages/icons-grommet/src/js/icons/UserSettings.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/UserWorker.jsx
+++ b/packages/icons-grommet/src/js/icons/UserWorker.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/VMMaintenance.jsx
+++ b/packages/icons-grommet/src/js/icons/VMMaintenance.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Validate.jsx
+++ b/packages/icons-grommet/src/js/icons/Validate.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Vend.jsx
+++ b/packages/icons-grommet/src/js/icons/Vend.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Video.jsx
+++ b/packages/icons-grommet/src/js/icons/Video.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/View.jsx
+++ b/packages/icons-grommet/src/js/icons/View.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/VirtualMachine.jsx
+++ b/packages/icons-grommet/src/js/icons/VirtualMachine.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/VirtualStorage.jsx
+++ b/packages/icons-grommet/src/js/icons/VirtualStorage.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Volume.jsx
+++ b/packages/icons-grommet/src/js/icons/Volume.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/VolumeLow.jsx
+++ b/packages/icons-grommet/src/js/icons/VolumeLow.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/VolumeMute.jsx
+++ b/packages/icons-grommet/src/js/icons/VolumeMute.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Vulnerability.jsx
+++ b/packages/icons-grommet/src/js/icons/Vulnerability.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Waypoint.jsx
+++ b/packages/icons-grommet/src/js/icons/Waypoint.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Webcam.jsx
+++ b/packages/icons-grommet/src/js/icons/Webcam.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Wheelchair.jsx
+++ b/packages/icons-grommet/src/js/icons/Wheelchair.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/WheelchairActive.jsx
+++ b/packages/icons-grommet/src/js/icons/WheelchairActive.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Wifi.jsx
+++ b/packages/icons-grommet/src/js/icons/Wifi.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/WifiLocked.jsx
+++ b/packages/icons-grommet/src/js/icons/WifiLocked.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/WifiLow.jsx
+++ b/packages/icons-grommet/src/js/icons/WifiLow.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/WifiMedium.jsx
+++ b/packages/icons-grommet/src/js/icons/WifiMedium.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/WifiNone.jsx
+++ b/packages/icons-grommet/src/js/icons/WifiNone.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/WifiOff.jsx
+++ b/packages/icons-grommet/src/js/icons/WifiOff.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Workshop.jsx
+++ b/packages/icons-grommet/src/js/icons/Workshop.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/Yoga.jsx
+++ b/packages/icons-grommet/src/js/icons/Yoga.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ZoomIn.jsx
+++ b/packages/icons-grommet/src/js/icons/ZoomIn.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/ZoomOut.jsx
+++ b/packages/icons-grommet/src/js/icons/ZoomOut.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 
 import { StyledIcon } from '../StyledIcon';

--- a/packages/icons-grommet/src/js/icons/index.d.ts
+++ b/packages/icons-grommet/src/js/icons/index.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
 export interface IconProps {

--- a/packages/icons-grommet/src/js/icons/index.js
+++ b/packages/icons-grommet/src/js/icons/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AIGenFill';
 export * from './AIGen';
 export * from './AISystems';

--- a/packages/icons-grommet/src/js/index.ts
+++ b/packages/icons-grommet/src/js/index.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 export * from './icons';

--- a/packages/icons-grommet/src/js/metadata.ts
+++ b/packages/icons-grommet/src/js/metadata.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export default {
   Accessibility: [
     'body',

--- a/packages/icons-grommet/src/js/themes/base.ts
+++ b/packages/icons-grommet/src/js/themes/base.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 type IconColorType =
   | string
   | {

--- a/packages/icons-grommet/src/js/themes/index.ts
+++ b/packages/icons-grommet/src/js/themes/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { base } from './base';

--- a/packages/icons-grommet/src/js/utils.ts
+++ b/packages/icons-grommet/src/js/utils.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 

--- a/packages/icons-grommet/vite.config.ts
+++ b/packages/icons-grommet/vite.config.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- Adds license header text to set of icon files

#### What are the relevant issues?
relates to https://github.com/grommet/hpe-design-system/issues/6360

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>