### PR TITLE
Add SPDX headers: remaining files

### DIFF
--- a/apps/design-tokens-manager/eslint.config.mjs
+++ b/apps/design-tokens-manager/eslint.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';

--- a/apps/design-tokens-manager/src/App.jsx
+++ b/apps/design-tokens-manager/src/App.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import { Box, Button, Grid, Grommet, Nav } from 'grommet';

--- a/apps/design-tokens-manager/src/build-token-tree.js
+++ b/apps/design-tokens-manager/src/build-token-tree.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const buildTokenTree = tokens => {
   const tree = {};
 

--- a/apps/design-tokens-manager/src/components/ContentPane.jsx
+++ b/apps/design-tokens-manager/src/components/ContentPane.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Header, Heading } from 'grommet';
 

--- a/apps/design-tokens-manager/src/components/CopyButton.jsx
+++ b/apps/design-tokens-manager/src/components/CopyButton.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Button } from 'grommet';
 import { Copy } from '@hpe-design/icons-grommet';

--- a/apps/design-tokens-manager/src/components/EmptyState.jsx
+++ b/apps/design-tokens-manager/src/components/EmptyState.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Paragraph } from 'grommet';

--- a/apps/design-tokens-manager/src/components/Header.tsx
+++ b/apps/design-tokens-manager/src/components/Header.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Link } from 'react-router-dom';
 import { Header as GrommetHeader, Button, Box, Text } from 'grommet';
 import { Element, Moon, Sun } from '@hpe-design/icons-grommet';

--- a/apps/design-tokens-manager/src/components/index.js
+++ b/apps/design-tokens-manager/src/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContentPane';
 export * from './CopyButton';
 export * from './Header';

--- a/apps/design-tokens-manager/src/components/utils/animations.js
+++ b/apps/design-tokens-manager/src/components/utils/animations.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 const skeletonAnimation = [];
 
 for (let index = 0; index < 20; index += 1) {

--- a/apps/design-tokens-manager/src/main.jsx
+++ b/apps/design-tokens-manager/src/main.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';

--- a/apps/design-tokens-manager/src/routes/Builder.jsx
+++ b/apps/design-tokens-manager/src/routes/Builder.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/apps/design-tokens-manager/src/routes/Docs.jsx
+++ b/apps/design-tokens-manager/src/routes/Docs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import {
   Toolbar,

--- a/apps/design-tokens-manager/src/routes/Scaler/ControlPane.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/ControlPane.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import {
   Box,

--- a/apps/design-tokens-manager/src/routes/Scaler/Results.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/Results.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 import { Box } from 'grommet';
 import { ContentPane, CopyButton } from '../../components';

--- a/apps/design-tokens-manager/src/routes/Scaler/components/ScaleLayout.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/components/ScaleLayout.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 
 export const ScaleLayout = ({ ...rest }) => {

--- a/apps/design-tokens-manager/src/routes/Scaler/components/ScaleToolbar.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/components/ScaleToolbar.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Button } from 'grommet';
 import { Sidebar } from '@hpe-design/icons-grommet';
 import { CopyButton } from '../../../components/CopyButton';

--- a/apps/design-tokens-manager/src/routes/Scaler/components/ScaleValue.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/components/ScaleValue.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 
 export const ScaleValue = ({ base, stops, value, ...rest }) => {

--- a/apps/design-tokens-manager/src/routes/Scaler/components/SpacingValues.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/components/SpacingValues.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { NameValuePair, NameValueList } from 'grommet';
 
 export const SpacingValues = ({ values, ...rest }) => {

--- a/apps/design-tokens-manager/src/routes/Scaler/components/index.js
+++ b/apps/design-tokens-manager/src/routes/Scaler/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ScaleLayout';
 export * from './ScaleToolbar';
 export * from './ScaleValue';

--- a/apps/design-tokens-manager/src/routes/Scaler/index.jsx
+++ b/apps/design-tokens-manager/src/routes/Scaler/index.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Box, Page, PageContent, PageHeader } from 'grommet';
 import { ControlPane } from './ControlPane';

--- a/apps/design-tokens-manager/src/routes/Scaler/utils.js
+++ b/apps/design-tokens-manager/src/routes/Scaler/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 const roundToNearest = (value, nearest) => {
   return Math.ceil(value / nearest) * nearest;
 };

--- a/apps/design-tokens-manager/src/routes/Visualizer.jsx
+++ b/apps/design-tokens-manager/src/routes/Visualizer.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Fragment, useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import {

--- a/apps/design-tokens-manager/src/vite-env.d.ts
+++ b/apps/design-tokens-manager/src/vite-env.d.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /// <reference types="vite/client" />

--- a/apps/design-tokens-manager/vite.config.ts
+++ b/apps/design-tokens-manager/vite.config.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 

--- a/packages/codemods/__tests__/migrate-grommet-icons-to-hpe.test.js
+++ b/packages/codemods/__tests__/migrate-grommet-icons-to-hpe.test.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
 import jscodeshift from 'jscodeshift';
 import transform from '../transforms/migrate-grommet-icons-to-hpe';

--- a/packages/codemods/__tests__/migrate-theme-v6-to-v7.test.js
+++ b/packages/codemods/__tests__/migrate-theme-v6-to-v7.test.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from "vitest";
 import jscodeshift from "jscodeshift";
 import migrateTshirtSizes from "../transforms/migrate-theme-v6-to-v7";

--- a/packages/codemods/bin/cli.js
+++ b/packages/codemods/bin/cli.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 /**
  * Enhanced Codemod dispatcher CLI for grommet-theme-hpe

--- a/packages/codemods/transforms/migrate-grommet-icons-to-hpe.js
+++ b/packages/codemods/transforms/migrate-grommet-icons-to-hpe.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Codemod for migrating from grommet-icons to @hpe-design/icons-grommet
  * Usage: npx hpe-design-system-codemods migrate-grommet-icons-to-hpe <path>

--- a/packages/codemods/transforms/migrate-theme-v6-to-v7.js
+++ b/packages/codemods/transforms/migrate-theme-v6-to-v7.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Codemod for migrating t-shirt size props from v6 to v7
  * Usage: node node_modules/grommet-theme-hpe/codemod <transform> <path>

--- a/packages/hpe-design-tokens/src/HPEStyleDictionary.ts
+++ b/packages/hpe-design-tokens/src/HPEStyleDictionary.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { StyleDictionary } from 'style-dictionary-utils';
 import {
   commonJs,

--- a/packages/hpe-design-tokens/src/color.ts
+++ b/packages/hpe-design-tokens/src/color.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Color } from './figma_api.js';
 
 /**

--- a/packages/hpe-design-tokens/src/figma_api.ts
+++ b/packages/hpe-design-tokens/src/figma_api.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import axios from 'axios';
 
 export interface VariableMode {

--- a/packages/hpe-design-tokens/src/figma_sync_config.ts
+++ b/packages/hpe-design-tokens/src/figma_sync_config.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/hpe-design-tokens/src/formats/commonJs.ts
+++ b/packages/hpe-design-tokens/src/formats/commonJs.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { fileHeader, minifyDictionary } from 'style-dictionary/utils';
 import { FormatFn, FormatFnArguments } from 'style-dictionary/types';
 import { jsonToNestedValue } from './utils/jsonToNestedValue.js';

--- a/packages/hpe-design-tokens/src/formats/commonJsGrommetRefs.ts
+++ b/packages/hpe-design-tokens/src/formats/commonJsGrommetRefs.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { fileHeader, minifyDictionary } from 'style-dictionary/utils';
 import { FormatFn, FormatFnArguments } from 'style-dictionary/types';
 import { getGrommetValue } from './utils/getGrommetValue.js';

--- a/packages/hpe-design-tokens/src/formats/cssBreakpoints.ts
+++ b/packages/hpe-design-tokens/src/formats/cssBreakpoints.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { FormatFn, FormatFnArguments } from 'style-dictionary/types';
 import { fileHeader, formattedVariables } from 'style-dictionary/utils';
 

--- a/packages/hpe-design-tokens/src/formats/cssColorModes.ts
+++ b/packages/hpe-design-tokens/src/formats/cssColorModes.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { FormatFn, FormatFnArguments } from 'style-dictionary/types';
 import { formattedVariables, fileHeader } from 'style-dictionary/utils';
 

--- a/packages/hpe-design-tokens/src/formats/esmGrommetRefs.ts
+++ b/packages/hpe-design-tokens/src/formats/esmGrommetRefs.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { fileHeader, minifyDictionary } from 'style-dictionary/utils';
 import { FormatFn, FormatFnArguments } from 'style-dictionary/types';
 import { getGrommetValue } from './utils/getGrommetValue.js';

--- a/packages/hpe-design-tokens/src/formats/index.ts
+++ b/packages/hpe-design-tokens/src/formats/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { commonJs } from './commonJs.js';
 export { commonJsGrommetRefs } from './commonJsGrommetRefs.js';
 export { cssColorModes } from './cssColorModes.js';

--- a/packages/hpe-design-tokens/src/formats/javascriptEsm.ts
+++ b/packages/hpe-design-tokens/src/formats/javascriptEsm.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { fileHeader, minifyDictionary } from 'style-dictionary/utils';
 import { FormatFn, FormatFnArguments } from 'style-dictionary/types';
 import { jsonToNestedValue } from './utils/jsonToNestedValue.js';

--- a/packages/hpe-design-tokens/src/formats/jsonFlat.ts
+++ b/packages/hpe-design-tokens/src/formats/jsonFlat.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { fileHeader } from 'style-dictionary/utils';
 import {
   TransformedToken,

--- a/packages/hpe-design-tokens/src/formats/utils/getGrommetValue.ts
+++ b/packages/hpe-design-tokens/src/formats/utils/getGrommetValue.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { usesReferences, getReferences } from 'style-dictionary/utils';
 import { excludedNameParts, isReference } from '../../utils.js';
 

--- a/packages/hpe-design-tokens/src/formats/utils/jsonToNestedValue.ts
+++ b/packages/hpe-design-tokens/src/formats/utils/jsonToNestedValue.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { excludedNameParts } from '../../utils.js';
 
 export const jsonToNestedValue = (

--- a/packages/hpe-design-tokens/src/jsonc.ts
+++ b/packages/hpe-design-tokens/src/jsonc.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { readFileSync } from 'fs';
 
 export function stripJsonComments(jsonText: string): string {

--- a/packages/hpe-design-tokens/src/scripts/build-style-dictionary.js
+++ b/packages/hpe-design-tokens/src/scripts/build-style-dictionary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import * as fs from 'fs';
 import { HPEStyleDictionary } from '../HPEStyleDictionary.ts';

--- a/packages/hpe-design-tokens/src/scripts/discover_figma_collection_keys.ts
+++ b/packages/hpe-design-tokens/src/scripts/discover_figma_collection_keys.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';

--- a/packages/hpe-design-tokens/src/scripts/release-stable.js
+++ b/packages/hpe-design-tokens/src/scripts/release-stable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import del from 'del';
 import fs from 'fs-extra';
 import git from 'simple-git';

--- a/packages/hpe-design-tokens/src/scripts/sync_figma_to_tokens.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_figma_to_tokens.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import 'dotenv/config';
 import * as fs from 'fs';
 import path from 'path';

--- a/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
+++ b/packages/hpe-design-tokens/src/scripts/sync_tokens_to_figma.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import 'dotenv/config';
 import * as fs from 'fs';
 import path from 'path';

--- a/packages/hpe-design-tokens/src/scripts/update-paddingY.ts
+++ b/packages/hpe-design-tokens/src/scripts/update-paddingY.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { readFileSync, writeFileSync } from 'fs';
 import {
   access,

--- a/packages/hpe-design-tokens/src/scripts/update-semantic-color-parity-fixtures.ts
+++ b/packages/hpe-design-tokens/src/scripts/update-semantic-color-parity-fixtures.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { writeFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/packages/hpe-design-tokens/src/scripts/verify-paddingY.ts
+++ b/packages/hpe-design-tokens/src/scripts/verify-paddingY.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { readFileSync } from 'fs';
 import { access, getThemeFiles, isReference } from '../utils.js';
 

--- a/packages/hpe-design-tokens/src/scripts/watch-token-build.mjs
+++ b/packages/hpe-design-tokens/src/scripts/watch-token-build.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';

--- a/packages/hpe-design-tokens/src/semantic_color.ts
+++ b/packages/hpe-design-tokens/src/semantic_color.ts
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './semantic_color_core.js';
 export * from './semantic_color_parser.js';

--- a/packages/hpe-design-tokens/src/semantic_color_core.ts
+++ b/packages/hpe-design-tokens/src/semantic_color_core.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // Target => Where color is applied.
 export const SEMANTIC_COLOR_TARGETS = [
   'background',

--- a/packages/hpe-design-tokens/src/semantic_color_figma_adapter.ts
+++ b/packages/hpe-design-tokens/src/semantic_color_figma_adapter.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   colorNameToHierarchyPartsCore,
   normalizeColorVariableNameFromFigmaCore,

--- a/packages/hpe-design-tokens/src/semantic_color_normalization.ts
+++ b/packages/hpe-design-tokens/src/semantic_color_normalization.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   SEMANTIC_COLOR_SUBROLES_BY_TARGET_FAMILY,
   SEMANTIC_COLOR_FIGMA_FAMILIES_BY_TARGET,

--- a/packages/hpe-design-tokens/src/semantic_color_parser.ts
+++ b/packages/hpe-design-tokens/src/semantic_color_parser.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // Parses semantic color token paths into canonical metadata and exports
 // helpers to serialize that metadata for build artifacts.
 import {

--- a/packages/hpe-design-tokens/src/sync_events.ts
+++ b/packages/hpe-design-tokens/src/sync_events.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   ApiGetLocalVariablesResponse,
   ApiPostVariablesPayload,

--- a/packages/hpe-design-tokens/src/sync_plan_report.ts
+++ b/packages/hpe-design-tokens/src/sync_plan_report.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   ApiGetLocalVariablesResponse,
   ApiPostVariablesPayload,

--- a/packages/hpe-design-tokens/src/tests/build.test.ts
+++ b/packages/hpe-design-tokens/src/tests/build.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { beforeAll, describe, expect, it } from 'vitest';
 import fs from 'fs';
 import { HPEStyleDictionary } from '../HPEStyleDictionary.js';

--- a/packages/hpe-design-tokens/src/tests/color.test.ts
+++ b/packages/hpe-design-tokens/src/tests/color.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import { colorApproximatelyEqual, parseColor, rgbToHex } from '../color.js';
 

--- a/packages/hpe-design-tokens/src/tests/figma_sync_config.test.ts
+++ b/packages/hpe-design-tokens/src/tests/figma_sync_config.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import fs from 'fs';
 import os from 'os';
 import path from 'path';

--- a/packages/hpe-design-tokens/src/tests/semantic_color_figma_adapter.test.ts
+++ b/packages/hpe-design-tokens/src/tests/semantic_color_figma_adapter.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { describe, expect, it } from 'vitest';
 

--- a/packages/hpe-design-tokens/src/tests/semantic_color_figma_adapter_parity.test.ts
+++ b/packages/hpe-design-tokens/src/tests/semantic_color_figma_adapter_parity.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/hpe-design-tokens/src/tests/semantic_color_normalization.test.ts
+++ b/packages/hpe-design-tokens/src/tests/semantic_color_normalization.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/hpe-design-tokens/src/tests/semantic_color_parser.test.ts
+++ b/packages/hpe-design-tokens/src/tests/semantic_color_parser.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import fs from 'fs';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/hpe-design-tokens/src/tests/semantic_color_payload_golden.test.ts
+++ b/packages/hpe-design-tokens/src/tests/semantic_color_payload_golden.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 
 import { ApiGetLocalVariablesResponse } from '../figma_api.js';

--- a/packages/hpe-design-tokens/src/tests/sync_contract_schemas.test.ts
+++ b/packages/hpe-design-tokens/src/tests/sync_contract_schemas.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/packages/hpe-design-tokens/src/tests/sync_events.test.ts
+++ b/packages/hpe-design-tokens/src/tests/sync_events.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/hpe-design-tokens/src/tests/sync_plan_report.test.ts
+++ b/packages/hpe-design-tokens/src/tests/sync_plan_report.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 
 import { ApiGetLocalVariablesResponse } from '../figma_api.js';

--- a/packages/hpe-design-tokens/src/tests/token_export.test.ts
+++ b/packages/hpe-design-tokens/src/tests/token_export.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import { ApiGetLocalVariablesResponse } from '../figma_api.js';
 import { tokenFilesFromLocalVariables } from '../token_export.js';

--- a/packages/hpe-design-tokens/src/tests/token_import.test.ts
+++ b/packages/hpe-design-tokens/src/tests/token_import.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { vi, describe, it, expect } from 'vitest';
 import { ApiGetLocalVariablesResponse } from '../figma_api.js';
 import {

--- a/packages/hpe-design-tokens/src/tests/token_import_alias_resolution.test.ts
+++ b/packages/hpe-design-tokens/src/tests/token_import_alias_resolution.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/hpe-design-tokens/src/token_export.ts
+++ b/packages/hpe-design-tokens/src/token_export.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { rgbToHex } from './color.js';
 import { ApiGetLocalVariablesResponse, Variable } from './figma_api.js';

--- a/packages/hpe-design-tokens/src/token_import.ts
+++ b/packages/hpe-design-tokens/src/token_import.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/packages/hpe-design-tokens/src/token_types.ts
+++ b/packages/hpe-design-tokens/src/token_types.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { VariableCodeSyntax, VariableScope } from './figma_api.js';
 
 /**

--- a/packages/hpe-design-tokens/src/transforms/colorNameJs.ts
+++ b/packages/hpe-design-tokens/src/transforms/colorNameJs.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Transform, TransformedToken } from 'style-dictionary/types';
 import { excludedNameParts } from '../utils.js';
 

--- a/packages/hpe-design-tokens/src/transforms/cssW3c.ts
+++ b/packages/hpe-design-tokens/src/transforms/cssW3c.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const cssW3c: string[] = [
   'attribute/cti',
   'name/css',

--- a/packages/hpe-design-tokens/src/transforms/index.ts
+++ b/packages/hpe-design-tokens/src/transforms/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { javascriptCss } from './javascriptCss.js';
 export { javascriptW3c } from './javascriptW3c.js';
 export { colorNameJs } from './colorNameJs.js';

--- a/packages/hpe-design-tokens/src/transforms/javascriptCss.ts
+++ b/packages/hpe-design-tokens/src/transforms/javascriptCss.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Custom style-dictionary transform group to convert token object into nested
  * object with css variable as value.

--- a/packages/hpe-design-tokens/src/transforms/javascriptW3c.ts
+++ b/packages/hpe-design-tokens/src/transforms/javascriptW3c.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const javascriptW3c: string[] = [
   'attribute/cti',
   'name/dot',

--- a/packages/hpe-design-tokens/src/transforms/linearGradientCss.ts
+++ b/packages/hpe-design-tokens/src/transforms/linearGradientCss.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Transform, TransformedToken } from 'style-dictionary/types';
 
 /**

--- a/packages/hpe-design-tokens/src/transforms/nameCss.ts
+++ b/packages/hpe-design-tokens/src/transforms/nameCss.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   PlatformConfig,
   Transform,

--- a/packages/hpe-design-tokens/src/transforms/numberToDimension.ts
+++ b/packages/hpe-design-tokens/src/transforms/numberToDimension.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Transform, TransformedToken } from 'style-dictionary/types';
 
 export const numberToDimension: Transform = {

--- a/packages/hpe-design-tokens/src/transforms/shadowCss.ts
+++ b/packages/hpe-design-tokens/src/transforms/shadowCss.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Transform } from 'style-dictionary/types';
 
 // supporting our own transform because style-dictionary doesn't support inset

--- a/packages/hpe-design-tokens/src/transforms/valueToCssVar.ts
+++ b/packages/hpe-design-tokens/src/transforms/valueToCssVar.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Transform, TransformedToken } from 'style-dictionary/types';
 import { excludedNameParts } from '../utils.js';
 

--- a/packages/hpe-design-tokens/src/types/esm/index.d.ts
+++ b/packages/hpe-design-tokens/src/types/esm/index.d.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 declare module 'hpe-design-tokens';

--- a/packages/hpe-design-tokens/src/types/grommet/index.d.ts
+++ b/packages/hpe-design-tokens/src/types/grommet/index.d.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 declare module 'hpe-design-tokens/grommet';

--- a/packages/hpe-design-tokens/src/utils.ts
+++ b/packages/hpe-design-tokens/src/utils.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { readdirSync } from 'fs';
 import { ApiGetLocalVariablesResponse } from './figma_api.js';
 import { ExpectedCollectionKeys } from './figma_sync_config.js';

--- a/packages/icons-svg/src/index.ts
+++ b/packages/icons-svg/src/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 const allIcons = import.meta.glob('./icons/*.svg', { eager: true });
 
 /**

--- a/packages/icons-svg/vite.config.ts
+++ b/packages/icons-svg/vite.config.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { viteStaticCopy } from 'vite-plugin-static-copy';

--- a/sandbox/grommet-app/eslint.config.mjs
+++ b/sandbox/grommet-app/eslint.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';

--- a/sandbox/grommet-app/src/App.jsx
+++ b/sandbox/grommet-app/src/App.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useMemo } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Grommet, Box } from 'grommet';

--- a/sandbox/grommet-app/src/Login.jsx
+++ b/sandbox/grommet-app/src/Login.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   Box,
   Form,

--- a/sandbox/grommet-app/src/components/Card/Card.jsx
+++ b/sandbox/grommet-app/src/components/Card/Card.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';

--- a/sandbox/grommet-app/src/components/Card/index.js
+++ b/sandbox/grommet-app/src/components/Card/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Card';

--- a/sandbox/grommet-app/src/components/Chat.tsx
+++ b/sandbox/grommet-app/src/components/Chat.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect } from 'react';
 import { Box, Button, Spinner, Text, TextArea } from 'grommet';
 import {

--- a/sandbox/grommet-app/src/components/CollapsibleMenu/CollapsibleMenu.tsx
+++ b/sandbox/grommet-app/src/components/CollapsibleMenu/CollapsibleMenu.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 import { ExpandableMenuItem } from './ExpandableMenuItem';

--- a/sandbox/grommet-app/src/components/CollapsibleMenu/ExpandableMenuItem.tsx
+++ b/sandbox/grommet-app/src/components/CollapsibleMenu/ExpandableMenuItem.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Collapsible, Text } from 'grommet';
 import { Down, LinkNext, Up } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/components/CollapsibleMenu/MenuItem.tsx
+++ b/sandbox/grommet-app/src/components/CollapsibleMenu/MenuItem.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Text } from 'grommet';
 import { MenuItemType } from './types';

--- a/sandbox/grommet-app/src/components/CollapsibleMenu/index.ts
+++ b/sandbox/grommet-app/src/components/CollapsibleMenu/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './CollapsibleMenu';

--- a/sandbox/grommet-app/src/components/CollapsibleMenu/types.ts
+++ b/sandbox/grommet-app/src/components/CollapsibleMenu/types.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export type MenuItemType = {
   key: string;
   label: string;

--- a/sandbox/grommet-app/src/components/ContentContainer/ContentContainer.jsx
+++ b/sandbox/grommet-app/src/components/ContentContainer/ContentContainer.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 
 export const ContentContainer = ({ ...rest }) => {

--- a/sandbox/grommet-app/src/components/ContentContainer/index.js
+++ b/sandbox/grommet-app/src/components/ContentContainer/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContentContainer';

--- a/sandbox/grommet-app/src/components/ContentPane/index.jsx
+++ b/sandbox/grommet-app/src/components/ContentPane/index.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Header, Heading } from 'grommet';

--- a/sandbox/grommet-app/src/components/DashboardCard/DashboardCard.jsx
+++ b/sandbox/grommet-app/src/components/DashboardCard/DashboardCard.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/sandbox/grommet-app/src/components/DashboardCard/index.js
+++ b/sandbox/grommet-app/src/components/DashboardCard/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DashboardCard';

--- a/sandbox/grommet-app/src/components/EmptyState/EmptyState.tsx
+++ b/sandbox/grommet-app/src/components/EmptyState/EmptyState.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { cloneElement } from 'react';
 import { Box, Heading, HeadingProps, Paragraph } from 'grommet';
 

--- a/sandbox/grommet-app/src/components/EmptyState/index.ts
+++ b/sandbox/grommet-app/src/components/EmptyState/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './EmptyState';

--- a/sandbox/grommet-app/src/components/FloatingActionButton/FloatingActionButton.jsx
+++ b/sandbox/grommet-app/src/components/FloatingActionButton/FloatingActionButton.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import styled from 'styled-components';
 import { Box, Button } from 'grommet';
 

--- a/sandbox/grommet-app/src/components/FloatingActionButton/index.js
+++ b/sandbox/grommet-app/src/components/FloatingActionButton/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './FloatingActionButton';

--- a/sandbox/grommet-app/src/components/GlobalHeader/GlobalHeader.jsx
+++ b/sandbox/grommet-app/src/components/GlobalHeader/GlobalHeader.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';

--- a/sandbox/grommet-app/src/components/GlobalHeader/index.js
+++ b/sandbox/grommet-app/src/components/GlobalHeader/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './GlobalHeader';

--- a/sandbox/grommet-app/src/components/HPEGreenLakeBadge.jsx
+++ b/sandbox/grommet-app/src/components/HPEGreenLakeBadge.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { Tween } from 'react-gsap';

--- a/sandbox/grommet-app/src/components/Legend/Legend.jsx
+++ b/sandbox/grommet-app/src/components/Legend/Legend.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 import PropTypes from 'prop-types';
 

--- a/sandbox/grommet-app/src/components/Legend/index.js
+++ b/sandbox/grommet-app/src/components/Legend/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Legend';

--- a/sandbox/grommet-app/src/components/Metric/Metric.jsx
+++ b/sandbox/grommet-app/src/components/Metric/Metric.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 import PropTypes from 'prop-types';

--- a/sandbox/grommet-app/src/components/Metric/index.js
+++ b/sandbox/grommet-app/src/components/Metric/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Metric';
 export * from './sizes';

--- a/sandbox/grommet-app/src/components/Metric/sizes.js
+++ b/sandbox/grommet-app/src/components/Metric/sizes.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const metricSizes = {
   small: {
     label: 'small',

--- a/sandbox/grommet-app/src/components/NavSidebar/NavSidebar.tsx
+++ b/sandbox/grommet-app/src/components/NavSidebar/NavSidebar.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Nav, Sidebar, Text } from 'grommet';
 import { Sidebar as SidebarIcon } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/components/NavSidebar/index.ts
+++ b/sandbox/grommet-app/src/components/NavSidebar/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavSidebar';

--- a/sandbox/grommet-app/src/components/NotificationMetric/NotificationMetric.jsx
+++ b/sandbox/grommet-app/src/components/NotificationMetric/NotificationMetric.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 import PropTypes from 'prop-types';
 import {

--- a/sandbox/grommet-app/src/components/NotificationMetric/index.js
+++ b/sandbox/grommet-app/src/components/NotificationMetric/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NotificationMetric';

--- a/sandbox/grommet-app/src/components/PropertiesPane/PropertiesPane.tsx
+++ b/sandbox/grommet-app/src/components/PropertiesPane/PropertiesPane.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { NameValueList, NameValuePair } from 'grommet';
 import ContentPane from '../ContentPane';

--- a/sandbox/grommet-app/src/components/PropertiesPane/index.ts
+++ b/sandbox/grommet-app/src/components/PropertiesPane/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './PropertiesPane';

--- a/sandbox/grommet-app/src/components/RoutedAnchor/RoutedAnchor.tsx
+++ b/sandbox/grommet-app/src/components/RoutedAnchor/RoutedAnchor.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor } from 'grommet';
 

--- a/sandbox/grommet-app/src/components/RoutedAnchor/index.ts
+++ b/sandbox/grommet-app/src/components/RoutedAnchor/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './RoutedAnchor';

--- a/sandbox/grommet-app/src/components/Selector/Selector.jsx
+++ b/sandbox/grommet-app/src/components/Selector/Selector.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { useContext } from 'react';
 import styled from 'styled-components';

--- a/sandbox/grommet-app/src/components/Selector/SelectorGroup.jsx
+++ b/sandbox/grommet-app/src/components/Selector/SelectorGroup.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { useState, useCallback, useMemo } from 'react';
 import { Box, Grid } from 'grommet';

--- a/sandbox/grommet-app/src/components/Selector/SelectorGroupContext.jsx
+++ b/sandbox/grommet-app/src/components/Selector/SelectorGroupContext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 export const SelectorGroupContext = React.createContext({});

--- a/sandbox/grommet-app/src/components/Selector/SelectorHeader.jsx
+++ b/sandbox/grommet-app/src/components/Selector/SelectorHeader.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import { useContext } from 'react';
 import { Box, Text, ThemeContext } from 'grommet';

--- a/sandbox/grommet-app/src/components/Selector/index.ts
+++ b/sandbox/grommet-app/src/components/Selector/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Selector';
 export * from './SelectorGroup';
 export * from './SelectorGroupContext';

--- a/sandbox/grommet-app/src/components/SkeletonContext/SkeletonContext.js
+++ b/sandbox/grommet-app/src/components/SkeletonContext/SkeletonContext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext } from 'react';
 
 export const SkeletonContext = createContext();

--- a/sandbox/grommet-app/src/components/SkeletonContext/index.js
+++ b/sandbox/grommet-app/src/components/SkeletonContext/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './SkeletonContext';

--- a/sandbox/grommet-app/src/components/ToggleGroup/ToggleGroup.jsx
+++ b/sandbox/grommet-app/src/components/ToggleGroup/ToggleGroup.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { ThemeContext as SCThemeContext } from 'styled-components';
 import { RadioButtonGroup, Box, Text } from 'grommet';

--- a/sandbox/grommet-app/src/components/ToggleGroup/index.js
+++ b/sandbox/grommet-app/src/components/ToggleGroup/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ToggleGroup';

--- a/sandbox/grommet-app/src/components/index.js
+++ b/sandbox/grommet-app/src/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Card';
 export * from './CollapsibleMenu';
 export * from './ContentPane';

--- a/sandbox/grommet-app/src/contexts/BackgroundContext.jsx
+++ b/sandbox/grommet-app/src/contexts/BackgroundContext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext } from 'react';
 
 export const BackgroundContext = createContext({});

--- a/sandbox/grommet-app/src/contexts/SupportingContext.jsx
+++ b/sandbox/grommet-app/src/contexts/SupportingContext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext } from 'react';
 
 export const SupportingContext = createContext({

--- a/sandbox/grommet-app/src/contexts/WorkspaceContext.jsx
+++ b/sandbox/grommet-app/src/contexts/WorkspaceContext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext } from 'react';
 
 export const WorkspaceContext = createContext({});

--- a/sandbox/grommet-app/src/contexts/index.js
+++ b/sandbox/grommet-app/src/contexts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { BackgroundContext } from './BackgroundContext';
 export { SupportingContext } from './SupportingContext';
 export { WorkspaceContext } from './WorkspaceContext';

--- a/sandbox/grommet-app/src/icons/Comfortable.jsx
+++ b/sandbox/grommet-app/src/icons/Comfortable.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Blank } from '@hpe-design/icons-grommet';
 
 export const Comfortable = ({ ...rest }) => (

--- a/sandbox/grommet-app/src/icons/Compact.jsx
+++ b/sandbox/grommet-app/src/icons/Compact.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Blank } from '@hpe-design/icons-grommet';
 
 export const Compact = ({ ...rest }) => (

--- a/sandbox/grommet-app/src/icons/Spacious.jsx
+++ b/sandbox/grommet-app/src/icons/Spacious.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Blank } from '@hpe-design/icons-grommet';
 
 export const Spacious = ({ ...rest }) => (

--- a/sandbox/grommet-app/src/icons/index.js
+++ b/sandbox/grommet-app/src/icons/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Comfortable';
 export * from './Compact';
 export * from './Spacious';

--- a/sandbox/grommet-app/src/main.jsx
+++ b/sandbox/grommet-app/src/main.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';

--- a/sandbox/grommet-app/src/pages/BillingSummary.jsx
+++ b/sandbox/grommet-app/src/pages/BillingSummary.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Notification } from 'grommet';
 import { DashboardCard, Metric } from '../components';
 

--- a/sandbox/grommet-app/src/pages/DeviceSummary.jsx
+++ b/sandbox/grommet-app/src/pages/DeviceSummary.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, Stack, Meter, Text } from 'grommet';
 import { DashboardCard } from '../components';

--- a/sandbox/grommet-app/src/pages/ExpiringSubscriptions.jsx
+++ b/sandbox/grommet-app/src/pages/ExpiringSubscriptions.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, List, Text, Notification } from 'grommet';
 import { StatusCritical, StatusWarning } from '@hpe-design/icons-grommet';
 import { DashboardCard } from '../components';

--- a/sandbox/grommet-app/src/pages/FeaturedServices.jsx
+++ b/sandbox/grommet-app/src/pages/FeaturedServices.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Anchor, Grid, Tabs, Tab } from 'grommet';
 import PropTypes from 'prop-types';
 import services from '../mockData/services.json';

--- a/sandbox/grommet-app/src/pages/GetStarted.jsx
+++ b/sandbox/grommet-app/src/pages/GetStarted.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Grid, ResponsiveContext, Heading } from 'grommet';
 import { DashboardCard } from '../components';

--- a/sandbox/grommet-app/src/pages/Learn.jsx
+++ b/sandbox/grommet-app/src/pages/Learn.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Heading } from 'grommet';
 import { DashboardCard } from '../components';

--- a/sandbox/grommet-app/src/pages/MonthlyCharges.jsx
+++ b/sandbox/grommet-app/src/pages/MonthlyCharges.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, DataChart, Text, Notification, Skeleton } from 'grommet';
 import { DashboardCard, Legend } from '../components';
 import expenses from '../mockData/expenses.json';

--- a/sandbox/grommet-app/src/pages/MyServices.jsx
+++ b/sandbox/grommet-app/src/pages/MyServices.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { List, Box, Text } from 'grommet';
 import { DashboardCard } from '../components';
 import services from '../mockData/services.json';

--- a/sandbox/grommet-app/src/pages/Notifications.jsx
+++ b/sandbox/grommet-app/src/pages/Notifications.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Heading, List, Text } from 'grommet';
 import {
   StatusCritical,

--- a/sandbox/grommet-app/src/pages/QuickActions.jsx
+++ b/sandbox/grommet-app/src/pages/QuickActions.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Anchor, Box, Button, Heading, Skeleton } from 'grommet';
 import PropTypes from 'prop-types';
 import {

--- a/sandbox/grommet-app/src/pages/RecentServices.jsx
+++ b/sandbox/grommet-app/src/pages/RecentServices.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import { Anchor, List, Grid, Text, Box, Button, Skeleton } from 'grommet';
 import { Link } from 'react-router-dom';

--- a/sandbox/grommet-app/src/pages/Recommended.jsx
+++ b/sandbox/grommet-app/src/pages/Recommended.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Heading } from 'grommet';
 import PropTypes from 'prop-types';
 import { DashboardCard } from '../components';

--- a/sandbox/grommet-app/src/pages/SustainabilityOverview.jsx
+++ b/sandbox/grommet-app/src/pages/SustainabilityOverview.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Link } from 'react-router-dom';
 import { DataChart, Grid, Notification, Skeleton } from 'grommet';
 import { DashboardCard } from '../components';

--- a/sandbox/grommet-app/src/pages/UserOverview.jsx
+++ b/sandbox/grommet-app/src/pages/UserOverview.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Meter, Text, Notification } from 'grommet';
 import { DashboardCard } from '../components';
 import { Legend } from '../components';

--- a/sandbox/grommet-app/src/pages/index.jsx
+++ b/sandbox/grommet-app/src/pages/index.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   Box,
   PageHeader,

--- a/sandbox/grommet-app/src/pages/layouts/components/Region.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/components/Region.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/layouts/components/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/components/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Region';

--- a/sandbox/grommet-app/src/pages/layouts/index.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/index.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Link, Outlet, Route } from 'react-router-dom';
 import { List, Page, PageContent, PageHeader } from 'grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/Collection.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/Collection.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo } from 'react';
 import {
   Grid,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/CollectionMenu.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/CollectionMenu.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/DataTableActions.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/DataTableActions.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Menu } from 'grommet';
 import { MoreVertical } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/DataView.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/DataView.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/PageActions.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/PageActions.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, Menu } from 'grommet';
 import { MoreVertical, Refresh, Share } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Collection';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Collection/tableColumns.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Collection/tableColumns.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { ColumnConfig } from "grommet";
 
 interface VirtualMachine {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DSCCSystemDetail.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DSCCSystemDetail.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DetailPane/Capacity.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DetailPane/Capacity.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from "react";
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DetailPane/DetailPane.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DetailPane/DetailPane.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from "react";
 import { Box, Tab, Tabs } from "grommet";
 import { Capacity } from "./Capacity";

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DetailPane/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/DetailPane/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DetailPane';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PerformanceSummary.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PerformanceSummary.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from "react";
 import { Box } from "grommet";
 import { DashboardCard, Metric } from "../../../../components";

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PhysicalCapacity.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PhysicalCapacity.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from "react";
 import { Box, Grid, Meter, Text } from "grommet";
 import { DashboardCard, Metric } from "../../../../components";

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PropertiesGeneral.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PropertiesGeneral.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { PropertiesPane } from '../../../../components';
 

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PropertiesRelated.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/PropertiesRelated.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { PropertiesPane } from '../../../../components';
 import { Anchor } from 'grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/SystemSummary.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/SystemSummary.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 import { DashboardCard, Metric, metricSizes } from '../../../../components';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/DSCCSystemDetail/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DSCCSystemDetail';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Costs.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Costs.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CardBody, Card, DataChart, Heading, Text } from 'grommet';
 import sustainability from '../../../../mockData/sustainability.json';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Dashboard.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Dashboard.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Page,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/GreenLakeStatus.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/GreenLakeStatus.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CardBody, Card, Heading, Text } from 'grommet';
 import { StatusGood } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Monitoring.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Monitoring.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CardBody, Card, Heading, Text } from 'grommet';
 import { StatusWarning } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Networking.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Networking.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Card, CardBody, Heading, Paragraph } from 'grommet';
 import { AIGenFill } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Storage.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Storage.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Card, CardBody, Heading, Paragraph } from 'grommet';
 import { AIGenFill } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Tasks.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Tasks.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, CardBody, Card, Heading, Text } from 'grommet';
 import { LinkNext } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Usage.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/Usage.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Grid, Box, Card, CardBody, Text, Heading, Meter } from 'grommet';
 import { Legend } from '../../../../components';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/components/Capacity.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/components/Capacity.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Card, CardBody, CardFooter, Heading, Text, Meter } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/components/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/components/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Capacity';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Dashboard/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Dashboard';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/DataTableActions.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/DataTableActions.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Menu } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/EmptyState.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/EmptyState.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './EmptyState';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/tableColumns.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/EmptyState/tableColumns.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const tableColumns = [
   {
     property: "name",

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Form/Form.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Form/Form.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Form/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Form/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Form';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/NavigationalSidebar/NavigationalSidebar.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/NavigationalSidebar/NavigationalSidebar.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Page, PageContent, PageHeader } from 'grommet';
 import { Left } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/NavigationalSidebar/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/NavigationalSidebar/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavigationalSidebar';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/NavigationalSidebar/navItems.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/NavigationalSidebar/navItems.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const navItems = {
   Dashboard: { key: 'dashboard', label: 'Dashboard' },
   Systems: { key: 'systems', label: 'Systems' },

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/OpsRampDetail.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/OpsRampDetail.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/OpsRampDetailTable.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/OpsRampDetailTable.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState, useEffect } from 'react';
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/QuickFilters.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/QuickFilters.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { SelectorGroup, Selector } from '../../../../components';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceAlerts.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceAlerts.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Grid, Box, Text, ResponsiveContext } from 'grommet';
 import { Metric, metricSizes } from '../../../../components';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceDetails.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceDetails.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceOverview.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceOverview.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Tabs, Tab, NameValueList, NameValuePair } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceTraits.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/ResourceTraits.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text, Tag } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/config.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/config.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, Button, ColumnConfig } from 'grommet';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/OpsRampDetail/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './OpsRampDetail';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/DetailSummary.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/DetailSummary.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, NameValueList, NameValuePair, Text } from 'grommet';
 import { StatusGood } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/ILOSecurity.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/ILOSecurity.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from "react";
 import { Box, NameValueList, NameValuePair } from "grommet";
 import { sentenceCase } from "../../../../utils/format";

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/JobList.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/JobList.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Button, List, NameValueList, NameValuePair, Text } from 'grommet';
 import { Edit, Trash } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/RecentActivity.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/RecentActivity.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, List, Paragraph, Text } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/RecordDetail.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/RecordDetail.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/ScheduledActions.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/ScheduledActions.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Anchor, Box, List, Menu, Text } from 'grommet';
 import { More } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/ScheduledJobs.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/ScheduledJobs.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from "react";
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/RecordDetail/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './RecordDetail';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Results/AcccessPoints.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Results/AcccessPoints.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, DataChart, Text, Skeleton, Menu } from 'grommet';
 import { Legend } from '../../../../components';
 import expenses from '../../../../mockData/expenses.json';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Results/Results.tsx
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Results/Results.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import {
   Box,

--- a/sandbox/grommet-app/src/pages/layouts/kinds/Results/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/Results/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Results';

--- a/sandbox/grommet-app/src/pages/layouts/kinds/index.ts
+++ b/sandbox/grommet-app/src/pages/layouts/kinds/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Collection';
 export * from './Dashboard';
 export * from './DSCCSystemDetail';

--- a/sandbox/grommet-app/src/pages/refresh/index.jsx
+++ b/sandbox/grommet-app/src/pages/refresh/index.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   Anchor,
   Box,

--- a/sandbox/grommet-app/src/pages/sticker-sheet/components/Compare.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/components/Compare.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Grommet, Stack, ThemeContext } from 'grommet';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/components/ModeContext.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/components/ModeContext.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 export const ModeContext = React.createContext({});

--- a/sandbox/grommet-app/src/pages/sticker-sheet/components/StyleInProgress.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/components/StyleInProgress.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Notification } from 'grommet';
 
 export const StyleInProgress = () => (

--- a/sandbox/grommet-app/src/pages/sticker-sheet/components/TabContent.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/components/TabContent.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box } from 'grommet';
 

--- a/sandbox/grommet-app/src/pages/sticker-sheet/components/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Compare';
 export * from './ModeContext';
 export * from './StyleInProgress';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Accordions.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Accordions.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Accordion, AccordionPanel } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Buttons.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Buttons.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Button } from 'grommet';
 import { User } from '@hpe-design/icons-grommet';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Menus.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Menus.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Menu } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components/Compare';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Paginations.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Paginations.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Pagination } from 'grommet';
 import { Compare } from '../../components/Compare';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Tabs.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/Tabs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Tab, Tabs } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/ToggleGroups.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/ToggleGroups.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, ToggleGroup } from 'grommet';
 import { List, Map, Table } from '@hpe-design/icons-grommet';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Controls/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Accordions';
 export * from './Buttons';
 export * from './Menus';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/CheckboxGroups.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/CheckboxGroups.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { CheckBoxGroup, FormField } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare, StyleInProgress } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/Checkboxes.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/Checkboxes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { CheckBox, FormField } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare, StyleInProgress } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/DateInputs.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/DateInputs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { DateInput } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/FileInputs.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/FileInputs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { FileInput } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/RadioButtonGroups.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/RadioButtonGroups.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { FormField, RadioButtonGroup } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare, StyleInProgress } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/RangeInputs.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/RangeInputs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { RangeInput } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/SelectMultiples.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/SelectMultiples.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { SelectMultiple } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/Selects.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/Selects.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Select } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/StarRatings.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/StarRatings.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { StarRating } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/Switches.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/Switches.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { CheckBox } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare, StyleInProgress } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/TextAreas.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/TextAreas.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { TextArea } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/TextInputs.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/TextInputs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { FormField, TextInput } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/ThumbsRatings.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/ThumbsRatings.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { ThumbsRating } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Inputs/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Checkboxes';
 export * from './CheckboxGroups';
 export * from './DateInputs';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/ContentSizes.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/ContentSizes.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/PageHeaders.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/PageHeaders.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { PageHeader } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/Spacing.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/Spacing.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Layouts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ContentSizes';
 export * from './PageHeaders';
 export * from './Spacing';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Anchors.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Anchors.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Anchor, Box } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Headings.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Headings.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Heading } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Paragraphs.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Paragraphs.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Paragraph } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Tags.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Tags.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Tag } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Texts.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/Texts.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Text } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Type/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Anchors';
 export * from './Headings';
 export * from './Paragraphs';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/DataTables.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/DataTables.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { DataTable } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Icons.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Icons.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import ContentPane from '../../../../components/ContentPane';
 import { Box } from 'grommet';
 import { User } from '@hpe-design/icons-grommet';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Meters.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Meters.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Meter } from 'grommet';
 import ContentPane from '../../../../components/ContentPane';
 import { Compare } from '../../components';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/NameValueLists.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/NameValueLists.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { NameValueList, NameValuePair } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Notifications.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Notifications.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Notification } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Spinners.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/Spinners.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Spinner } from 'grommet';
 import { Compare } from '../../components';
 import ContentPane from '../../../../components/ContentPane';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/Visualizations/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DataTables';
 export * from './Icons';
 export * from './Meters';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/content/index.js
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/content/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Controls';
 export * from './Inputs';
 export * from './Layouts';

--- a/sandbox/grommet-app/src/pages/sticker-sheet/index.jsx
+++ b/sandbox/grommet-app/src/pages/sticker-sheet/index.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/sandbox/grommet-app/src/pages/sustainability/Devices.jsx
+++ b/sandbox/grommet-app/src/pages/sustainability/Devices.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/sandbox/grommet-app/src/pages/sustainability/SustainabilityInsights.jsx
+++ b/sandbox/grommet-app/src/pages/sustainability/SustainabilityInsights.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { createContext, useContext, useState } from 'react';
 import {
   Grid,

--- a/sandbox/grommet-app/src/pages/sustainability/index.jsx
+++ b/sandbox/grommet-app/src/pages/sustainability/index.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   Anchor,
   Box,

--- a/sandbox/grommet-app/src/themes/index.ts
+++ b/sandbox/grommet-app/src/themes/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './themes';

--- a/sandbox/grommet-app/src/themes/theme-utils/scale-to-theme.js
+++ b/sandbox/grommet-app/src/themes/theme-utils/scale-to-theme.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // scale-to-theme.js
 // Utility functions to convert scale definitions and t-shirt sizes to theme objects
 // Scale definition example:

--- a/sandbox/grommet-app/src/themes/themes.ts
+++ b/sandbox/grommet-app/src/themes/themes.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { hpe as hpeV5 } from 'grommet-theme-hpe-v5';
 import { hpe as hpeV6 } from 'grommet-theme-hpe-v6';
 import { hpe as hpeV8 } from 'grommet-theme-hpe-v8';

--- a/sandbox/grommet-app/src/themes/tokenColors.ts
+++ b/sandbox/grommet-app/src/themes/tokenColors.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // These color namespaces were introduced in hpe-design-tokens v0
 // but not available for grommet-theme-hpe-v5.
 // Backfilling these color namespaces allows for a more seamless theme toggle

--- a/sandbox/grommet-app/src/utils/format.ts
+++ b/sandbox/grommet-app/src/utils/format.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const sentenceCase = (str: string | number) => {
   let adjustedStr = str;
   if (typeof adjustedStr === 'number') adjustedStr = adjustedStr.toString();

--- a/sandbox/grommet-app/src/utils/skeleton.js
+++ b/sandbox/grommet-app/src/utils/skeleton.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useState } from 'react';
 
 const skeletonAnimation = [];

--- a/sandbox/grommet-app/src/utils/status.tsx
+++ b/sandbox/grommet-app/src/utils/status.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   StatusCritical,

--- a/sandbox/grommet-app/vite.config.js
+++ b/sandbox/grommet-app/vite.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 

--- a/sandbox/native-web/components/common/DashboardCard.js
+++ b/sandbox/native-web/components/common/DashboardCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { LinkNext } from '../../icons/LinkNext';
 
 export const DashboardCard = ({

--- a/sandbox/native-web/components/common/DemoCard.js
+++ b/sandbox/native-web/components/common/DemoCard.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const DemoCard = ({ title, body, footer }) => `
     <div class="card">
         <h2>${title}</h2>

--- a/sandbox/native-web/components/common/Legend.js
+++ b/sandbox/native-web/components/common/Legend.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const Legend = ({ label, background, value }) => `
 <div class="row gap-xsmall align-center justify-between">
 <div class="row gap-xsmall align-center">

--- a/sandbox/native-web/components/common/Metric.js
+++ b/sandbox/native-web/components/common/Metric.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 
 const sizes = {

--- a/sandbox/native-web/components/common/Notification.js
+++ b/sandbox/native-web/components/common/Notification.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { StatusWarningSmall } from '../../icons/StatusWarningSmall';
 
 export const Notification = ({

--- a/sandbox/native-web/components/common/NotificationMetric.js
+++ b/sandbox/native-web/components/common/NotificationMetric.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { StatusCritical } from '../../icons/StatusCritical';
 import { StatusOk } from '../../icons/StatusOk';

--- a/sandbox/native-web/components/common/PageHeader.js
+++ b/sandbox/native-web/components/common/PageHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const PageHeader = ({
   title,
   actions,

--- a/sandbox/native-web/components/common/index.js
+++ b/sandbox/native-web/components/common/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './DashboardCard';
 export * from './Legend';
 export * from './Metric';

--- a/sandbox/native-web/components/dashboard/BillingSummary.js
+++ b/sandbox/native-web/components/dashboard/BillingSummary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { DashboardCard } from '../common/DashboardCard';
 import { Notification } from '../common/Notification';

--- a/sandbox/native-web/components/dashboard/DeviceSummary.js
+++ b/sandbox/native-web/components/dashboard/DeviceSummary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { DashboardCard } from '../common/DashboardCard';
 import { Legend } from '../common/Legend';

--- a/sandbox/native-web/components/dashboard/ExpiringSubscriptions.js
+++ b/sandbox/native-web/components/dashboard/ExpiringSubscriptions.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { DashboardCard } from '../common/DashboardCard';
 import { Notification } from '../common/Notification';
 import mockData from '../../mockData/mockData.json';

--- a/sandbox/native-web/components/dashboard/Learn.js
+++ b/sandbox/native-web/components/dashboard/Learn.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { DashboardCard } from '../common/DashboardCard';
 import mockData from '../../mockData/mockData.json';
 

--- a/sandbox/native-web/components/dashboard/MonthlyCharges.js
+++ b/sandbox/native-web/components/dashboard/MonthlyCharges.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { DashboardCard } from '../common/DashboardCard';
 import { Notification } from '../common/Notification';

--- a/sandbox/native-web/components/dashboard/Notifications.js
+++ b/sandbox/native-web/components/dashboard/Notifications.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { DashboardCard } from '../common/DashboardCard';
 import { NotificationMetric } from '../common/NotificationMetric';
 import mockData from '../../mockData/mockData.json';

--- a/sandbox/native-web/components/dashboard/QuickActions.js
+++ b/sandbox/native-web/components/dashboard/QuickActions.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const QuickActions = ({ actions }) => `<div class="gap-medium">
 <div class="row align-center justify-between">
   <h2>Quick actions</h2>

--- a/sandbox/native-web/components/dashboard/RecentServices.js
+++ b/sandbox/native-web/components/dashboard/RecentServices.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import mockData from '../../mockData/mockData.json';
 
 const dates = [

--- a/sandbox/native-web/components/dashboard/Recommended.js
+++ b/sandbox/native-web/components/dashboard/Recommended.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import mockData from '../../mockData/mockData.json';
 import { DashboardCard } from '../common/DashboardCard';
 

--- a/sandbox/native-web/components/dashboard/SustainabilityOverview.js
+++ b/sandbox/native-web/components/dashboard/SustainabilityOverview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { DashboardCard } from '../common/DashboardCard';
 import { Notification } from '../common/Notification';

--- a/sandbox/native-web/components/dashboard/UserOverview.js
+++ b/sandbox/native-web/components/dashboard/UserOverview.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 import { DashboardCard } from '../common/DashboardCard';
 import { Legend } from '../common/Legend';

--- a/sandbox/native-web/components/dashboard/index.js
+++ b/sandbox/native-web/components/dashboard/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './BillingSummary';
 export * from './DeviceSummary';
 export * from './ExpiringSubscriptions';

--- a/sandbox/native-web/components/index.js
+++ b/sandbox/native-web/components/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './common';
 export * from './dashboard';

--- a/sandbox/native-web/icons/AppsRounded.js
+++ b/sandbox/native-web/icons/AppsRounded.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const AppsRounded = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/Checkmark.js
+++ b/sandbox/native-web/icons/Checkmark.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const Checkmark = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/HPEGreenLakeBadge.js
+++ b/sandbox/native-web/icons/HPEGreenLakeBadge.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 
 export const HPEGreenLakeBadge =

--- a/sandbox/native-web/icons/LinkNext.js
+++ b/sandbox/native-web/icons/LinkNext.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const LinkNext = ({
   color = 'primary',
   size = 'medium',

--- a/sandbox/native-web/icons/StatusCritical.js
+++ b/sandbox/native-web/icons/StatusCritical.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const StatusCritical = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/StatusCriticalSmall.js
+++ b/sandbox/native-web/icons/StatusCriticalSmall.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const StatusCriticalSmall = ({
   color = '#000',

--- a/sandbox/native-web/icons/StatusInfo.js
+++ b/sandbox/native-web/icons/StatusInfo.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const StatusInfo = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/StatusInfoSmall.js
+++ b/sandbox/native-web/icons/StatusInfoSmall.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const StatusInfoSmall = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 12 12"
 a11yTitle="Status is info"

--- a/sandbox/native-web/icons/StatusOk.js
+++ b/sandbox/native-web/icons/StatusOk.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const StatusOk = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/StatusOkSmall.js
+++ b/sandbox/native-web/icons/StatusOkSmall.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const StatusOkSmall = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 12 12"
 a11yTitle="Status is ok"

--- a/sandbox/native-web/icons/StatusWarning.js
+++ b/sandbox/native-web/icons/StatusWarning.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const StatusWarning = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"
 a11yTitle="Status is warning"

--- a/sandbox/native-web/icons/StatusWarningSmall.js
+++ b/sandbox/native-web/icons/StatusWarningSmall.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const StatusWarningSmall = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 12 12"
 a11yTitle="Status is warning"

--- a/sandbox/native-web/icons/Sun.js
+++ b/sandbox/native-web/icons/Sun.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const Sun = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/User.js
+++ b/sandbox/native-web/icons/User.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const User = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/UserAdd.js
+++ b/sandbox/native-web/icons/UserAdd.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable max-len */
 export const UserAdd = ({ color = '#000', size = 'medium' }) => `<svg
 viewBox="0 0 24 24"

--- a/sandbox/native-web/icons/index.js
+++ b/sandbox/native-web/icons/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppsRounded';
 export * from './LinkNext';
 export * from './StatusCritical';

--- a/sandbox/native-web/main.js
+++ b/sandbox/native-web/main.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import 'hpe-design-tokens/dist/css/primitives.css';
 import 'hpe-design-tokens/dist/css/color.light.css';
 import 'hpe-design-tokens/dist/css/color.dark.css';

--- a/sandbox/native-web/utils.js
+++ b/sandbox/native-web/utils.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const toggleThemeMode = element => {
   const handleChange = () => {
     if (element.getAttribute('id') === 'lightMode') {

--- a/sandbox/tailwind-app/eslint.config.mjs
+++ b/sandbox/tailwind-app/eslint.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';

--- a/sandbox/tailwind-app/postcss.config.js
+++ b/sandbox/tailwind-app/postcss.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export default {
   plugins: {
     tailwindcss: {},

--- a/sandbox/tailwind-app/src/App.jsx
+++ b/sandbox/tailwind-app/src/App.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /* eslint-disable react/prop-types */
 import './App.css';
 import React from 'react';

--- a/sandbox/tailwind-app/src/components/Button/Button.jsx
+++ b/sandbox/tailwind-app/src/components/Button/Button.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // eslint-disable-next-line react/prop-types
 export const Button = ({ label, kind = 'default', ...rest }) => {
   return (

--- a/sandbox/tailwind-app/src/components/Button/index.js
+++ b/sandbox/tailwind-app/src/components/Button/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { Button } from './Button';

--- a/sandbox/tailwind-app/src/main.jsx
+++ b/sandbox/tailwind-app/src/main.jsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';

--- a/sandbox/tailwind-app/tailwind.config-full.js
+++ b/sandbox/tailwind-app/tailwind.config-full.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [],

--- a/sandbox/tailwind-app/tailwind.config.js
+++ b/sandbox/tailwind-app/tailwind.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // import hpeConfig from 'design-tokens/dist/tailwind/tailwind.config.js';
 
 /** @type {import('tailwindcss').Config} */

--- a/sandbox/tailwind-app/vite.config.js
+++ b/sandbox/tailwind-app/vite.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 

--- a/scripts/telemetry-status.mjs
+++ b/scripts/telemetry-status.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 
 import fs from 'fs';
 import path from 'path';

--- a/scripts/telemetry-status.mjs
+++ b/scripts/telemetry-status.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
-
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/scripts/telemetry-write.mjs
+++ b/scripts/telemetry-write.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 
 import fs from 'fs';
 import path from 'path';

--- a/scripts/telemetry-write.mjs
+++ b/scripts/telemetry-write.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
-
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/scripts/validate-capability-manifests.mjs
+++ b/scripts/validate-capability-manifests.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/shared/aries-core/.storybook/darkModeHooks.js
+++ b/shared/aries-core/.storybook/darkModeHooks.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect } from 'react';
 import { addons } from 'storybook/preview-api';
 import { DARK_MODE_EVENT_NAME } from '@vueless/storybook-dark-mode';

--- a/shared/aries-core/.storybook/main.mjs
+++ b/shared/aries-core/.storybook/main.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { join, dirname, resolve } from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';

--- a/shared/aries-core/.storybook/manager.js
+++ b/shared/aries-core/.storybook/manager.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { addons } from 'storybook/manager-api';
 
 addons.setConfig({

--- a/shared/aries-core/.storybook/preview.mjs
+++ b/shared/aries-core/.storybook/preview.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Grommet, Box } from 'grommet';
 import { hpe as hpeStable } from 'grommet-theme-hpe';

--- a/shared/aries-core/babel.config.js
+++ b/shared/aries-core/babel.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 module.exports = function(api) {
   api.cache(true);
 

--- a/shared/aries-core/eslint.config.mjs
+++ b/shared/aries-core/eslint.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';

--- a/shared/aries-core/jest.config.js
+++ b/shared/aries-core/jest.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: [

--- a/shared/aries-core/src/js/components/core/Identifier/Identifier.js
+++ b/shared/aries-core/src/js/components/core/Identifier/Identifier.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Text } from 'grommet';

--- a/shared/aries-core/src/js/components/core/Identifier/index.js
+++ b/shared/aries-core/src/js/components/core/Identifier/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { Identifier } from './Identifier';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavContainer.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import { Box, ThemeType } from 'grommet';
 import { ThemeContext } from 'styled-components';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavHeader.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/NavHeader.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Button, Heading } from 'grommet';
 import { Sidebar as SidebarIcon } from '@hpe-design/icons-grommet';
 import { useEffect, useState } from 'react';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/index.ts
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavContainer/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavContainer';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavGroup/GroupHeading.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavGroup/GroupHeading.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from 'grommet';
 import { NavItemWithLevel } from '../NavList';
 

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavGroup/NavGroup.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavGroup/NavGroup.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 import { NavItemWithLevel } from '../NavList';
 import { GroupHeading } from './GroupHeading';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavGroup/index.ts
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavGroup/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavGroup';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/ActiveMarker.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/ActiveMarker.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 
 interface ActiveMarkerProps {

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/ItemContainer.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/ItemContainer.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box } from 'grommet';
 import { ActiveMarker } from './ActiveMarker';
 

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/ItemLabel.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/ItemLabel.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Box, Text } from 'grommet';
 

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/NavItem.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/NavItem.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Button } from 'grommet';
 import { ItemContainer } from './ItemContainer';
 import { ItemLabel } from './ItemLabel';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/index.ts
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavItem/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavItem';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavList.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavList.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { AnnounceContext, Collapsible, List } from 'grommet';
 import { Down, Up } from '@hpe-design/icons-grommet';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/NavigationMenu.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/NavigationMenu.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useEffect, useMemo, useState } from 'react';
 import { type BoxProps, Nav } from 'grommet';
 import { NavItemType } from './NavItem';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/__tests__/NavigationMenu.test.tsx
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/__tests__/NavigationMenu.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';

--- a/shared/aries-core/src/js/components/core/NavigationMenu/index.ts
+++ b/shared/aries-core/src/js/components/core/NavigationMenu/index.ts
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './NavigationMenu';
 export * from './NavItem';

--- a/shared/aries-core/src/js/components/core/Popover/Popover.js
+++ b/shared/aries-core/src/js/components/core/Popover/Popover.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Button, Drop } from 'grommet';
 import { Close } from '@hpe-design/icons-grommet';
 

--- a/shared/aries-core/src/js/components/core/Popover/index.js
+++ b/shared/aries-core/src/js/components/core/Popover/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Popover';

--- a/shared/aries-core/src/js/components/core/RangeSelector/RangeSelector.js
+++ b/shared/aries-core/src/js/components/core/RangeSelector/RangeSelector.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { RangeSelector } from 'grommet';

--- a/shared/aries-core/src/js/components/core/RangeSelector/index.js
+++ b/shared/aries-core/src/js/components/core/RangeSelector/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { RangeSelector } from './RangeSelector';

--- a/shared/aries-core/src/js/components/core/ScreenReaderOnly/ScreenReaderOnly.tsx
+++ b/shared/aries-core/src/js/components/core/ScreenReaderOnly/ScreenReaderOnly.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export const ScreenReaderOnly: React.FC<React.PropsWithChildren<object>> = ({
   children,
 }) => {

--- a/shared/aries-core/src/js/components/core/ScreenReaderOnly/index.ts
+++ b/shared/aries-core/src/js/components/core/ScreenReaderOnly/index.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ScreenReaderOnly';

--- a/shared/aries-core/src/js/components/core/Selector/Selector.js
+++ b/shared/aries-core/src/js/components/core/Selector/Selector.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/shared/aries-core/src/js/components/core/Selector/SelectorGroup.js
+++ b/shared/aries-core/src/js/components/core/Selector/SelectorGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Grid } from 'grommet';

--- a/shared/aries-core/src/js/components/core/Selector/SelectorHeader.js
+++ b/shared/aries-core/src/js/components/core/Selector/SelectorHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { cloneElement, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text, ThemeContext } from 'grommet';

--- a/shared/aries-core/src/js/components/core/Selector/index.js
+++ b/shared/aries-core/src/js/components/core/Selector/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Selector';
 export * from './SelectorGroup';

--- a/shared/aries-core/src/js/components/core/Tile/Tile.js
+++ b/shared/aries-core/src/js/components/core/Tile/Tile.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 

--- a/shared/aries-core/src/js/components/core/Tile/index.js
+++ b/shared/aries-core/src/js/components/core/Tile/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { Tile } from './Tile';

--- a/shared/aries-core/src/js/components/core/Tiles/Tiles.js
+++ b/shared/aries-core/src/js/components/core/Tiles/Tiles.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Grid } from 'grommet';

--- a/shared/aries-core/src/js/components/core/Tiles/index.js
+++ b/shared/aries-core/src/js/components/core/Tiles/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { Tiles } from './Tiles';

--- a/shared/aries-core/src/js/components/core/index.js
+++ b/shared/aries-core/src/js/components/core/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Identifier';
 export * from './NavigationMenu/index.ts';
 export * from './Popover';

--- a/shared/aries-core/src/js/components/helpers/Anchors/Anchor.js
+++ b/shared/aries-core/src/js/components/helpers/Anchors/Anchor.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Anchor as GrommetAnchor, Box, Text } from 'grommet';

--- a/shared/aries-core/src/js/components/helpers/Anchors/AnchorCallToAction.js
+++ b/shared/aries-core/src/js/components/helpers/Anchors/AnchorCallToAction.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Anchor } from 'grommet';

--- a/shared/aries-core/src/js/components/helpers/Anchors/AnchorGroup.js
+++ b/shared/aries-core/src/js/components/helpers/Anchors/AnchorGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ResponsiveContext } from 'grommet';

--- a/shared/aries-core/src/js/components/helpers/Anchors/NavLink.js
+++ b/shared/aries-core/src/js/components/helpers/Anchors/NavLink.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Anchor, Text } from 'grommet';

--- a/shared/aries-core/src/js/components/helpers/Anchors/index.js
+++ b/shared/aries-core/src/js/components/helpers/Anchors/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './Anchor';
 export * from './AnchorCallToAction';
 export * from './AnchorGroup';

--- a/shared/aries-core/src/js/components/helpers/AppIdentity/AppIdentity.js
+++ b/shared/aries-core/src/js/components/helpers/AppIdentity/AppIdentity.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Text } from 'grommet';

--- a/shared/aries-core/src/js/components/helpers/AppIdentity/AppIdentity.tsx
+++ b/shared/aries-core/src/js/components/helpers/AppIdentity/AppIdentity.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Text } from 'grommet';

--- a/shared/aries-core/src/js/components/helpers/AppIdentity/index.js
+++ b/shared/aries-core/src/js/components/helpers/AppIdentity/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export { AppIdentity } from './AppIdentity';

--- a/shared/aries-core/src/js/components/helpers/index.js
+++ b/shared/aries-core/src/js/components/helpers/index.js
@@ -1,2 +1,4 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppIdentity';
 export * from './Anchors';

--- a/shared/aries-core/src/js/components/index.js
+++ b/shared/aries-core/src/js/components/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './core';
 export * from './helpers';
 export * from './layouts';

--- a/shared/aries-core/src/js/components/layouts/ActionMenu/ActionMenu.js
+++ b/shared/aries-core/src/js/components/layouts/ActionMenu/ActionMenu.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Menu } from 'grommet';

--- a/shared/aries-core/src/js/components/layouts/ActionMenu/index.js
+++ b/shared/aries-core/src/js/components/layouts/ActionMenu/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ActionMenu';

--- a/shared/aries-core/src/js/components/layouts/ButtonGroup/ButtonGroup.js
+++ b/shared/aries-core/src/js/components/layouts/ButtonGroup/ButtonGroup.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Box, ThemeContext } from 'grommet';

--- a/shared/aries-core/src/js/components/layouts/ButtonGroup/index.js
+++ b/shared/aries-core/src/js/components/layouts/ButtonGroup/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ButtonGroup';

--- a/shared/aries-core/src/js/components/layouts/EmptyState/EmptyState.js
+++ b/shared/aries-core/src/js/components/layouts/EmptyState/EmptyState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Paragraph } from 'grommet';

--- a/shared/aries-core/src/js/components/layouts/EmptyState/index.js
+++ b/shared/aries-core/src/js/components/layouts/EmptyState/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './EmptyState';

--- a/shared/aries-core/src/js/components/layouts/Layer/LayerHeader.js
+++ b/shared/aries-core/src/js/components/layouts/Layer/LayerHeader.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Header, Heading, Paragraph } from 'grommet';

--- a/shared/aries-core/src/js/components/layouts/Layer/index.js
+++ b/shared/aries-core/src/js/components/layouts/Layer/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './LayerHeader';

--- a/shared/aries-core/src/js/components/layouts/ModalDialog/ModalDialog.js
+++ b/shared/aries-core/src/js/components/layouts/ModalDialog/ModalDialog.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { Box, Footer, Layer } from 'grommet';
 import { LayerHeader } from '../Layer';

--- a/shared/aries-core/src/js/components/layouts/ModalDialog/index.js
+++ b/shared/aries-core/src/js/components/layouts/ModalDialog/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ModalDialog';

--- a/shared/aries-core/src/js/components/layouts/index.js
+++ b/shared/aries-core/src/js/components/layouts/index.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './ActionMenu';
 export * from './ButtonGroup';
 export * from './EmptyState';

--- a/shared/aries-core/src/js/components/typography/TextEmphasis.js
+++ b/shared/aries-core/src/js/components/typography/TextEmphasis.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Text } from 'grommet';
 
 export const TextEmphasis = ({ ...rest }) => {

--- a/shared/aries-core/src/js/components/typography/index.js
+++ b/shared/aries-core/src/js/components/typography/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './TextEmphasis';

--- a/shared/aries-core/src/js/index.d.ts
+++ b/shared/aries-core/src/js/index.d.ts
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './components';

--- a/shared/aries-core/src/js/index.js
+++ b/shared/aries-core/src/js/index.js
@@ -1,1 +1,3 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './components';

--- a/shared/aries-core/src/js/setupTests.ts
+++ b/shared/aries-core/src/js/setupTests.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import '@testing-library/jest-dom';
 
 // Mock for matchMedia which is used by Grommet

--- a/shared/aries-core/src/stories/codeBlocks.stories.js
+++ b/shared/aries-core/src/stories/codeBlocks.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CodeBlockExample } from 'apps/docs/src/examples/templates/code-blocks/CodeBlocks';
 import CodeBlockExampleSource from 'apps/docs/src/examples/templates/code-blocks/CodeBlocks.js?raw';

--- a/shared/aries-core/src/stories/components/Accordion.stories.tsx
+++ b/shared/aries-core/src/stories/components/Accordion.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Accordion, AccordionPanel, Box } from 'grommet';

--- a/shared/aries-core/src/stories/components/Anchor.stories.tsx
+++ b/shared/aries-core/src/stories/components/Anchor.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import { Anchor, AnchorType } from 'grommet';

--- a/shared/aries-core/src/stories/components/Avatar.stories.tsx
+++ b/shared/aries-core/src/stories/components/Avatar.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Avatar } from 'grommet';

--- a/shared/aries-core/src/stories/components/Box.stories.tsx
+++ b/shared/aries-core/src/stories/components/Box.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import { Box, Text, BoxTypes } from 'grommet';

--- a/shared/aries-core/src/stories/components/Button.stories.tsx
+++ b/shared/aries-core/src/stories/components/Button.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Button } from 'grommet';

--- a/shared/aries-core/src/stories/components/Card.stories.tsx
+++ b/shared/aries-core/src/stories/components/Card.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import {

--- a/shared/aries-core/src/stories/components/CheckBox.stories.tsx
+++ b/shared/aries-core/src/stories/components/CheckBox.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { CheckBox } from 'grommet';

--- a/shared/aries-core/src/stories/components/CheckBoxGroup.stories.tsx
+++ b/shared/aries-core/src/stories/components/CheckBoxGroup.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { CheckBoxGroup } from 'grommet';

--- a/shared/aries-core/src/stories/components/DateInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/DateInput.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Box, DateInput } from 'grommet';

--- a/shared/aries-core/src/stories/components/FileInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/FileInput.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { FileInput } from 'grommet';

--- a/shared/aries-core/src/stories/components/Footer.stories.tsx
+++ b/shared/aries-core/src/stories/components/Footer.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import { Footer, Text, Box, Button, BoxTypes } from 'grommet';

--- a/shared/aries-core/src/stories/components/Grid.stories.tsx
+++ b/shared/aries-core/src/stories/components/Grid.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import { Grid, Box, Text, GridExtendedProps, BoxExtendedProps } from 'grommet';

--- a/shared/aries-core/src/stories/components/Header.stories.tsx
+++ b/shared/aries-core/src/stories/components/Header.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import { Header, Button, Avatar, Box, Text, HeaderExtendedProps } from 'grommet';

--- a/shared/aries-core/src/stories/components/Layer.stories.tsx
+++ b/shared/aries-core/src/stories/components/Layer.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { StoryObj } from '@storybook/react-webpack5';
 import { Layer, Box, Button, Heading, Text, LayerExtendedProps } from 'grommet';

--- a/shared/aries-core/src/stories/components/Main.stories.tsx
+++ b/shared/aries-core/src/stories/components/Main.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Main, Heading, Text, BoxExtendedProps } from 'grommet';
 import type { StoryObj } from '@storybook/react-webpack5';

--- a/shared/aries-core/src/stories/components/MaskedInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/MaskedInput.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { MaskedInput } from 'grommet';

--- a/shared/aries-core/src/stories/components/Menu.stories.tsx
+++ b/shared/aries-core/src/stories/components/Menu.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Menu } from 'grommet';

--- a/shared/aries-core/src/stories/components/NameValueList.stories.tsx
+++ b/shared/aries-core/src/stories/components/NameValueList.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { NameValueList, NameValuePair } from 'grommet';

--- a/shared/aries-core/src/stories/components/Notification.stories.tsx
+++ b/shared/aries-core/src/stories/components/Notification.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Notification } from 'grommet';

--- a/shared/aries-core/src/stories/components/Page.stories.tsx
+++ b/shared/aries-core/src/stories/components/Page.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Page, PageContent, PageHeader, Heading, Paragraph, PageExtendedProps } from 'grommet';
 import type { StoryObj } from '@storybook/react-webpack5';

--- a/shared/aries-core/src/stories/components/Pagination.stories.tsx
+++ b/shared/aries-core/src/stories/components/Pagination.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Pagination } from 'grommet';

--- a/shared/aries-core/src/stories/components/RadioButtonGroup.stories.tsx
+++ b/shared/aries-core/src/stories/components/RadioButtonGroup.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { RadioButtonGroup } from 'grommet';

--- a/shared/aries-core/src/stories/components/RangeInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/RangeInput.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';

--- a/shared/aries-core/src/stories/components/Select.stories.tsx
+++ b/shared/aries-core/src/stories/components/Select.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Select } from 'grommet';

--- a/shared/aries-core/src/stories/components/SelectMultiple.stories.tsx
+++ b/shared/aries-core/src/stories/components/SelectMultiple.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { SelectMultiple } from 'grommet';

--- a/shared/aries-core/src/stories/components/Skeleton.stories.tsx
+++ b/shared/aries-core/src/stories/components/Skeleton.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Skeleton } from 'grommet';

--- a/shared/aries-core/src/stories/components/Spinner.stories.tsx
+++ b/shared/aries-core/src/stories/components/Spinner.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Spinner } from 'grommet';

--- a/shared/aries-core/src/stories/components/Tabs.stories.tsx
+++ b/shared/aries-core/src/stories/components/Tabs.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Tabs, Tab, Text, Box } from 'grommet';

--- a/shared/aries-core/src/stories/components/Tag.stories.tsx
+++ b/shared/aries-core/src/stories/components/Tag.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Tag } from 'grommet';

--- a/shared/aries-core/src/stories/components/TextArea.stories.tsx
+++ b/shared/aries-core/src/stories/components/TextArea.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { TextArea } from 'grommet';

--- a/shared/aries-core/src/stories/components/TextInput.stories.tsx
+++ b/shared/aries-core/src/stories/components/TextInput.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { TextInput } from 'grommet';

--- a/shared/aries-core/src/stories/components/Tip.stories.tsx
+++ b/shared/aries-core/src/stories/components/Tip.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Button, Tip } from 'grommet';

--- a/shared/aries-core/src/stories/components/ToggleGroup.stories.tsx
+++ b/shared/aries-core/src/stories/components/ToggleGroup.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { ToggleGroup } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/Data.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/Data.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataTable, DataTableProps, Text, Box, Meter } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataFilter.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataFilter.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataFilter, DataTable } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataFilters.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataFilters.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataFilter, DataFilters, DataTable } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataSearch.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataSearch.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataSearch, DataTable } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataSort.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataSort.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataSort, DataTable } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataSummary.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataSummary.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataSummary } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataTable.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataTable.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { DataTable, type DataTableProps } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataTableColumns.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataTableColumns.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Box, Data, DataTableColumns, DataTable } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataTableGroupBy.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataTableGroupBy.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataTableGroupBy, DataTable } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/DataView.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/DataView.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataView, DataTable, Toolbar } from 'grommet';

--- a/shared/aries-core/src/stories/components/data/Toolbar.stories.tsx
+++ b/shared/aries-core/src/stories/components/data/Toolbar.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { Data, DataSearch, DataSort, DataTable, Toolbar } from 'grommet';

--- a/shared/aries-core/src/stories/dashboards.stories.js
+++ b/shared/aries-core/src/stories/dashboards.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { DashboardExample } from 'apps/docs/src/examples/templates/dashboards/DashboardExample';
 import { ThreeColumnDashboard } from 'apps/docs/src/examples/templates/dashboards';

--- a/shared/aries-core/src/stories/dataTableCustomization.stories.js
+++ b/shared/aries-core/src/stories/dataTableCustomization.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { ColumnSettingsExample } from 'apps/docs/src/examples/templates/table-customization/components/ColumnSettingsExample';
 import { TableCustomizationExample } from 'apps/docs/src/examples/templates/table-customization/components/TableCustomizationExample';

--- a/shared/aries-core/src/stories/emptyState.stories.js
+++ b/shared/aries-core/src/stories/emptyState.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { ActionEmptyState } from 'apps/docs/src/examples/templates/empty-state/ActionEmptyState';
 import { CardEmptyState } from 'apps/docs/src/examples/templates/empty-state/CardEmptyState';

--- a/shared/aries-core/src/stories/filtering.stories.js
+++ b/shared/aries-core/src/stories/filtering.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { FilteringCards } from 'apps/docs/src/examples/templates/filtering/FilteringCards/FilteringCards';
 import { FilteringTable } from 'apps/docs/src/examples/templates/filtering/FilteringTable/FilteringTable';

--- a/shared/aries-core/src/stories/forms.stories.js
+++ b/shared/aries-core/src/stories/forms.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { ChangePasswordExample } from 'apps/docs/src/examples/templates/forms/ChangePasswordExample';
 import { CharacterCounterExample } from 'apps/docs/src/examples/templates/forms/CharacterCounterExample';

--- a/shared/aries-core/src/stories/globalNotifications.stories.js
+++ b/shared/aries-core/src/stories/globalNotifications.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { BannerContentLayoutExample } from 'apps/docs/src/examples/templates/global-banner-notifications/BannerContentLayoutExample';
 import { BannerNotificationCritical } from 'apps/docs/src/examples/templates/global-banner-notifications/Examples/BannerNotificationCritical';

--- a/shared/aries-core/src/stories/inlineNotifications.stories.js
+++ b/shared/aries-core/src/stories/inlineNotifications.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { FormValidation } from 'apps/docs/src/examples/templates/inline-notifications/InlineFormValidation';
 import { InlineNotificationExample } from 'apps/docs/src/examples/templates/inline-notifications/InlineNotificationExample';

--- a/shared/aries-core/src/stories/lists.stories.js
+++ b/shared/aries-core/src/stories/lists.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { ListIconIdentifierExample } from 'apps/docs/src/examples/templates/list-views/ListIconIdentifierExample';
 import { ListImageIdentifierExample } from 'apps/docs/src/examples/templates/list-views/ListImageIdentifierExample';

--- a/shared/aries-core/src/stories/managingChildObjects.stories.js
+++ b/shared/aries-core/src/stories/managingChildObjects.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { CreateCluster } from 'apps/docs/src/examples/templates/forms/managing-child-objects/CreateCluster';
 import { CreateRole } from 'apps/docs/src/examples/templates/forms/managing-child-objects/CreateRole';

--- a/shared/aries-core/src/stories/navigation/NavigationMenuExample.tsx
+++ b/shared/aries-core/src/stories/navigation/NavigationMenuExample.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Page, PageContent, PageHeader } from 'grommet';
 import { useSessionStorage } from '@shared/hooks';
 import { AppShell, NavigationPanel, navItems } from './content';

--- a/shared/aries-core/src/stories/navigation/NavigationMenuSubheadings.tsx
+++ b/shared/aries-core/src/stories/navigation/NavigationMenuSubheadings.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Page, PageContent, PageHeader } from 'grommet';
 import { useSessionStorage } from '@shared/hooks';
 import { AppShell, NavigationPanel, navItemsSubheadings } from './content';

--- a/shared/aries-core/src/stories/navigation/content/AppHeader.tsx
+++ b/shared/aries-core/src/stories/navigation/content/AppHeader.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Button, Header, Text } from 'grommet';
 import { ContextControls } from './ContextControls';
 

--- a/shared/aries-core/src/stories/navigation/content/AppShell.tsx
+++ b/shared/aries-core/src/stories/navigation/content/AppShell.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useRef } from 'react';
 import { Box, Grid, Main, ResponsiveContext, type BoxProps } from 'grommet';
 import { AppHeader } from './AppHeader';

--- a/shared/aries-core/src/stories/navigation/content/ContextControls.tsx
+++ b/shared/aries-core/src/stories/navigation/content/ContextControls.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Button } from 'grommet';
 import { AIGen, Help, User } from '@hpe-design/icons-grommet';
 import { ButtonGroup } from '../../../js/components';

--- a/shared/aries-core/src/stories/navigation/content/ContextPane.tsx
+++ b/shared/aries-core/src/stories/navigation/content/ContextPane.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, BoxProps, Button, Header, Heading } from 'grommet';
 import { Genie } from './Genie';
 import { Help } from './Help';

--- a/shared/aries-core/src/stories/navigation/content/Genie.tsx
+++ b/shared/aries-core/src/stories/navigation/content/Genie.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Paragraph } from 'grommet';
 
 export const Genie = ({ ...rest }) => {

--- a/shared/aries-core/src/stories/navigation/content/Help.tsx
+++ b/shared/aries-core/src/stories/navigation/content/Help.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Paragraph } from 'grommet';
 
 export const Help = ({ ...rest }) => {

--- a/shared/aries-core/src/stories/navigation/content/LayerHeader.tsx
+++ b/shared/aries-core/src/stories/navigation/content/LayerHeader.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Button, Header, Heading } from 'grommet';
 import { Sidebar } from '@hpe-design/icons-grommet';
 

--- a/shared/aries-core/src/stories/navigation/content/NavigationPanel.tsx
+++ b/shared/aries-core/src/stories/navigation/content/NavigationPanel.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useContext, useEffect, useState } from 'react';
 import { Box, Button, Layer, ResponsiveContext } from 'grommet';
 import { Sidebar } from '@hpe-design/icons-grommet';

--- a/shared/aries-core/src/stories/navigation/content/UserPreferences.tsx
+++ b/shared/aries-core/src/stories/navigation/content/UserPreferences.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Box, Paragraph } from 'grommet';
 
 export const UserPreferences = ({ ...rest }) => {

--- a/shared/aries-core/src/stories/navigation/content/index.ts
+++ b/shared/aries-core/src/stories/navigation/content/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 export * from './AppHeader';
 export * from './AppShell';
 export * from './Genie';

--- a/shared/aries-core/src/stories/navigation/content/nav-items.tsx
+++ b/shared/aries-core/src/stories/navigation/content/nav-items.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   Apps,
   Storage,

--- a/shared/aries-core/src/stories/navigation/navigation.stories.tsx
+++ b/shared/aries-core/src/stories/navigation/navigation.stories.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { NavigationMenuExample } from './NavigationMenuExample';
 import { NavigationMenuSubheadings } from './NavigationMenuSubheadings';
 // ts-expect-error is intentional: TypeScript can't resolve webpack's ?raw query syntax.

--- a/shared/aries-core/src/stories/popover.stories.js
+++ b/shared/aries-core/src/stories/popover.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { PopoverInlineExample } from 'apps/docs/src/examples/templates/popover/PopoverInlineExample';
 import { PopoverSimpleExample } from 'apps/docs/src/examples/templates/popover/PopoverSimpleExample';

--- a/shared/aries-core/src/stories/selector.stories.js
+++ b/shared/aries-core/src/stories/selector.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { SimpleSelector } from 'apps/docs/src/examples/templates/selector/SelectorSimple';
 import { QuickFilter as QuickFilterExample } from 'apps/docs/src/examples/templates/selector/QuickFilter';

--- a/shared/aries-core/src/stories/utils/commonArgs.tsx
+++ b/shared/aries-core/src/stories/utils/commonArgs.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { colors, hpe } from 'grommet-theme-hpe';
 import * as Icons from '@hpe-design/icons-grommet';

--- a/shared/aries-core/src/stories/wizard.stories.js
+++ b/shared/aries-core/src/stories/wizard.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TwoColumnWizardExample } from 'apps/docs/src/examples/templates/wizard/TwoColumnWizardExample';
 import { WizardValidationExample } from 'apps/docs/src/examples/templates/wizard/WizardValidationExample';

--- a/shared/aries-core/tools/release-stable.js
+++ b/shared/aries-core/tools/release-stable.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import dotenv from 'dotenv';
 import del from 'del';
 import fs from 'fs-extra';

--- a/shared/aries-core/webpack.config.js
+++ b/shared/aries-core/webpack.config.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/shared/hooks/__tests__/useInert.test.tsx
+++ b/shared/hooks/__tests__/useInert.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { useLayoutEffect } from 'react';
 import { cleanup, render, screen, renderHook } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, describe, it, expect } from 'vitest';

--- a/shared/hooks/__tests__/useLocalStorage.test.ts
+++ b/shared/hooks/__tests__/useLocalStorage.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useLocalStorage } from '../src/useLocalStorage';

--- a/shared/hooks/__tests__/useSessionStorage.test.ts
+++ b/shared/hooks/__tests__/useSessionStorage.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useSessionStorage } from '../src/useSessionStorage';

--- a/shared/hooks/__tests__/useThemePreview.test.ts
+++ b/shared/hooks/__tests__/useThemePreview.test.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { buildThemePreview, useThemePreview } from '../src/useThemePreview';

--- a/shared/hooks/eslint.config.mjs
+++ b/shared/hooks/eslint.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';

--- a/shared/hooks/src/__tests__/setup.ts
+++ b/shared/hooks/src/__tests__/setup.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 const mockSessionStorage = (() => {
   let store: Record<string, string> = {};
 

--- a/shared/hooks/src/external-modules.d.ts
+++ b/shared/hooks/src/external-modules.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 declare module 'grommet-theme-hpe/dist/es6/themes/hpe.js' {
   export function buildTheme(
     tokens: unknown,

--- a/shared/hooks/src/index.ts
+++ b/shared/hooks/src/index.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // Main entry point for @shared/hooks package
 export { useInert } from './useInert';
 export { useLocalStorage } from './useLocalStorage';

--- a/shared/hooks/src/useInert.ts
+++ b/shared/hooks/src/useInert.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { RefObject, useEffect, useRef } from 'react';

--- a/shared/hooks/src/useLocalStorage.ts
+++ b/shared/hooks/src/useLocalStorage.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useEffect, useState } from 'react';

--- a/shared/hooks/src/useSessionStorage.ts
+++ b/shared/hooks/src/useSessionStorage.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useEffect, useState } from 'react';

--- a/shared/hooks/src/useThemePreview.ts
+++ b/shared/hooks/src/useThemePreview.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+
 'use client';
 
 import { useMemo } from 'react';

--- a/shared/hooks/vitest.config.ts
+++ b/shared/hooks/vitest.config.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-INSERT_PR_#_HERE--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
- Adds license header text to set of remaining files in the Stacked PRs

#### What are the relevant issues?
relates to https://github.com/grommet/hpe-design-system/issues/6360

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>