### PR TITLE
[monorepo] fixed release workflow CI

### DIFF
--- a/.github/workflows/design-tokens-release-pr.yml
+++ b/.github/workflows/design-tokens-release-pr.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   release-pr:
     runs-on: ubuntu-latest
+    env:
+      HUSKY: '0'
     steps:
       - name: Check out master
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->


#### What does this PR do?

This pull request makes a minor update to the GitHub Actions workflow configuration by setting the `HUSKY` environment variable to `'0'` in the `release-pr` job. This change disables Husky hooks during the workflow execution, which can help prevent issues related to git hooks running in CI environments.

