### PR TITLE
[hpe-design-tokens] Updated `update-design-tokens-stable` workflow

### DIFF
--- a/.github/workflows/update-design-tokens-stable.yml
+++ b/.github/workflows/update-design-tokens-stable.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Sync tokens to Figma file
         run: pnpm --filter hpe-design-tokens sync-tokens-to-figma -- --env=production
         env:
+          # required to bypass the CI production-mutation guardrail for this intentional stable sync
+          ALLOW_PRODUCTION_WRITES: 'true'
           FILE_KEY_PRIMITIVE: ${{ secrets.GH_ACTION_FIGMA_FILE_KEY_PRIMITIVE }}
           FILE_KEY_SEMANTIC: ${{ secrets.GH_ACTION_FIGMA_FILE_KEY_SEMANTIC }}
           FILE_KEY_COMPONENT: ${{ secrets.GH_ACTION_FIGMA_FILE_KEY_COMPONENT }}


### PR DESCRIPTION
#### What does this PR do?

This pull request makes a small but important change to the GitHub Actions workflow for syncing design tokens. The change allows the workflow to intentionally bypass the CI production-mutation guardrail during stable syncs.

* [`.github/workflows/update-design-tokens-stable.yml`](diffhunk://#diff-0b05e38cb8feb977adb4fbd24d89db324d56b36191bece628b82235bd9a1d752R45-R46): Added the `ALLOW_PRODUCTION_WRITES` environment variable to enable production writes during the sync-tokens-to-figma job.

