### PR TITLE
fix: publish downloaded token artifact explicitly

### DIFF
--- a/.github/workflows/design-tokens-publish.yml
+++ b/.github/workflows/design-tokens-publish.yml
@@ -153,7 +153,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if ! npm view "${{ env.PACKAGE_NAME }}@${{ inputs.version }}" version >/dev/null 2>&1; then
-            npm publish release-artifact/*.tgz --access public --provenance --tag latest
+            candidate_tarball="$(find release-artifact -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+            if [[ -z "$candidate_tarball" || ! -f "$candidate_tarball" ]]; then
+              echo "No release tarball found in release-artifact" >&2
+              exit 1
+            fi
+            npm publish "$candidate_tarball" --access public --provenance --tag latest
           fi
 
       - name: Verify NPM registry and clean consumer


### PR DESCRIPTION
Run 34538297626 reached NPM publish, but npm interpreted the bare `release-artifact/*.tgz` argument as a GitHub SSH spec. This fix finds the downloaded tarball, validates that it exists, and passes the explicit tarball path to `npm publish`.

Candidate run `34535139171`, version `2.3.0`, and approved SHA `d29406fda867e1033933b46ea6d1ba3f2b7432fb` remain unchanged.

Validation passed with `git diff --check` and Prettier.
