### PR TITLE
Add workflow_dispatch trigger to update-design-tokens-stable

### DIFF
--- a/.github/workflows/update-design-tokens-stable.yml
+++ b/.github/workflows/update-design-tokens-stable.yml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - packages/hpe-design-tokens/**
+  workflow_dispatch: {}
 
 jobs:
   update-design-tokens-stable:


### PR DESCRIPTION
Allows manually re-running this workflow to verify the grommet-theme-hpe tarball pin fix (merged in #6526/#6527) without waiting for a push that touches packages/hpe-design-tokens/**.