### PR TITLE
Fail release-stable step when git push fails instead of silently succeeding

### DIFF
--- a/packages/hpe-design-tokens/src/scripts/release-stable.js
+++ b/packages/hpe-design-tokens/src/scripts/release-stable.js
@@ -45,7 +45,11 @@ if (process.env.CI) {
       .then(() => git(localFolder).add(['--all', '.']))
       .then(() => git(localFolder).commit(`${BRANCH} updated`))
       .then(() => git(localFolder).push('origin', BRANCH))
-      .catch(err => console.error('failed: ', err));
+      .catch(err => {
+        console.error('failed: ', err);
+        // surface the failure so CI doesn't report success on a failed release
+        process.exitCode = 1;
+      });
   });
 } else {
   console.warn(


### PR DESCRIPTION
The release-stable script (used by update-design-tokens-stable.yml) swallowed git push errors in a .catch() that only logged, letting the CI step report success even when the push to design-tokens-stable failed (observed as a transient 'could not read Password' git push error). Now the process exit code is set to 1 on failure so CI surfaces real failures instead of silently succeeding.