### PR TITLE
[Docs] Text input refactor

### DIFF
--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadDefaultSuggestionPreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadDefaultSuggestionPreview.js
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Form, FormField, TextInput } from 'grommet';
+
+export const TextInputBadDefaultSuggestionPreview = () => (
+  <Form>
+    <FormField
+      label="Favorite fruit"
+      htmlFor="bad-default-suggestion"
+      name="fruit"
+    >
+      {/* Don't use defaultSuggestion — it causes unexpected context changes
+          for screen reader users */}
+      <TextInput
+        id="bad-default-suggestion"
+        name="fruit"
+        placeholder="Start typing…"
+        suggestions={['Apples', 'Bananas', 'Blueberries', 'Grapes', 'Oranges']}
+        defaultSuggestion={0}
+      />
+    </FormField>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadMultiLinePreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadMultiLinePreview.js
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Form, FormField, TextInput } from 'grommet';
+
+export const TextInputBadMultiLinePreview = () => (
+  <Form>
+    <FormField
+      label="Description"
+      htmlFor="bad-multi-line"
+      name="description"
+    >
+      {/* Don't use TextInput for content that needs multiple lines — use
+          TextArea */}
+      <TextInput
+        id="bad-multi-line"
+        name="description"
+         placeholder={
+           'Enter a detailed description including ' +
+           'steps to reproduce...'
+         }
+      />
+    </FormField>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadPatternPreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadPatternPreview.js
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Form, FormField, TextInput } from 'grommet';
+
+export const TextInputBadPatternPreview = () => (
+  <Form>
+    <FormField
+      label="Phone number"
+      htmlFor="bad-pattern-phone"
+      name="phone"
+    >
+      {/* Don't use plain TextInput for pattern-constrained values — use
+          MaskedInput */}
+      <TextInput
+        id="bad-pattern-phone"
+        name="phone"
+        placeholder="(xxx) xxx-xxxx"
+      />
+    </FormField>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadPlaceholderOnlyPreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputBadPlaceholderOnlyPreview.js
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Box, Form, TextInput } from 'grommet';
+
+export const TextInputBadPlaceholderOnlyPreview = () => (
+  <Form>
+    <Box pad={{ horizontal: 'xsmall' }}>
+      {/* Don't rely on placeholder as the only label — it disappears on input
+          and fails accessibility */}
+      <TextInput
+        id="bad-placeholder-only"
+        name="email"
+        placeholder="Email address"
+        type="email"
+      />
+    </Box>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodLabeledPreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodLabeledPreview.js
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Form, FormField, TextInput } from 'grommet';
+
+export const TextInputGoodLabeledPreview = () => (
+  <Form>
+    <FormField
+      label="Email address"
+      htmlFor="good-labeled-email"
+      name="email"
+    >
+      <TextInput
+        id="good-labeled-email"
+        name="email"
+        placeholder="e.g. jane@example.com"
+        type="email"
+      />
+    </FormField>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodMaskedInputPreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodMaskedInputPreview.js
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Form, FormField, MaskedInput } from 'grommet';
+
+const maskPhone = [
+  { fixed: '(' },
+  { length: 3, regexp: /^[0-9]{1,3}$/, placeholder: 'xxx' },
+  { fixed: ')' },
+  { fixed: ' ' },
+  { length: 3, regexp: /^[0-9]{1,3}$/, placeholder: 'xxx' },
+  { fixed: '-' },
+  { length: 4, regexp: /^[0-9]{1,4}$/, placeholder: 'xxxx' },
+];
+
+export const TextInputGoodMaskedInputPreview = () => (
+  <Form>
+    <FormField
+      label="Phone number"
+      htmlFor="good-masked-phone"
+      name="phone"
+    >
+      <MaskedInput
+        id="good-masked-phone"
+        name="phone"
+        mask={maskPhone}
+      />
+    </FormField>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodSingleLinePreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodSingleLinePreview.js
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Form, FormField, TextInput } from 'grommet';
+
+export const TextInputGoodSingleLinePreview = () => (
+  <Form>
+    <FormField label="Full name" htmlFor="good-single-line" name="fullName">
+      <TextInput
+        id="good-single-line"
+        name="fullName"
+        placeholder="e.g. Jane Smith"
+      />
+    </FormField>
+  </Form>
+);

--- a/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodSuggestionsPreview.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/TextInputGoodSuggestionsPreview.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { Form, FormField, TextInput } from 'grommet';
+
+const allFruits = ['Apples', 'Bananas', 'Blueberries', 'Grapes', 'Oranges'];
+
+export const TextInputGoodSuggestionsPreview = () => {
+  const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState(allFruits);
+
+  const onChange = event => {
+    const next = event.target.value;
+    setValue(next);
+    if (next) {
+      const regexp = new RegExp(next, 'i');
+      setSuggestions(allFruits.filter(f => regexp.test(f)));
+    } else {
+      setSuggestions(allFruits);
+    }
+  };
+
+  return (
+    <Form>
+      <FormField
+        label="Favorite fruit"
+        htmlFor="good-suggestions"
+        name="fruit"
+      >
+        <TextInput
+          id="good-suggestions"
+          name="fruit"
+          placeholder="Start typing…"
+          value={value}
+          onChange={onChange}
+          suggestions={suggestions}
+          onSuggestionSelect={({ suggestion }) => setValue(suggestion)}
+        />
+      </FormField>
+    </Form>
+  );
+};

--- a/apps/docs/src/examples/components/textinput/DosDonts/index.js
+++ b/apps/docs/src/examples/components/textinput/DosDonts/index.js
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+export * from './TextInputGoodSingleLinePreview';
+export * from './TextInputBadMultiLinePreview';
+export * from './TextInputGoodMaskedInputPreview';
+export * from './TextInputBadPatternPreview';
+export * from './TextInputGoodLabeledPreview';
+export * from './TextInputBadPlaceholderOnlyPreview';
+export * from './TextInputGoodSuggestionsPreview';
+export * from './TextInputBadDefaultSuggestionPreview';

--- a/apps/docs/src/examples/components/textinput/index.js
+++ b/apps/docs/src/examples/components/textinput/index.js
@@ -7,3 +7,4 @@ export * from './TextInputPasswordExample';
 export * from './TextInputReadOnlyExample';
 export * from './TextInputSuggestionsExample';
 export * from './TextInputValidationExample';
+export * from './DosDonts';

--- a/apps/docs/src/pages/components/textinput.mdx
+++ b/apps/docs/src/pages/components/textinput.mdx
@@ -1,12 +1,25 @@
-import { AccessibilitySection, Example } from '../../layouts';
+import { Checkmark } from '@hpe-design/icons-grommet';
 import {
-  TextInputExample,
+  AccessibilitySection,
+  BestPracticeGroup,
+  Example,
+} from '../../layouts';
+import {
   TextInputDisabledExample,
+  TextInputExample,
   TextInputLabeledByExample,
   TextInputPasswordExample,
   TextInputReadOnlyExample,
   TextInputSuggestionsExample,
   TextInputValidationExample,
+  TextInputGoodSingleLinePreview,
+  TextInputBadMultiLinePreview,
+  TextInputGoodMaskedInputPreview,
+  TextInputBadPatternPreview,
+  TextInputGoodLabeledPreview,
+  TextInputBadPlaceholderOnlyPreview,
+  TextInputGoodSuggestionsPreview,
+  TextInputBadDefaultSuggestionPreview,
 } from '../../examples';
 
 <Example
@@ -20,25 +33,111 @@ import {
   <TextInputExample />
 </Example>
 
-## Guidance
+## Use cases
 
-The TextInput component allows the user to input shorter forms of data and content. Passwords and tags can also be used with the TextInput component. Style can be variable, based upon the use case and customer need that will elicit user confidence in success.
+### Entering short free-form text
 
-## About TextInput
+Use TextInput for short, single-line fields such as names, email addresses, and usernames where the user types a value directly. Place the TextInput inside a `FormField` with a visible label — for example, a `FormField` labeled "Username" with a `TextInput` that has matching `id` and `name` attributes — so that the label is correctly paired with the input for all users. Provide `placeholder` text as a supplemental hint about the expected format, such as `"e.g. jane@example.com"`, but never as a substitute for the label. As the user types, the controlled value updates via `onChange`; submitting the enclosing `Form` collects and passes the value to the `onSubmit` handler.
 
-Text input fields perform text validation. Some use cases for TextInput include username fields, password fields, and search fields. In some cases, it may be beneficial to use an icon to reinforce the context. One example when an icon would be useful would be a search input.
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputExample />
+</Example>
 
-There are many ways to give the user hints about how to properly fill out a text input. In addition to the label, placeholder text can help guide the user. When you want to place syntax restrictions on the input, such as an email address or phone number, consider using [MaskedInput](/components/maskedinput).
+### Masking credentials with a password field
 
-A TextInput display the following states: enabled, focused, focused with value, validation, and disabled.
+Apply `type="password"` to prevent typed characters from appearing on screen, protecting passwords, PINs, and other sensitive credentials from shoulder-surfing. Place the TextInput inside a `FormField` with a visible label such as "Password" so screen readers announce the field purpose before the user begins typing. Control the value with `useState` and update it via `onChange` on each keystroke. When the user submits the enclosing `Form`, the masked value is included in the form data.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputPasswordExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputPasswordExample />
+</Example>
+
+### Surfacing autocomplete suggestions
+
+Use the `suggestions` prop to present a drop-down list of options below the input, helping users discover valid values or recall previously entered ones. The user types inside a `FormField` — for example, a field labeled "Favorite fruit" — and a suggestion drop appears with options such as "Apples", "Oranges", and "Bananas". The list can be a static array or dynamically filtered on each keystroke by updating the array in response to `onChange`. The user presses Arrow Down / Up to navigate the list, Enter to select a suggestion and close the drop, or Escape to dismiss without selecting.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputSuggestionsExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputSuggestionsExample />
+</Example>
+
+### Labeling an input with an icon
+
+Use an icon as the sole accessible name for a TextInput when a visible text label would be inappropriate — for example, a search field in a header or toolbar where space is constrained. Assign a unique `id` to the icon element and reference it on the TextInput via `aria-labelledby` — for example, `<Search id="search-icon" />` paired with `aria-labelledby="search-icon"` on the input. Apply `reverse` to position the icon on the trailing edge of the field. Screen readers announce the icon's accessible label; sighted users recognize the field's purpose from the familiar icon shape alone.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputLabeledByExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputLabeledByExample />
+</Example>
+
+### Displaying a read-only value
+
+Apply `readOnly` when the application needs to surface a pre-populated value that the user should not modify in the current context — for example, a locked profile email on a confirmation screen, or a field that becomes editable only after the user explicitly enables edit mode. Place the TextInput inside a `FormField` with a visible label such as "Email" and set the `value` prop to the pre-populated string, for example `"testemail@abc.com"`. Unlike a disabled input, a read-only input still receives tab focus and its value is included in form submission data.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputReadOnlyExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputReadOnlyExample />
+</Example>
+
+### Copying a read-only value to the clipboard
+
+Apply `readOnlyCopy` when users are expected to copy and paste the displayed value into another system — such as an API key, a generated access token, or an account identifier. This combines read-only behavior with a copy-to-clipboard button rendered inside the right edge of the input. Place the TextInput inside a `FormField` labeled "API Key" with a static value such as `"abc123-example-token"`. When the user clicks the copy button, the value is copied to the clipboard immediately without requiring the user to manually select text.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputReadOnlyExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputReadOnlyExample />
+</Example>
+
+## Anatomy
+
+{/* TODO: Add anatomy diagram image */}
+
+| Label  | Region               | Purpose                                                                                                                    |                         Required                         | Notes                                                                                                                                    |
+| :----: | -------------------- | -------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------: | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **1**  | **Input field**      | The interactive area where the user types text.                                                                            | <span><Checkmark a11yTitle="true" size="small" /></span> | --                                                                                                                                       |
+| **1a** | **Placeholder text** | Hints at the expected value or format when the input is empty.                                                             |                         Optional                         | Does not meet accessibility requirements alone. Always pair with a visible label or `aria-labelledby`.                                   |
+| **1b** | **Icon**             | Provides a visual cue about the input's purpose or serves as the accessible label in icon-labeled variants.                |                         Optional                         | --                                                                                                                                       |
+| **1c** | **Copy button**      | Copies the read-only value to the clipboard.                                                                               |                         Optional                         | Only rendered when `readOnlyCopy` is true.                                                                                               |
+| **2**  | **Label**            | Identifies the purpose of the input to all users, including screen reader users.                                           | <span><Checkmark a11yTitle="true" size="small" /></span> | Rendered by the enclosing `FormField`. If TextInput is used outside a `FormField`, supply an `aria-labelledby` attribute instead.        |
+| **3**  | **Suggestions drop** | Displays autocomplete options below the input when the `suggestions` prop is provided.                                     |                         Optional                         | --                                                                                                                                       |
+| **4**  | **Validation message** | Communicates a field error to the user.                                                                                  |                         Optional                         | Rendered by the enclosing `FormField`'s `error` prop.                                                                                    |
 
 ## Variants
 
-A TextInput's visual state informs the user of its ability to be interacted with or if any validation errors have occured.
+### Default
+
+Standard text input inside a `FormField` with a visible label. Use any time a user needs to enter short free-form text — names, email addresses, or identifiers — within a form.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputExample />
+</Example>
 
 ### Password
 
-Used to maintain the privacy of the password, PIN, or any credentials allowing access to an account a user has entered. This is achieved by applying type="password" to the TextInput.
+Masks the typed value so credentials remain private. Apply `type="password"` to the TextInput. Use for password fields, PIN entry, or any credential field where the typed value must not be visible on screen.
 
 <Example
   docs="https://v2.grommet.io/textinput?theme=hpe#props"
@@ -50,7 +149,7 @@ Used to maintain the privacy of the password, PIN, or any credentials allowing a
 
 ### With suggestions
 
-Used to prompt users with available options or suggestions. Suggestions may persist regardless of what the user has entered or may be filtered based on what the user has typed. One common use case for suggestions would be to display prior values for the same field.
+Presents an autocomplete drop with a list of options below the input. Suggestions may be static or dynamically filtered as the user types. Use when prior values, known options, or filtered matches can guide the user — such as a recurring-value field or a search field with known result types.
 
 <Example
   docs="https://v2.grommet.io/textinput?theme=hpe#props"
@@ -62,7 +161,7 @@ Used to prompt users with available options or suggestions. Suggestions may pers
 
 ### Labeled by icon
 
-Some situations may need TextInput without a visual label, such as when implementing a search field. To meet accessibility requirements, the TextInput may be labeled by another visual context such as an icon with an id.
+Omits a visible text label and instead uses an icon with a matching `id` as the accessible name via `aria-labelledby`. Use in space-constrained contexts where a visible text label is not appropriate, such as a standalone search field in a header or toolbar.
 
 <Example
   docs="https://v2.grommet.io/textinput?theme=hpe#props"
@@ -74,7 +173,7 @@ Some situations may need TextInput without a visual label, such as when implemen
 
 ### Validation
 
-Used to indicate that a TextInput does not meet the validation requirements of its bounding FormField. Click the Validate button while the TextInput is empty to see the validation state.
+Displays an error state when the field fails `FormField` validation requirements. The error message is surfaced by the enclosing `FormField`'s `error` prop. Use for any TextInput that has required or format constraints and must communicate a validation failure to the user.
 
 <Example
   docs="https://v2.grommet.io/textinput?theme=hpe#props"
@@ -86,7 +185,7 @@ Used to indicate that a TextInput does not meet the validation requirements of i
 
 ### Disabled
 
-Used to indicate that a TextInput cannot be interacted with. When an input is disabled, it will not receive tab focus and will not be submitted with form data.
+Prevents user interaction. A disabled TextInput does not receive tab focus and is not submitted with form data. Use when a field's value is not applicable or available in the current application state.
 
 <Example
   docs="https://v2.grommet.io/textinput?theme=hpe#props"
@@ -96,11 +195,9 @@ Used to indicate that a TextInput cannot be interacted with. When an input is di
   <TextInputDisabledExample />
 </Example>
 
-### Readonly
+### Read-only
 
-Used to indicate that a TextInput cannot be edited. When an input is readonly, it will still receive tab focus and be submitted with form data.
-
-Apply `readOnlyCopy` to TextInput to display a copy button in the input.
+Displays an existing value the user should not edit. Unlike disabled, a read-only input still receives tab focus and its value is submitted with form data. Use when a value is pre-populated and should be visible but not changed by the user in the current context, such as a confirmation screen or a locked profile field.
 
 <Example
   docs="https://v2.grommet.io/textinput?theme=hpe#props"
@@ -110,17 +207,155 @@ Apply `readOnlyCopy` to TextInput to display a copy button in the input.
   <TextInputReadOnlyExample />
 </Example>
 
+### Read-only with copy
+
+Combines `readOnly` behavior with a copy-to-clipboard button rendered inside the input. Use when displaying values users are expected to copy and paste, such as API keys, generated tokens, or account identifiers.
+
+<Example
+  docs="https://v2.grommet.io/textinput?theme=hpe#props"
+  code="https://raw.githubusercontent.com/grommet/hpe-design-system/master/apps/docs/src/examples/components/textinput/TextInputReadOnlyExample.js"
+  height={{ min: 'small' }}
+>
+  <TextInputReadOnlyExample />
+</Example>
+
+## Dos and don'ts
+
+<BestPracticeGroup>
+  <Example
+    bestPractice={{
+      type: 'do',
+      message: 'Use TextInput for short, single-line text entry.',
+    }}
+  >
+    <TextInputGoodSingleLinePreview />
+  </Example>
+  <Example
+    bestPractice={{
+      type: 'dont',
+      message: "Don't use TextInput for longer, multi-line text. Use TextArea instead.",
+    }}
+  >
+    <TextInputBadMultiLinePreview />
+  </Example>
+</BestPracticeGroup>
+
+<BestPracticeGroup>
+  <Example
+    bestPractice={{
+      type: 'do',
+      message:
+        'Use MaskedInput for values that must conform to a specific pattern, such as phone numbers or dates.',
+    }}
+  >
+    <TextInputGoodMaskedInputPreview />
+  </Example>
+  <Example
+    bestPractice={{
+      type: 'dont',
+      message:
+        "Don't use TextInput when input must conform to a specific pattern such as a phone number or date. Use MaskedInput instead.",
+    }}
+  >
+    <TextInputBadPatternPreview />
+  </Example>
+</BestPracticeGroup>
+
+<BestPracticeGroup>
+  <Example
+    bestPractice={{
+      type: 'do',
+      message:
+        'Always pair placeholder text with a visible label or aria-labelledby to meet accessibility requirements.',
+    }}
+  >
+    <TextInputGoodLabeledPreview />
+  </Example>
+  <Example
+    bestPractice={{
+      type: 'dont',
+      message:
+        "Don't use placeholder text as a substitute for a visible label. Placeholder alone fails accessibility requirements.",
+    }}
+  >
+    <TextInputBadPlaceholderOnlyPreview />
+  </Example>
+</BestPracticeGroup>
+
+<BestPracticeGroup>
+  <Example
+    bestPractice={{
+      type: 'do',
+      message:
+        'Order suggestions so the most relevant or likely options appear at the top.',
+    }}
+  >
+    <TextInputGoodSuggestionsPreview />
+  </Example>
+  <Example
+    bestPractice={{
+      type: 'dont',
+      message:
+        "Don't use the defaultSuggestion prop. It can cause unexpected context changes for screen reader users and fails WCAG 3.2.1.",
+    }}
+  >
+    <TextInputBadDefaultSuggestionPreview />
+  </Example>
+</BestPracticeGroup>
+
+## Behaviors and states
+
+### Interactive states
+
+- **Rest**: The input displays its label and placeholder text with default styling, indicating it is available for interaction.
+- **Hover**: A border highlight appears to signal the input is interactive and ready to receive focus.
+- **Focus**: A visible focus ring appears when the input is focused via keyboard or pointer, indicating the user can type.
+- **Active**: The user is actively typing; the cursor is positioned inside the field.
+
+### Application states
+
+- **Disabled**: Apply the `disabled` prop to prevent all interaction. The input is visually muted, does not receive tab focus, and its value is excluded from form submission.
+- **Read-only**: Apply `readOnly` or `readOnlyCopy` to display a value the user cannot edit. The field still receives tab focus and its value is submitted with the form.
+- **Error**: When the enclosing `FormField` receives an `error` prop, a validation message appears below the input and `aria-invalid="true"` is applied to the input element.
+
+### Data states
+
+- **Empty**: The input shows `placeholder` text when it has no value, hinting at the expected input format.
+- **Has value**: The input displays the current controlled or uncontrolled value the user has entered.
+
 ## Accessibility
 
-In every case possible, TextInput should be used inside of a FormField to ensure that a label is appropriately paired with the input. This behavior is important to screen reader users who need to know to which context the TextInput is referring.
+Always place TextInput inside a `FormField` to ensure the label is correctly paired with the input for screen reader users.
 
-If you need to use TextInput outside of the context of a FormField, it is important to make sure the TextInput is labeled in an alternate way to meet accessibility requirements. One approach is to use another visual indicator, such as the TextInput's icon, to serve as the label. See how this is done in the [Labeled by icon](#labeled-by-icon) example.
+Placeholder text alone does not meet accessibility label requirements. Use it only as a supplement to a visible label or `aria-labelledby`.
 
-Placeholder text does not serve as a sufficient means of meeting accessibility requirements for labels. To meet accessbility requirements, placeholder text should be used in conjunction with a label or aria-labelledby attribute.
+### Keyboard navigation
 
-While Grommet's TextInput supports a `defaultSuggestion` prop, it is not recommended for use because it can lead to potential "context changes" on screen readers such as VoiceOver. This would fail [WCAG 3.2.1](https://www.w3.org/TR/WCAG22/#on-focus).
+| Key              | Action                                                             |
+| ---------------- | ------------------------------------------------------------------ |
+| Tab              | Moves focus into or out of the input field                         |
+| Arrow Down / Up  | Moves focus through suggestions when the suggestions drop is open  |
+| Enter            | Selects the highlighted suggestion                                 |
+| Escape           | Closes the suggestions drop without selecting                      |
 
-Instead, order the suggestions such that the most relevant or likely are at the top.
+### ARIA
+
+| Attribute          | Value                        | Condition                                                                                                       |
+| ------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `aria-labelledby`  | id of the labeling element   | When TextInput is used outside a `FormField` and relies on an icon or other visual element as its accessible name |
+| `aria-invalid`     | `true`                       | When the enclosing `FormField` is in an error or validation state                                               |
+| `aria-disabled`    | `true`                       | When the `disabled` prop is true                                                                                |
+
+### Screen reader announcements
+
+| Trigger              | Message                  |
+| -------------------- | ------------------------ |
+| Suggestion selected  | Selected &#123;suggestion&#125;.   |
+
+### Notes
+
+- Avoid using the `defaultSuggestion` prop. It can produce unexpected context changes for screen reader users and fails WCAG 3.2.1 (On Focus).
+- When suggestions are used, order them so the most relevant or likely options appear at the top rather than relying on `defaultSuggestion`.
 
 ### WCAG compliance
 

--- a/apps/docs/todos/DEPRECATED-textinput.md
+++ b/apps/docs/todos/DEPRECATED-textinput.md
@@ -1,0 +1,88 @@
+# DEPRECATED — TextInput
+
+Content from `apps/docs/src/pages/components/textinput.mdx.bak` that was intentionally NOT
+carried over to the new `textinput.mdx` because it is considered deprecated, replaced, or
+superseded by a richer structured alternative.
+
+---
+
+## Deprecated items
+
+### 1. `## Guidance` section
+
+**Original content (removed entirely):**
+> The TextInput component allows the user to input shorter forms of data and content. Passwords and tags can also be used with the TextInput component. Style can be variable, based upon the use case and customer need that will elicit user confidence in success.
+
+**Reason removed:** Generic one-paragraph summary with no actionable guidance. The reference to
+"tags" is no longer surfaced anywhere in the docs (tag entry is not a first-class promoted
+pattern). The phrase "style can be variable, based upon the use case and customer need that will
+elicit user confidence in success" added no actionable information. Replaced by the detailed,
+use-case-driven structure of the new `## Use cases` section.
+
+---
+
+### 2. `## About TextInput` section
+
+**Original content (removed entirely):**
+> Text input fields perform text validation. Some use cases for TextInput include username fields, password fields, and search fields. In some cases, it may be beneficial to use an icon to reinforce the context. One example when an icon would be useful would be a search input.
+>
+> There are many ways to give the user hints about how to properly fill out a text input. In addition to the label, placeholder text can help guide the user. When you want to place syntax restrictions on the input, such as an email address or phone number, consider using [MaskedInput](/components/maskedinput).
+>
+> A TextInput display the following states: enabled, focused, focused with value, validation, and disabled.
+
+**Reason removed:** Free-form introductory narrative. Its substance was redistributed:
+- Per-use-case descriptions now appear under `## Use cases`.
+- The MaskedInput callout was converted to a Dos and don'ts example.
+- States are now enumerated precisely in the `## Behaviors and states` section.
+
+---
+
+### 3. Variants section intro paragraph
+
+**Original content (removed entirely):**
+> A TextInput's visual state informs the user of its ability to be interacted with or if any validation errors have occured.
+
+**Reason removed:** Surface-level transition sentence with a typo ("occured"). Each variant in
+the new MDX is now self-described with a dedicated `when` statement, making this opener redundant.
+
+---
+
+### 4. `## Accessibility` freeform prose paragraphs
+
+**Original content (removed entirely):**
+> In every case possible, TextInput should be used inside of a FormField to ensure that a label is appropriately paired with the input. This behavior is important to screen reader users who need to know to which context the TextInput is referring.
+>
+> If you need to use TextInput outside of the context of a FormField, it is important to make sure the TextInput is labeled in an alternate way to meet accessibility requirements. One approach is to use another visual indicator, such as the TextInput's icon, to serve as the label. See how this is done in the [Labeled by icon](#labeled-by-icon) example.
+>
+> Placeholder text does not serve as a sufficient means of meeting accessibility requirements for labels. To meet accessbility requirements, placeholder text should be used in conjunction with a label or aria-labelledby attribute.
+>
+> While Grommet's TextInput supports a `defaultSuggestion` prop, it is not recommended for use because it can lead to potential "context changes" on screen readers such as VoiceOver. This would fail [WCAG 3.2.1](https://www.w3.org/TR/WCAG22/#on-focus).
+>
+> Instead, order the suggestions such that the most relevant or likely are at the top.
+
+**Reason removed:** Informal narrative prose replaced by the structured `## Accessibility`
+section, which includes:
+- A keyboard navigation table (`### Keyboard navigation`)
+- An ARIA attributes table (`### ARIA`)
+- A screen reader announcements table (`### Screen reader announcements`)
+- A dedicated `### Notes` subsection for the `defaultSuggestion` warning
+- A Dos and don'ts example pair for the `defaultSuggestion` anti-pattern
+
+All substantive guidance was preserved; only the unstructured prose format was deprecated.
+
+---
+
+### 5. Combined `### Readonly` variant (single section for both readOnly and readOnlyCopy)
+
+**Original content (removed):**
+> ### Readonly
+>
+> Used to indicate that a TextInput cannot be edited. When an input is readonly, it will still receive tab focus and be submitted with form data.
+>
+> Apply `readOnlyCopy` to TextInput to display a copy button in the input.
+
+**Reason removed:** `readOnly` and `readOnlyCopy` were collapsed into one "Readonly" section with
+a single example. In the new MDX these are split into separate `### Read-only` and
+`### Read-only with copy` variants, each with a distinct description and dedicated use case
+entry. The combined format is deprecated in favor of the split structure that more clearly
+distinguishes the two behaviors.

--- a/apps/docs/todos/TODO-textinput.md
+++ b/apps/docs/todos/TODO-textinput.md
@@ -1,0 +1,58 @@
+# TODO — TextInput
+
+Content gaps in `apps/docs/src/pages/components/textinput.mdx` that require human attention.
+
+---
+
+## Checklist
+
+- [ ] **1. Anatomy diagram image**
+  Add an actual anatomy diagram to replace the placeholder comment on line ~112:
+  ```
+  {/* TODO: Add anatomy diagram image */}
+  ```
+  The anatomy table already exists and is complete; only the visual diagram is missing.
+  See `apps/docs/src/pages/components/menu.mdx` (`<MenuAnatomy />`) for the expected pattern.
+  **File:** `apps/docs/src/pages/components/textinput.mdx`
+
+- [ ] **2. Dedicated `TextInputReadOnlyCopyExample` example**
+  Both the `### Read-only` and `### Read-only with copy` Variants sections, as well as the
+  "Copying a read-only value to the clipboard" Use cases section, currently point to the same
+  example file (`TextInputReadOnlyExample.js`) and render the same component (`<TextInputReadOnlyExample />`).
+  A dedicated `TextInputReadOnlyCopyExample.js` is needed to demonstrate the `readOnlyCopy` prop
+  and copy-to-clipboard interaction specifically.
+  - Create: `apps/docs/src/examples/components/textinput/TextInputReadOnlyCopyExample.js`
+  - Update: import and `<Example code=...>` blocks in the Use cases and Variants sections of
+    `apps/docs/src/pages/components/textinput.mdx`
+
+- [ ] **3. `onSelect` callback not demonstrated**
+  The YAML (`knowledge/core/data/components/textinput.yaml`) documents an `onSelect` prop
+  (fires when the user selects a suggestion from the drop), but no coded example exercises it.
+  The existing `TextInputSuggestionsExample.js` should be updated, or a new example added,
+  to show `onSelect` in action (e.g. display the selected value or trigger a side-effect).
+  **File:** `apps/docs/src/examples/components/textinput/TextInputSuggestionsExample.js`
+
+- [ ] **4. `icon` prop left-side placement not shown**
+  The YAML documents the `icon` prop with a note that `reverse` positions it on the right
+  (right-side is the only placement demonstrated in the "Labeled by icon" variant).
+  No example shows the icon in its default left-side position.
+  Consider adding a left-side icon use case or a note in the Variants section clarifying
+  when to use each placement.
+  **File:** `apps/docs/src/pages/components/textinput.mdx`
+
+- [ ] **5. Content guidelines section absent**
+  `apps/docs/src/pages/components/menu.mdx` has a `## Content guidelines` section with
+  guidance on writing effective labels, descriptions, and naming conventions.
+  The textinput MDX has no equivalent. Consider adding guidance on:
+  - Writing good `FormField` label text (clear, concise, action-oriented)
+  - Best practices for `placeholder` text wording (supplemental, not instructional)
+  - Appropriate label text when using `aria-labelledby` with an icon
+  **File:** `apps/docs/src/pages/components/textinput.mdx`
+
+- [ ] **6. Additional `type` values not demonstrated**
+  The YAML documents the `type` prop as accepting `"email"`, `"text"`, `"search"`, `"tel"`,
+  and `"url"` in addition to `"password"`, but only `type="password"` has a dedicated example.
+  At minimum, add a note or callout in the relevant Use cases or Variants section directing
+  users to apply the correct `type` for built-in browser validation and mobile keyboard
+  optimization (e.g. `type="email"` for email fields, `type="tel"` for phone fields).
+  **File:** `apps/docs/src/pages/components/textinput.mdx`

--- a/knowledge/capabilities/docs-refactor/plan.md
+++ b/knowledge/capabilities/docs-refactor/plan.md
@@ -78,7 +78,7 @@ The orchestrator detects the current pipeline stage, confirms before making any 
 - [ ] tabs
 - [ ] tag
 - [ ] textarea
-- [ ] textinput
+- [x] textinput
 - [ ] tip
 - [ ] togglegroup
 - [ ] toolbar

--- a/knowledge/core/data/components/textinput.yaml
+++ b/knowledge/core/data/components/textinput.yaml
@@ -1,0 +1,394 @@
+id: textinput
+name: TextInput
+description: >-
+  Allows the user to input shorter forms of data and content. Common use cases
+  include username fields, password fields, and search fields.
+links:
+  designer: >-
+    https://designer.grommet.io/textinput?id=HPE-design-system-hpedesignsystem-hpe-com&mode=edit
+  docs: https://v2.grommet.io/textinput?theme=hpe#props
+  figma: >-
+    https://www.figma.com/design/HDckqS2MWhINfC8EIQPMV1/HPE-Design-System-Components-V2?m=auto&node-id=3026-1767&t=ZqPsisuevR3KPp96-1
+  grommetSource: >-
+    https://github.com/grommet/grommet/blob/master/src/js/components/TextInput/TextInput.js
+props:
+  - name: type
+    type: string
+    required: false
+    description: >-
+      HTML input type attribute. Use "password" to mask credential input. Other
+      common values include "email", "text", "search", "tel", and "url".
+  - name: placeholder
+    type: string
+    required: false
+    description: >-
+      Hint text displayed inside the input when it has no value. Does not
+      satisfy accessibility label requirements on its own; always pair with a
+      FormField label or aria-labelledby.
+  - name: value
+    type: string
+    required: false
+    description: Controlled value of the input.
+  - name: onChange
+    type: (event: React.ChangeEvent<HTMLInputElement>) => void
+    required: false
+    description: Callback fired when the input value changes.
+  - name: onSelect
+    type: (event: { suggestion: string }) => void
+    required: false
+    description: Callback fired when the user selects a suggestion from the drop.
+  - name: suggestions
+    type: "string[] | { label: React.ReactNode, value?: string }[]"
+    required: false
+    description: >-
+      Array of autocomplete suggestions to display below the input. May be
+      static or dynamically filtered based on the current input value.
+  - name: disabled
+    type: boolean
+    required: false
+    description: >-
+      Prevents interaction with the input. A disabled input does not receive tab
+      focus and is not submitted with form data.
+  - name: readOnly
+    type: boolean
+    required: false
+    description: >-
+      Makes the input non-editable. Unlike disabled, a read-only input still
+      receives tab focus and its value is submitted with form data.
+  - name: readOnlyCopy
+    type: boolean
+    required: false
+    description: >-
+      Applies readOnly behavior and adds a copy button inside the input,
+      allowing users to copy the value to the clipboard.
+  - name: icon
+    type: React.ReactNode
+    required: false
+    description: >-
+      Icon rendered inside the input field. Useful for reinforcing context
+      (e.g., a Search icon). When used as the sole accessible label, assign an
+      id to the icon and reference it via aria-labelledby on the input.
+  - name: reverse
+    type: boolean
+    required: false
+    description: >-
+      When true, positions the icon on the right side of the input instead of
+      the default left.
+  - name: id
+    type: string
+    required: false
+    description: >-
+      HTML id attribute. Should match the htmlFor on the associated FormField
+      label for proper accessibility pairing.
+  - name: name
+    type: string
+    required: false
+    description: >-
+      HTML name attribute. Used to identify the field in form submission data
+      and to pair it with the enclosing FormField.
+usage:
+  whenToUse:
+    - Use for short, free-form text entry such as usernames, email addresses,
+      and search queries.
+    - Use type="password" to mask credentials (passwords, PINs).
+    - Use suggestions to surface prior values or available options for a field.
+    - Add an icon to reinforce the purpose of the input (e.g., a Search icon
+      for search fields).
+    - Use readOnly when the value must be visible but not editable.
+    - Use readOnlyCopy when users may need to copy the displayed value.
+  whenToAvoid:
+    - Do not use TextInput for longer, multi-line text entry — use TextArea.
+    - Do not use TextInput when input must conform to a specific pattern such as
+      a phone number or date — use MaskedInput instead.
+    - Do not use placeholder text as a substitute for a visible label or
+      aria-labelledby. Placeholder alone fails accessibility requirements.
+    - Avoid using the defaultSuggestion prop; it can trigger unexpected context
+      changes for screen reader users and fails WCAG 3.2.1.
+variants:
+  - name: default
+    description: >-
+      Standard text input inside a FormField with a visible label. The most
+      common usage pattern.
+    when: >-
+      Any time a user needs to enter short free-form text — names, email
+      addresses, identifiers — within a form.
+    example: |
+      <Form>
+        <FormField name="username" label="Label" htmlFor="username">
+          <TextInput
+            id="username"
+            name="username"
+            placeholder="Placeholder text"
+            type="email"
+          />
+        </FormField>
+      </Form>
+  - name: password
+    description: >-
+      Masks the typed value so credentials remain private. Achieved by applying
+      type="password" to the TextInput.
+    when: >-
+      Password fields, PIN entry, or any credential field where the value must
+      not be visible on screen.
+    example: |
+      <Form>
+        <FormField name="password" label="Password" htmlFor="password">
+          <TextInput
+            id="password"
+            name="password"
+            placeholder="Placeholder text"
+            type="password"
+            value={password}
+            onChange={event => setPassword(event.target.value)}
+          />
+        </FormField>
+      </Form>
+  - name: with-suggestions
+    description: >-
+      Presents an autocomplete drop with a list of options below the input.
+      Suggestions may be static or dynamically filtered as the user types.
+    when: >-
+      When prior values, known options, or filtered matches can guide the user —
+      e.g., a recurring-value field or a search field with known result types.
+    example: |
+      <Form>
+        <FormField label="Favorite fruit" name="fruit" htmlFor="fruit-input">
+          <TextInput
+            id="fruit-input"
+            name="fruit"
+            placeholder="Placeholder text"
+            suggestions={['Apples', 'Oranges', 'Bananas']}
+          />
+        </FormField>
+      </Form>
+  - name: labeled-by-icon
+    description: >-
+      Omits a visible text label and instead uses an icon with a matching id as
+      the accessible name via aria-labelledby. Meets accessibility requirements
+      without a visible label.
+    when: >-
+      Space-constrained contexts where a visible text label is not appropriate,
+      such as a standalone search field in a header or toolbar.
+    example: |
+      <TextInput
+        placeholder="Search"
+        icon={<Search id="search-icon" />}
+        aria-labelledby="search-icon"
+        reverse
+      />
+  - name: validation
+    description: >-
+      Displays an error state when the field fails FormField validation
+      requirements. The error message is surfaced by the enclosing FormField.
+    when: >-
+      Any TextInput that has required or format constraints and must communicate
+      a validation failure to the user.
+    example: |
+      <Form>
+        <FormField
+          name="required-field"
+          label="Label"
+          htmlFor="required-field"
+          error="Type something to resolve this error."
+          required
+        >
+          <TextInput
+            id="required-field"
+            name="required-field"
+            placeholder="Placeholder text"
+            value={value}
+            onChange={event => setValue(event.target.value)}
+          />
+        </FormField>
+      </Form>
+  - name: disabled
+    description: >-
+      Prevents user interaction. A disabled TextInput does not receive tab focus
+      and is not submitted with form data.
+    when: >-
+      When a field's value is not applicable or available given the current
+      application state, and the user should not be able to interact with it.
+    example: |
+      <Form>
+        <FormField name="disabled-field" label="Label" htmlFor="disabled-input" disabled>
+          <TextInput
+            id="disabled-input"
+            name="disabled-field"
+            placeholder="Placeholder text"
+            disabled
+          />
+        </FormField>
+      </Form>
+  - name: readonly
+    description: >-
+      Displays an existing value that the user should not edit. Unlike disabled,
+      the field still receives tab focus and its value is submitted with form
+      data.
+    when: >-
+      When a value is pre-populated and should be visible but not changed by the
+      user in the current context, such as a confirmation screen or a locked
+      profile field.
+    example: |
+      <Form>
+        <FormField name="readonly-email" label="Email" htmlFor="readonly-input">
+          <TextInput
+            id="readonly-input"
+            name="readonly-email"
+            value="testemail@abc.com"
+            readOnly
+          />
+        </FormField>
+      </Form>
+  - name: readonly-copy
+    description: >-
+      Combines readOnly with a copy-to-clipboard button rendered inside the
+      input. Useful when users frequently need to copy the displayed value.
+    when: >-
+      Displaying values users are expected to copy and paste, such as API keys,
+      generated tokens, or account identifiers.
+    example: |
+      <Form>
+        <FormField name="api-key" label="API Key" htmlFor="api-key-input">
+          <TextInput
+            id="api-key-input"
+            name="api-key"
+            value="abc123-example-token"
+            readOnlyCopy
+          />
+        </FormField>
+      </Form>
+examples:
+  - description: Basic text input in a FormField
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputExample.js
+  - description: Password input masking credentials
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputPasswordExample.js
+  - description: Static and filtered autocomplete suggestions
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputSuggestionsExample.js
+  - description: Icon-labeled input without a visible text label
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputLabeledByExample.js
+  - description: Validation state triggered by FormField error
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputValidationExample.js
+  - description: Disabled input
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputDisabledExample.js
+  - description: Read-only input and read-only with copy button
+    codeFile: >-
+      apps/docs/src/examples/components/textinput/TextInputReadOnlyExample.js
+anatomy:
+  - label: '1'
+    region: Input field
+    purpose: The interactive area where the user types text.
+    availability: required
+  - label: 1a
+    region: Placeholder text
+    purpose: Hints at the expected value or format when the input is empty.
+    availability: optional
+    notes: >-
+      Does not satisfy accessibility requirements on its own. Must be
+      accompanied by a label or aria-labelledby.
+  - label: 1b
+    region: Icon
+    purpose: >-
+      Provides a visual cue about the input's purpose (e.g., search) or serves
+      as the accessible label in icon-labeled variants.
+    availability: optional
+  - label: 1c
+    region: Copy button
+    purpose: Copies the read-only value to the clipboard.
+    availability: optional
+    notes: Only rendered when readOnlyCopy is true.
+  - label: '2'
+    region: Label
+    purpose: Identifies the purpose of the input to all users including screen reader users.
+    availability: required
+    notes: >-
+      Rendered by the enclosing FormField. If TextInput is used outside a
+      FormField, supply an aria-labelledby attribute.
+  - label: '3'
+    region: Suggestions drop
+    purpose: >-
+      Displays autocomplete options below the input when the suggestions prop is
+      provided.
+    availability: optional
+  - label: '4'
+    region: Validation message
+    purpose: Communicates a field error to the user.
+    availability: optional
+    notes: Rendered by the enclosing FormField's error prop.
+behaviors:
+  interactiveStates:
+    - rest
+    - hover
+    - focus
+    - active
+  applicationStates:
+    - disabled
+    - readonly
+    - error
+  dataStates:
+    - empty
+    - has-value
+accessibility:
+  keyboard:
+    - key: Tab
+      action: Moves focus into or out of the input field
+    - key: Arrow Down/Up
+      action: Moves focus through suggestions when the suggestions drop is open
+    - key: Enter
+      action: Selects the highlighted suggestion
+    - key: Escape
+      action: Closes the suggestions drop without selecting
+  aria:
+    - attribute: aria-labelledby
+      value: id of the labeling element
+      condition: >-
+        When TextInput is used outside a FormField and relies on an icon or
+        other visual element as its label
+    - attribute: aria-invalid
+      value: 'true'
+      condition: When the FormField is in an error/validation state
+    - attribute: aria-disabled
+      value: 'true'
+      condition: When the disabled prop is true
+  announcements:
+    - trigger: Suggestion selected
+      message: Selected {suggestion}.
+  notes:
+    - >-
+      Always place TextInput inside a FormField to ensure the label is correctly
+      paired with the input for screen reader users.
+    - >-
+      Placeholder text alone does not meet accessibility label requirements.
+      Use it only as a supplement to a visible label or aria-labelledby.
+    - >-
+      Avoid using the defaultSuggestion prop. It can produce unexpected context
+      changes for screen reader users and fails WCAG 3.2.1 (On Focus).
+    - >-
+      When suggestions are used, order them so the most relevant or likely
+      options appear at the top rather than relying on defaultSuggestion.
+  wcag:
+    - criterion: 1.3.1 Info and Relationships
+      status: pass
+    - criterion: 1.4.3 Contrast (Minimum)
+      status: pass
+    - criterion: 2.1.1 Keyboard
+      status: pass
+    - criterion: 2.4.7 Focus Visible
+      status: pass
+    - criterion: 3.2.1 On Focus
+      status: conditional
+      notes: >-
+        Do not use defaultSuggestion; it can cause unexpected context changes on
+        focus, failing this criterion.
+    - criterion: 4.1.2 Name, Role, Value
+      status: pass
+relatedComponents:
+  - maskedinput
+  - textarea
+  - select
+  - formfield


### PR DESCRIPTION
<!--- Insert the PR's # for the deploy preview's URL -->
[Deploy Preview](https://deploy-preview-6501--keen-mayer-a86c8b.netlify.app/)

#### What does this PR do?
Implemented the docs refactor workflow to Text Input.

Added:
textinput.yaml: Structured source content extracted from the original docs.
TODO-textinput.md: Remaining documentation follow-up items.
DEPRECATED-textinput.md: Original content identified as deprecated.
Dos and Donts as well as Use case coded examples.

Modified:
textinput.mdx: Rebuilt TextInput documentation page.
textinput.mdx.bak: Original MDX backup, created during the workflow and later deleted.
plan.md: Marks TextInput as complete in the refactor checklist.
index.js: Exports the new do/don’t and use case examples.

#### What are the relevant issues?
None yet, this PR was a result of a demo.
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
