### PR TITLE
[monorepo] fixed release workflow CI

### DIFF
--- a/.github/workflows/design-tokens-release-pr.yml
+++ b/.github/workflows/design-tokens-release-pr.yml
@@ -44,7 +44,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: >-
-            pnpm exec changeset version --ignore aries --ignore design-tokens-manager --ignore docs --ignore @hpe-design/code-connect --ignore hpe-design-system-codemods --ignore @hpe-design/icons-svg --ignore @shared/hooks --ignore @shared/aries-core --ignore grommet-app --ignore native-web --ignore tailwind-app --ignore @hpe-design/icons-grommet
+            pnpm exec changeset version --ignore design-tokens-manager --ignore docs --ignore @hpe-design/code-connect --ignore hpe-design-system-codemods --ignore @hpe-design/icons-svg --ignore @shared/hooks --ignore @shared/aries-core --ignore grommet-app --ignore native-web --ignore tailwind-app --ignore @hpe-design/icons-grommet
           title: 'chore: prepare hpe-design-tokens release'
           commit: 'chore: prepare hpe-design-tokens release'
         env:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->




#### What does this PR do?

This pull request makes a small change to the release workflow configuration. The `aries` package is no longer ignored during the versioning step of the `design-tokens-release-pr.yml` workflow.

