### PR TITLE
fixed release workflow CI

### DIFF
--- a/.github/workflows/design-tokens-release-pr.yml
+++ b/.github/workflows/design-tokens-release-pr.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Create or update release PR
         uses: changesets/action@v1
         with:
-          version: pnpm exec changeset version
+          version: >-
+            pnpm exec changeset version --ignore aries --ignore design-tokens-manager --ignore docs --ignore @hpe-design/code-connect --ignore hpe-design-system-codemods --ignore @hpe-design/icons-svg --ignore @shared/hooks --ignore @shared/aries-core --ignore grommet-app --ignore native-web --ignore tailwind-app --ignore @hpe-design/icons-grommet
           title: 'chore: prepare hpe-design-tokens release'
           commit: 'chore: prepare hpe-design-tokens release'
         env:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This pull request updates the release workflow for design tokens to exclude several packages from the versioning process. This ensures that only relevant packages are included in the release PR, streamlining the release process.

**Workflow improvements:**

* Updated the `version` step in `.github/workflows/design-tokens-release-pr.yml` to ignore a list of packages (such as `aries`, `design-tokens-manager`, `docs`, and others) during the `changeset version` command, so that only necessary packages are included in the release.

