### PR TITLE
fix: force local path for token tarball publish

### DIFF
--- a/.github/workflows/design-tokens-publish.yml
+++ b/.github/workflows/design-tokens-publish.yml
@@ -158,7 +158,7 @@ jobs:
               echo "No release tarball found in release-artifact" >&2
               exit 1
             fi
-            npm publish "$candidate_tarball" --access public --provenance --tag latest
+            npm publish "./$candidate_tarball" --access public --provenance --tag latest
           fi
 
       - name: Verify NPM registry and clean consumer


### PR DESCRIPTION
run 34538820438 confirmed the prior fix found the tarball but npm still parsed `release-artifact/hpe-design-tokens-2.3.0.tgz` as a GitHub SSH spec because it lacked `./`; this changes the invocation to `npm publish "./$candidate_tarball"`. Candidate run `34535139171`, version `2.3.0`, and approved SHA `d29406fda867e1033933b46ea6d1ba3f2b7432fb` remain unchanged. Validation: git diff check and Prettier. Do not stage/modify `packages/hpe-design-tokens/release-artifacts/`, merge, rerun, or publish.