### PR TITLE
feat: use npm trusted publishing for token releases

### DIFF
--- a/.github/workflows/design-tokens-publish.yml
+++ b/.github/workflows/design-tokens-publish.yml
@@ -114,7 +114,7 @@ jobs:
           ' candidate-CHANGELOG.md > release-notes.md
           test -s release-notes.md
 
-      - name: Configure NPM authentication
+      - name: Configure npm registry for trusted publishing
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -148,9 +148,12 @@ jobs:
               --draft
           fi
 
+      - name: Verify npm trusted publishing client
+        run: |
+          npm_major=$(npm --version | cut -d. -f1)
+          test "$npm_major" -ge 11
+
       - name: Publish NPM package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if ! npm view "${{ env.PACKAGE_NAME }}@${{ inputs.version }}" version >/dev/null 2>&1; then
             candidate_tarball="$(find release-artifact -maxdepth 1 -type f -name '*.tgz' -print -quit)"

--- a/knowledge/capabilities/design-tokens-publishing/README.md
+++ b/knowledge/capabilities/design-tokens-publishing/README.md
@@ -2,6 +2,11 @@
 
 Status: active
 
+### One-time npm trusted publishing configuration
+
+- Configure npm trusted publishing for package `hpe-design-tokens` with repository `grommet/hpe-design-system`, workflow `.github/workflows/design-tokens-publish.yml`, and default branch `master`; configure any required npm environment.
+- After migration, no NPM token is required. A stage-only token is incompatible with this direct `npm publish` workflow.
+
 ## Purpose
 
 Prepare and verify an `hpe-design-tokens` release, coordinate the protected GitHub and NPM
@@ -45,7 +50,7 @@ second maintainer reviews the candidate artifact and stable-sync result, manuall
 `.github/workflows/design-tokens-publish.yml` from the default branch.
 
 The publisher requires the candidate run ID, exact version, and exact commit SHA. It verifies
-the candidate run and artifact before reading the repository-level `NPM_TOKEN` secret. It then
+the candidate run and artifact before using npm trusted publishing via GitHub OIDC. It then
 publishes the exact tarball with the `latest` tag and provenance, creates or reuses a draft
 GitHub release, verifies the NPM registry and a clean consumer install, and publishes the
 GitHub release last. It uploads release notes and a Slack-ready announcement draft as workflow

--- a/packages/hpe-design-tokens/docs/OPERATIONS.md
+++ b/packages/hpe-design-tokens/docs/OPERATIONS.md
@@ -158,7 +158,7 @@ with:
 - `version`: the exact candidate version.
 - `commit_sha`: the exact candidate commit SHA.
 
-The publisher verifies the candidate run and immutable artifact before reading `NPM_TOKEN`, then
+The publisher verifies the candidate run and immutable artifact before using npm trusted publishing via GitHub OIDC, then
 publishes the artifact to NPM with provenance, verifies the registry version and a clean consumer
 install, compares the registry tarball checksum with the approved candidate tarball, and
 publishes the GitHub release. Release notes and Slack highlights are extracted from
@@ -171,7 +171,7 @@ evidence. A maintainer must post the Slack announcement manually.
 Before the first publication, a repository administrator must confirm:
 
 - [ ] The repository contains the candidate and publish workflows on the default branch.
-- [ ] The repository contains an `NPM_TOKEN` secret scoped to publish `hpe-design-tokens`.
+- [ ] Configure npm trusted publishing via GitHub OIDC for package `hpe-design-tokens`, repository `grommet/hpe-design-system`, workflow `.github/workflows/design-tokens-publish.yml`, and default branch `master`; configure any required npm environment. No NPM token is required after migration, and a stage-only token is incompatible with this direct `npm publish` workflow.
 - [ ] Actions are allowed to create contents and releases for this repository.
 - [ ] The package is public on NPM and `latest` is the intended distribution tag.
 - [ ] NPM provenance is enabled for the package and organization policy permits it.


### PR DESCRIPTION
The current stage-only NPM_TOKEN caused run 34539227449 to fail with E403/E_STAGE_REQUIRED. This migration removes NODE_AUTH_TOKEN, retains job-level id-token: write, verifies npm major >= 11, keeps npm publish --provenance, and documents npm trusted publisher configuration for package hpe-design-tokens, repository grommet/hpe-design-system, workflow .github/workflows/design-tokens-publish.yml, branch master.

Candidate run 34535139171/version 2.3.0/SHA d29406fda867e1033933b46ea6d1ba3f2b7432fb remain unchanged, and npm-side trusted publisher registration is required after merge.

Validation:
- git diff --check
- Prettier
- local npm major guard